### PR TITLE
Fix CI by temporarily allowing lint violated by darling crate

### DIFF
--- a/foundations-macros/src/info_metric/mod.rs
+++ b/foundations-macros/src/info_metric/mod.rs
@@ -1,3 +1,6 @@
+// See: https://github.com/cloudflare/foundations/issues/50
+#![allow(clippy::manual_unwrap_or_default)]
+
 use crate::common::Result;
 use darling::FromMeta;
 use proc_macro::TokenStream;


### PR DESCRIPTION
The darling crate has an open issue (see https://github.com/TedDriggs/darling/issues/293 ) which, until fixed, raises a new clippy lint (as of Rust 1.79).

So we temporarily allow it so that we unblock foundations CI.