### PR TITLE
ZTC-1478: track the number of times a logger has been replaced with a child logger

### DIFF
--- a/foundations/src/telemetry/log/internal.rs
+++ b/foundations/src/telemetry/log/internal.rs
@@ -1,11 +1,93 @@
 use super::init::LogHarness;
 use crate::telemetry::scope::Scope;
 use slog::{Logger, OwnedKV, SendSyncRefUnwindSafeKV};
+use std::ops::Deref;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
+pub const MAX_LOG_GENERATION: u32 = 1000;
+pub const EXCEEDED_MAX_LOG_GENERATION_ERROR: &str = "foundations::telemetry::log: maximum logger generation exceeded (are add_fields! or set_verbosity being called in a loop?)";
+
+// The slog_logger() function exposes Arc<RwLock<Logger>> as a public
+// interface, so we can't store the generation number where it would make the
+// most sense to store it, which would be inside the RwLock, right next to
+// the Logger.
+//
+// Doing it this way means we lose the enforced atomicity between updating the
+// Logger and updating the generation number. In general, we try to only read
+// or write the generation number while we hold the appropriate lock on the
+// Logger. It is not mission-critical that we do this. The generation number
+// is just a guard rail to prevent us from going wild. Even if there is some
+// race condition and we're off by one or two, it won't affect its ability to
+// do its job.
+//
 // NOTE: we intentionally use a lock without poisoning here to not
 // panic the threads if they just share telemetry with failed thread.
