### PR TITLE
Only use `socket.set_reuse_port` on supported operating systems

### DIFF
--- a/foundations/src/telemetry/server.rs
+++ b/foundations/src/telemetry/server.rs
@@ -135,6 +135,7 @@ fn bind_socket(addr: SocketAddr) -> BootstrapResult<Socket> {
     )?;
 
     socket.set_reuse_address(true)?;
+    #[cfg(unix)]
     socket.set_reuse_port(true)?;
     socket.bind(&SockAddr::from(addr))?;
     socket.listen(1024)?;


### PR DESCRIPTION
Hey!

In [`server.rs`](https://github.com/cloudflare/foundations/blob/8409e9186c9b98afd690f884b4a00ca5779f5c55/foundations/src/telemetry/server.rs#L138) the `socket2::Socket::set_reuse_port` function is used. This function, as explained in the [documentation](https://docs.rs/socket2/latest/socket2/struct.Socket.html#method.set_reuse_port) is only available under "Unix and neither Solaris nor illumos". This PR ensures that this line is only ran on targets where it is supported. This allows `metrics` to be used on e.g. Windows. This does change the behaviour between unix and non-unix systems, so if another solutions is prefered please feel free to suggest! To note: According to [this stackoverflow post](https://stackoverflow.com/questions/14388706/how-do-so-reuseaddr-and-so-reuseport-differ), Windows with only `SO_REUSEADDR`, set by the line above, behaves close to exactly the same as BSD with both `SO_REUSEPORT` and `SO_REUSEADDR`.