### PR TITLE
Construct metrics registry with default() when name_in_metrics is empty

### DIFF
--- a/foundations/src/telemetry/metrics/internal.rs
+++ b/foundations/src/telemetry/metrics/internal.rs
@@ -99,7 +99,10 @@ fn new_registry(
     service_name_format: &ServiceNameFormat,
 ) -> RwLock<Registry> {
     RwLock::new(match service_name_format {
-        ServiceNameFormat::MetricPrefix => Registry::with_prefix(service_name_in_metrics),
+        ServiceNameFormat::MetricPrefix => match service_name_in_metrics {
+            "" => Registry::default(),
+            _ => Registry::with_prefix(service_name_in_metrics),
+        },
         // FIXME(nox): Due to prometheus-client 0.18 not supporting the creation of
         // registries with specific label values, we use this service identifier
         // format directly in `Registries::get_main` and `Registries::get_optional`.


### PR DESCRIPTION
This adds a clause to use `Registry::default()` if `name_in_metrics` is empty

At the moment using the `with_prefix` method, the metrics that get rendered ends up looking like this: `_my_metric` because `prefix` is `Option`
https://github.com/prometheus/client_rust/blob/master/src/registry.rs#L62

Using `Registry::default()` will set prefix to `None` so that metrics get rendered without the leading underscore.