### PR TITLE
Disable `default-features` for dependency `prometheus`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ ipnetwork = "0.20"
 once_cell = "1.5"
 parking_lot = "0.12"
 proc-macro2 = { version = "1", default-features = false }
-prometheus = "0.13.3"
+prometheus = { version = "0.13.3", default-features = false }
 prometheus-client = "0.18.1"
 prometools = "0.2.1"
 rand = "0.8"


### PR DESCRIPTION
By default, the prometheus crate enables the feature to push metrics, which is not used in this libary.
If needed, a downstream user can enable the feature flag.
