### PR TITLE
telemetry: make logger verbosity public

### DIFF
--- a/foundations/src/telemetry/log/mod.rs
+++ b/foundations/src/telemetry/log/mod.rs
@@ -43,6 +43,12 @@ pub fn set_verbosity(level: Level) -> Result<()> {
     Ok(())
 }
 
+/// Gets the current log's verbosity.
+pub fn verbosity() -> LogVerbosity {
+    let harness = LogHarness::get();
+    harness.settings.verbosity
+}
+
 /// Returns current log as a raw [slog] crate's `Logger` used by Foundations internally.
 ///
 /// Can be used to propagate the logging context to libraries that don't use Foundations'


### PR DESCRIPTION
I'm using [`slog-stdlog`](https://docs.rs/slog-stdlog/latest/slog_stdlog/) to read Quiche logs from Foundations, but I want to be able to configure the level of logs they emit. To do so, `slog-stdlog` exposes an [`init_with_level`](https://docs.rs/slog-stdlog/latest/slog_stdlog/fn.init_with_level.html) method - we obviously then need to get the verbosity level for the current logger.

I didn't see anything that lets us do this, as `Context::current_log()` just gets us a `SharedLog` which doesn't expose verbosity/`LoggerSettings` - if there's an easier way, please feel free to decline this PR.