### PR TITLE
telemetry: change LogVerbosity to an enum, use it throughout public API

### DIFF
--- a/foundations/src/telemetry/log/init.rs
+++ b/foundations/src/telemetry/log/init.rs
@@ -140,7 +140,7 @@ where
         drain,
         FieldRedactFilterFactory::new(settings.redact_keys.clone()),
     );
-    let drain = drain.filter_level(*settings.verbosity);
+    let drain = drain.filter_level(settings.verbosity.into());
 
     RateLimitingDrain::new(drain, settings)
 }

--- a/foundations/src/telemetry/log/mod.rs
+++ b/foundations/src/telemetry/log/mod.rs
@@ -39,11 +39,11 @@ pub use self::testing::TestLogRecord;
 /// verbosity level.
 ///
 /// [`init`]: crate::telemetry::init
-pub fn set_verbosity(level: Level) -> Result<()> {
+pub fn set_verbosity(verbosity: LogVerbosity) -> Result<()> {
     let harness = LogHarness::get();
 
     let mut settings = harness.settings.clone();
-    settings.verbosity = LogVerbosity(level);
+    settings.verbosity = verbosity;
 
     let current_log = current_log();
     let mut current_log_lock = current_log.write();

--- a/foundations/src/telemetry/log/mod.rs
+++ b/foundations/src/telemetry/log/mod.rs
@@ -21,7 +21,7 @@ use self::internal::current_log;
 use crate::telemetry::log::init::build_log_with_drain;
 use crate::telemetry::settings::LogVerbosity;
 use crate::Result;
-use slog::{Level, Logger, OwnedKV};
+use slog::{Logger, OwnedKV};
 use std::ops::Deref;
 use std::sync::Arc;
 

--- a/foundations/src/telemetry/settings/logging.rs
+++ b/foundations/src/telemetry/settings/logging.rs
@@ -122,30 +122,3 @@ pub struct LogVolumeMetricSettings {
     /// Whether to enable log volume metrics
     pub enabled: bool,
 }
-
-#[cfg(feature = "settings")]
-mod with_settings_feature {
-    use super::*;
-
-    impl<'de> Deserialize<'de> for LogVerbosity {
-        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
-        {
-            Level::from_str(&String::deserialize(deserializer)?)
-                .map_err(|_| de::Error::custom("incorrect verbosity level"))
-                .map(LogVerbosity)
-        }
-    }
-
-    impl Serialize for LogVerbosity {
-        fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-        {
-            s.serialize_str(self.0.as_str())
-        }
-    }
-
-    impl Settings for LogVerbosity {}
-}

--- a/foundations/src/telemetry/testing.rs
+++ b/foundations/src/telemetry/testing.rs
@@ -6,7 +6,6 @@ feature_use!(cfg(feature = "logging"), {
     use super::log::testing::{create_test_log, TestLogRecord, TestLogRecords};
     use super::settings::LogVerbosity;
     use super::settings::LoggingSettings;
-    use slog::Level;
     use std::sync::Arc;
     use std::sync::RwLockReadGuard;
 });
@@ -52,7 +51,7 @@ impl TestTelemetryContext {
         #[cfg(feature = "logging")]
         let (log, log_records) = {
             create_test_log(&LoggingSettings {
-                verbosity: LogVerbosity(Level::Trace),
+                verbosity: LogVerbosity::Trace,
                 ..Default::default()
             })
         };

--- a/foundations/tests/logging.rs
+++ b/foundations/tests/logging.rs
@@ -1,9 +1,8 @@
 use foundations::telemetry::log::internal::LoggerWithKvNestingTracking;
 use foundations::telemetry::log::{add_fields, set_verbosity, warn};
-use foundations::telemetry::settings::{LoggingSettings, RateLimitingSettings};
+use foundations::telemetry::settings::{LogVerbosity, LoggingSettings, RateLimitingSettings};
 use foundations::telemetry::TestTelemetryContext;
 use foundations_macros::with_test_telemetry;
-use slog::Level;
 
 #[with_test_telemetry(test)]
 fn test_rate_limiter(mut ctx: TestTelemetryContext) {
@@ -39,7 +38,7 @@ fn test_exceed_limit_kv_nesting(_ctx: TestTelemetryContext) {
     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         for _ in 0..((LoggerWithKvNestingTracking::MAX_NESTING / 2) + 1) {
             add_fields! { "key1" => "hello" }
-            set_verbosity(Level::Info).expect("set_verbosity");
+            set_verbosity(LogVerbosity::Info).expect("set_verbosity");
         }
     })) {
         Ok(_) => panic!("test case exceeded the maximum log KV nesting, but there was no panic"),
@@ -70,6 +69,6 @@ fn test_exceed_limit_kv_nesting(_ctx: TestTelemetryContext) {
 fn test_not_exceed_limit_kv_nesting(_ctx: TestTelemetryContext) {
     for _ in 0..((LoggerWithKvNestingTracking::MAX_NESTING / 2) - 5) {
         add_fields! { "key1" => "hello" }
-        set_verbosity(Level::Info).expect("set_verbosity");
+        set_verbosity(LogVerbosity::Info).expect("set_verbosity");
     }
 }


### PR DESCRIPTION
Closes #13.