-pub(crate) type SharedLog = Arc<parking_lot::RwLock<Logger>>;
+pub(crate) type SharedLog = Arc<LogContext>;
+
+#[derive(Debug)]
+pub struct LogContext {
+    // The logger itself. This is the most important part of this struct.
+    pub logger: Arc<parking_lot::RwLock<Logger>>,
+
+    // Generation number, incremented every time the logger is replaced with
+    // a child of itself. Accuracy is not critical as this is only used as a
+    // safety check. Nevertheless, when possible, please be holding the
+    // logger's lock when you read or write the generation number.
+    pub(crate) generation: AtomicU32,
+}
+
+impl LogContext {
+    // Create a new LogContext based on a fresh logger. The generation number
+    // is initialized to zero.
+    pub(crate) fn new(logger: Logger) -> Self {
+        Self {
+            logger: Arc::new(parking_lot::RwLock::new(logger)),
+            generation: AtomicU32::new(0),
+        }
+    }
+
+    // Update this LogContext's logger object, and, atomically, increment
+    // the generation number. This mutates 'self' using interior mutability,
+    // even though it only takes a shared reference to self.
+    pub(crate) fn update<F>(&self, f: F)
+    where
+        F: FnOnce(&Logger) -> Logger,
+    {
+        let mut logger_lock = self.logger.write();
+        let generation = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
+        let logger = f(logger_lock.deref());
+        *logger_lock = logger;
+
+        if generation >= MAX_LOG_GENERATION {
+            panic!("{}", EXCEEDED_MAX_LOG_GENERATION_ERROR);
+        }
+    }
+
+    // Use interior mutability to replace the contents of 'self' with the
+    // contents of 'other', while only holding a shared reference to 'self'
+    #[allow(dead_code)]
+    pub(crate) fn overwrite_from(&self, other: Self) {
+        let mut logger_lock = self.logger.write();
+        let other_logger_lock = other.logger.read();
+        self.generation
+            .store(other.generation.load(Ordering::SeqCst), Ordering::SeqCst);
+        *logger_lock = other_logger_lock.clone();
+    }
+}
+
+impl Clone for LogContext {
+    // Create a new LogContext object that is functionally the same as this one
+    // (refers to the same logger, has the same generation number).
+    fn clone(&self) -> Self {
+        let logger_lock = self.logger.read();
+        let generation = self.generation.load(Ordering::SeqCst);
+        Self {
+            logger: Arc::new(parking_lot::RwLock::new(logger_lock.clone())),
+            generation: AtomicU32::new(generation),
+        }
+    }
+}
 
 #[must_use]
 pub(crate) struct LogScope(#[allow(dead_code)] Scope<SharedLog>);
@@ -21,10 +103,8 @@ pub fn add_log_fields<T>(fields: OwnedKV<T>)
 where
     T: SendSyncRefUnwindSafeKV + 'static,
 {
-    let log = current_log();
-    let mut log_lock = log.write();
-
-    *log_lock = log_lock.new(fields);
+    let parent = current_log();
+    parent.update(move |logger: &Logger| logger.new(fields))
 }
 
 pub fn current_log() -> SharedLog {
@@ -36,7 +116,5 @@ pub fn current_log() -> SharedLog {
 
 pub(crate) fn fork_log() -> SharedLog {
     let parent = current_log();
-    let log = parent.read().new(slog::o!());
-
-    Arc::new(parking_lot::RwLock::new(log))
+    Arc::new((*parent).clone())
 }

--- a/foundations/src/telemetry/log/mod.rs
+++ b/foundations/src/telemetry/log/mod.rs
@@ -29,6 +29,15 @@ pub use self::testing::TestLogRecord;
 
 /// Sets current log's verbosity, overriding the settings used in [`init`].
 ///
+/// For reasons related to the current implementation of `set_verbosity()`,
+/// there is a danger of stack overflow if it is called an extremely large
+/// number of times on the same logger. To protect against the possibility of
+/// stack overflow, there is an internal counter which will trigger a panic if a
+/// a limit of (currently) 1000 calls on a single logger is reached.
+///
+/// To avoid this panic, only call `set_verbosity()` when there is an actual
+/// change to the verbosity level.
+///
 /// [`init`]: crate::telemetry::init
 pub fn set_verbosity(level: Level) -> Result<()> {
     let harness = LogHarness::get();
@@ -36,9 +45,10 @@ pub fn set_verbosity(level: Level) -> Result<()> {
     let mut settings = harness.settings.clone();
     settings.verbosity = LogVerbosity(level);
 
-    let kv = OwnedKV(current_log().read().list().clone());
-    let logger = build_log_with_drain(&settings, kv, Arc::clone(&harness.root_drain));
-    *current_log().write() = logger;
+    current_log().update(|logger: &Logger| {
+        let kv = OwnedKV(logger.list().clone());
+        build_log_with_drain(&settings, kv, Arc::clone(&harness.root_drain))
+    });
 
     Ok(())
 }
@@ -56,7 +66,7 @@ pub fn verbosity() -> LogVerbosity {
 ///
 /// [slog]: https://crates.io/crates/slog
 pub fn slog_logger() -> Arc<parking_lot::RwLock<Logger>> {
-    current_log()
+    Arc::clone(&current_log().logger)
 }
 
 // NOTE: `#[doc(hidden)]` + `#[doc(inline)]` for `pub use` trick is used to prevent these macros
@@ -65,6 +75,16 @@ pub fn slog_logger() -> Arc<parking_lot::RwLock<Logger>> {
 /// Adds fields to all the log records, making them context fields.
 ///
 /// Calling the method with same field name multiple times updates the key value.
+/// There is a small cost in performance if large numbers of the same field
+/// are added, which then must be deduplicated at runtime. For that reason, as
+/// well as the fact that there is a danger of stack overflow if `add_fields!`
+/// is called an extremely large number of times on the same logger, there is
+/// an internal counter which will trigger a panic if a limit of (currently)
+/// 1000 calls on a single logger is reached.
+///
+/// To avoid this panic, make sure to only use `add_fields!` for fields that
+/// will remain relatively static (under 1000 updates over the lifetime of any
+/// given logger).
 ///
 /// Certain added fields may not be present in the resulting logs if
 /// [`LoggingSettings::redact_keys`] is used.
@@ -183,7 +203,7 @@ macro_rules! __add_fields {
 macro_rules! __error {
     ( $($args:tt)+ ) => {
         $crate::reexports_for_macros::slog::error!(
-            $crate::telemetry::log::internal::current_log().read(),
+            $crate::telemetry::log::internal::current_log().logger.read(),
             $($args)+
         );
     };
@@ -245,7 +265,7 @@ macro_rules! __error {
 macro_rules! __warn {
     ( $($args:tt)+ ) => {
         $crate::reexports_for_macros::slog::warn!(
-            $crate::telemetry::log::internal::current_log().read(),
+            $crate::telemetry::log::internal::current_log().logger.read(),
             $($args)+
         );
     };
@@ -307,7 +327,7 @@ macro_rules! __warn {
 macro_rules! __debug {
     ( $($args:tt)+ ) => {
         $crate::reexports_for_macros::slog::debug!(
-            $crate::telemetry::log::internal::current_log().read(),
+            $crate::telemetry::log::internal::current_log().logger.read(),
             $($args)+
         );
     };
@@ -369,7 +389,7 @@ macro_rules! __debug {
 macro_rules! __info {
     ( $($args:tt)+ ) => {
         $crate::reexports_for_macros::slog::info!(
-            $crate::telemetry::log::internal::current_log().read(),
+            $crate::telemetry::log::internal::current_log().logger.read(),
             $($args)+
         );
     };
@@ -431,7 +451,7 @@ macro_rules! __info {
 macro_rules! __trace {
     ( $($args:tt)+ ) => {
         $crate::reexports_for_macros::slog::trace!(
-            $crate::telemetry::log::internal::current_log().read(),
+            $crate::telemetry::log::internal::current_log().logger.read(),
             $($args)+
         );
     };

--- a/foundations/src/telemetry/testing.rs
+++ b/foundations/src/telemetry/testing.rs
@@ -63,7 +63,7 @@ impl TestTelemetryContext {
         TestTelemetryContext {
             inner: TelemetryContext {
                 #[cfg(feature = "logging")]
-                log: Arc::new(parking_lot::RwLock::new(log)),
+                log: Arc::new(log),
 
                 #[cfg(feature = "tracing")]
                 span: None,
@@ -85,7 +85,7 @@ impl TestTelemetryContext {
     #[cfg(feature = "logging")]
     pub fn set_logging_settings(&mut self, logging_settings: LoggingSettings) {
         let (log, log_records) = { create_test_log(&logging_settings) };
-        *self.inner.log.write() = log;
+        self.inner.log.overwrite_from(log);
         self.log_records = log_records;
     }
 

--- a/foundations/tests/logging.rs
+++ b/foundations/tests/logging.rs
@@ -1,4 +1,7 @@
-use foundations::telemetry::log::warn;
+use foundations::telemetry::log::internal::{
+    EXCEEDED_MAX_LOG_GENERATION_ERROR, MAX_LOG_GENERATION,
+};
+use foundations::telemetry::log::{add_fields, warn};
 use foundations::telemetry::settings::{LoggingSettings, RateLimitingSettings};
 use foundations::telemetry::TestTelemetryContext;
 use foundations_macros::with_test_telemetry;
@@ -24,4 +27,45 @@ fn test_rate_limiter(mut ctx: TestTelemetryContext) {
     }
 
     assert!(ctx.log_records().len() < 32);
+}
+
+// Every time we call the add_fields! macro, it adds one to the depth of the
+// nested structure of Arcs inside the logger object. If the structure gets
+// too deeply nested, it causes a stack overflow on drop.
+//
+// This test case makes sure that before it would hit a dangerous depth, it
+// panics (with an error that gives you a hint as to where to go look in your
+// code).
+#[with_test_telemetry(test)]
+fn test_exceed_limit_num_generations(_ctx: TestTelemetryContext) {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        for _ in 1..(MAX_LOG_GENERATION + 1) {
+            add_fields! { "key1" => "hello" }
+        }
+    })) {
+        Ok(_) => panic!("test case exceeded the maximum log generation, but there was no panic"),
+        Err(err) => {
+            if let Some(msg) = err.downcast_ref::<&'static str>() {
+                assert_eq!(*msg, EXCEEDED_MAX_LOG_GENERATION_ERROR);
+            } else if let Some(msg) = err.downcast_ref::<String>() {
+                assert_eq!(*msg, EXCEEDED_MAX_LOG_GENERATION_ERROR);
+            } else {
+                panic!("test case exceeded the maximum log generation, but the panic was not castable to the expected type");
+            }
+        }
+    }
+}
+
+// Negative version of above test. If we're just under the limit, we shouldn't
+// get a panic, and we also shouldn't stack overflow. This helps us make sure
+// we didn't set the limit too high. For example, if we set the limit to be
+// 1,000,000, then having this test here would make sure that it doesn't
+// cause a stack overflow at 999,990. And if it did cause a stack overflow at
+// 999,990, then this test would make sure we notice that and don't set the
+// limit that high!
+#[with_test_telemetry(test)]
+fn test_not_exceed_limit_num_generations(_ctx: TestTelemetryContext) {
+    for _ in 1..(MAX_LOG_GENERATION - 10) {
+        add_fields! { "key1" => "hello" }
+    }
 }


### PR DESCRIPTION
Every time we call the add_fields! macro, it adds one to the depth of the nested structure of Arcs inside the logger object. If the structure gets too deeply nested, it causes a stack overflow on drop.

Fixing this to make it keep the structure flat rather than nested would be difficult; so, this commit makes it keep track of how many times it has replaced a logger with a child logger, and it stops you (with a panic) before you reach a dangerous level of nesting.

The panic string is intended to be informative enough so that you get a hint as to where to go look in your code.