### PR TITLE
ZTC-1478: rework PR #47 in light of the fact that the next release we do is going to have to be a major version bump anyway, no matter what

### DIFF
--- a/foundations/src/telemetry/log/init.rs
+++ b/foundations/src/telemetry/log/init.rs
@@ -1,7 +1,7 @@
 use super::field_dedup::FieldDedupFilterFactory;
 use super::field_filtering::FieldFilteringDrain;
 use super::field_redact::FieldRedactFilterFactory;
-use super::internal::{LogContext, SharedLog};
+use super::internal::{LoggerWithKvNestingTracking, SharedLog};
 
 #[cfg(feature = "metrics")]
 use crate::telemetry::log::log_volume::LogVolumeMetricsDrain;
@@ -31,11 +31,12 @@ static HARNESS: OnceCell<LogHarness> = OnceCell::new();
 
 static NOOP_HARNESS: Lazy<LogHarness> = Lazy::new(|| {
     let root_drain = Arc::new(Discard);
-    let noop_log = LogContext::new(Logger::root(Arc::clone(&root_drain), slog::o!()));
+    let noop_log =
+        LoggerWithKvNestingTracking::new(Logger::root(Arc::clone(&root_drain), slog::o!()));
 
     LogHarness {
         root_drain,
-        root_log: Arc::new(noop_log),
+        root_log: Arc::new(parking_lot::RwLock::new(noop_log)),
         settings: Default::default(),
         log_scope_stack: Default::default(),
     }
@@ -104,7 +105,9 @@ pub(crate) fn init(service_info: &ServiceInfo, settings: &LoggingSettings) -> Bo
     let root_log = build_log_with_drain(settings, root_kv, Arc::clone(&root_drain));
     let harness = LogHarness {
         root_drain,
-        root_log: Arc::new(LogContext::new(root_log)),
+        root_log: Arc::new(parking_lot::RwLock::new(LoggerWithKvNestingTracking::new(
+            root_log,
+        ))),
         settings: settings.clone(),
         log_scope_stack: Default::default(),
     };

--- a/foundations/src/telemetry/log/internal.rs
+++ b/foundations/src/telemetry/log/internal.rs
@@ -2,90 +2,57 @@ use super::init::LogHarness;
 use crate::telemetry::scope::Scope;
 use slog::{Logger, OwnedKV, SendSyncRefUnwindSafeKV};
 use std::ops::Deref;
-use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
-pub const MAX_LOG_GENERATION: u32 = 1000;
-pub const EXCEEDED_MAX_LOG_GENERATION_ERROR: &str = "foundations::telemetry::log: maximum logger generation exceeded (are add_fields! or set_verbosity being called in a loop?)";
-
-// The slog_logger() function exposes Arc<RwLock<Logger>> as a public
-// interface, so we can't store the generation number where it would make the
-// most sense to store it, which would be inside the RwLock, right next to
-// the Logger.
-//
-// Doing it this way means we lose the enforced atomicity between updating the
-// Logger and updating the generation number. In general, we try to only read
-// or write the generation number while we hold the appropriate lock on the
-// Logger. It is not mission-critical that we do this. The generation number
-// is just a guard rail to prevent us from going wild. Even if there is some
-// race condition and we're off by one or two, it won't affect its ability to
-// do its job.
-//
 // NOTE: we intentionally use a lock without poisoning here to not
 // panic the threads if they just share telemetry with failed thread.
-pub(crate) type SharedLog = Arc<LogContext>;
+pub(crate) type SharedLog = Arc<parking_lot::RwLock<LoggerWithKvNestingTracking>>;
 
-#[derive(Debug)]
-pub struct LogContext {
-    // The logger itself. This is the most important part of this struct.
-    pub logger: Arc<parking_lot::RwLock<Logger>>,
+#[derive(Debug, Clone)]
+pub struct LoggerWithKvNestingTracking {
+    // The logger itself. This is the most important part of this struct. (We implement Deref to
+    // let you go straight to this field, in contexts where you need a &Logger)
+    pub(crate) inner: Logger,
 
-    // Generation number, incremented every time the logger is replaced with
-    // a child of itself. Accuracy is not critical as this is only used as a
-    // safety check. Nevertheless, when possible, please be holding the
-    // logger's lock when you read or write the generation number.
-    pub(crate) generation: AtomicU32,
+    // KV nesting level. You should increment this (using the inc_nesting_level() method) every
+    // time you replace the logger with a child of itself. You should likewise set this back to
+    // zero if you replace the logger with a "root" logger that doesn't have any nested KVs in it.
+    // (That said, accuracy is not critical, as this is only used as a safety check)
+    pub(crate) nesting_level: u32,
 }
 
-impl LogContext {
-    // Create a new LogContext based on a fresh logger. The generation number
-    // is initialized to zero.
+impl LoggerWithKvNestingTracking {
+    pub const MAX_NESTING: u32 = 1000;
+    pub const EXCEEDED_MAX_NESTING_ERROR: &'static str = "foundations: maximum logger KV nesting exceeded (are add_fields! or set_verbosity being called in a loop?)";
+
+    // Create a new LoggerWithKvNestingTracking based on a fresh logger. The KV nesting level is
+    // initialized to zero.
     pub(crate) fn new(logger: Logger) -> Self {
         Self {
-            logger: Arc::new(parking_lot::RwLock::new(logger)),
-            generation: AtomicU32::new(0),
+            inner: logger,
+            nesting_level: 0,
         }
     }
 
-    // Update this LogContext's logger object, and, atomically, increment
-    // the generation number. This mutates 'self' using interior mutability,
-    // even though it only takes a shared reference to self.
-    pub(crate) fn update<F>(&self, f: F)
-    where
-        F: FnOnce(&Logger) -> Logger,
-    {
-        let mut logger_lock = self.logger.write();
-        let generation = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
-        let logger = f(logger_lock.deref());
-        *logger_lock = logger;
+    // Increment the KV nesting level. You should call this every time you have replaced the
+    // logger with a child of itself.
+    pub(crate) fn inc_nesting_level(&mut self) {
+        self.nesting_level += 1;
 
-        if generation >= MAX_LOG_GENERATION {
-            panic!("{}", EXCEEDED_MAX_LOG_GENERATION_ERROR);
-        }
-    }
-
-    // Use interior mutability to replace the contents of 'self' with the
-    // contents of 'other', while only holding a shared reference to 'self'
-    #[allow(dead_code)]
-    pub(crate) fn overwrite_from(&self, other: Self) {
-        let mut logger_lock = self.logger.write();
-        let other_logger_lock = other.logger.read();
-        self.generation
-            .store(other.generation.load(Ordering::SeqCst), Ordering::SeqCst);
-        *logger_lock = other_logger_lock.clone();
+        assert!(
+            self.nesting_level < Self::MAX_NESTING,
+            "{}",
+            Self::EXCEEDED_MAX_NESTING_ERROR
+        );
     }
 }
 
-impl Clone for LogContext {
-    // Create a new LogContext object that is functionally the same as this one
-    // (refers to the same logger, has the same generation number).
-    fn clone(&self) -> Self {
-        let logger_lock = self.logger.read();
-        let generation = self.generation.load(Ordering::SeqCst);
-        Self {
-            logger: Arc::new(parking_lot::RwLock::new(logger_lock.clone())),
-            generation: AtomicU32::new(generation),
-        }
+impl Deref for LoggerWithKvNestingTracking {
+    type Target = Logger;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }
 
@@ -103,8 +70,11 @@ pub fn add_log_fields<T>(fields: OwnedKV<T>)
 where
     T: SendSyncRefUnwindSafeKV + 'static,
 {
-    let parent = current_log();
-    parent.update(move |logger: &Logger| logger.new(fields))
+    let log = current_log();
+    let mut log_lock = log.write();
+
+    log_lock.inner = log_lock.inner.new(fields);
+    log_lock.inc_nesting_level();
 }
 
 pub fn current_log() -> SharedLog {
@@ -116,5 +86,7 @@ pub fn current_log() -> SharedLog {
 
 pub(crate) fn fork_log() -> SharedLog {
     let parent = current_log();
-    Arc::new((*parent).clone())
+    let log = parent.read().clone();
+
+    Arc::new(parking_lot::RwLock::new(log))
 }

--- a/foundations/src/telemetry/testing.rs
+++ b/foundations/src/telemetry/testing.rs
@@ -63,7 +63,7 @@ impl TestTelemetryContext {
         TestTelemetryContext {
             inner: TelemetryContext {
                 #[cfg(feature = "logging")]
-                log: Arc::new(log),
+                log: Arc::new(parking_lot::RwLock::new(log)),
 
                 #[cfg(feature = "tracing")]
                 span: None,
@@ -85,7 +85,7 @@ impl TestTelemetryContext {
     #[cfg(feature = "logging")]
     pub fn set_logging_settings(&mut self, logging_settings: LoggingSettings) {
         let (log, log_records) = { create_test_log(&logging_settings) };
-        self.inner.log.overwrite_from(log);
+        *self.inner.log.write() = log;
         self.log_records = log_records;
     }
 

--- a/foundations/tests/logging.rs
+++ b/foundations/tests/logging.rs
@@ -1,10 +1,9 @@
-use foundations::telemetry::log::internal::{
-    EXCEEDED_MAX_LOG_GENERATION_ERROR, MAX_LOG_GENERATION,
-};
-use foundations::telemetry::log::{add_fields, warn};
+use foundations::telemetry::log::internal::LoggerWithKvNestingTracking;
+use foundations::telemetry::log::{add_fields, set_verbosity, warn};
 use foundations::telemetry::settings::{LoggingSettings, RateLimitingSettings};
 use foundations::telemetry::TestTelemetryContext;
 use foundations_macros::with_test_telemetry;
+use slog::Level;
 
 #[with_test_telemetry(test)]
 fn test_rate_limiter(mut ctx: TestTelemetryContext) {
@@ -29,43 +28,48 @@ fn test_rate_limiter(mut ctx: TestTelemetryContext) {
     assert!(ctx.log_records().len() < 32);
 }
 
-// Every time we call the add_fields! macro, it adds one to the depth of the
-// nested structure of Arcs inside the logger object. If the structure gets
-// too deeply nested, it causes a stack overflow on drop.
+// Every time we call set_verbosity(), or the add_fields! macro, it adds one to the depth of the
+// nested structure of Arcs inside the logger object. If the structure gets too deeply nested, it
+// causes a stack overflow on drop.
 //
-// This test case makes sure that before it would hit a dangerous depth, it
-// panics (with an error that gives you a hint as to where to go look in your
-// code).
+// This test case makes sure that before it would hit a dangerous depth, it panics (with an error
+// that gives you a hint as to where to go look in your code).
 #[with_test_telemetry(test)]
-fn test_exceed_limit_num_generations(_ctx: TestTelemetryContext) {
+fn test_exceed_limit_kv_nesting(_ctx: TestTelemetryContext) {
     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        for _ in 1..(MAX_LOG_GENERATION + 1) {
+        for _ in 0..((LoggerWithKvNestingTracking::MAX_NESTING / 2) + 1) {
             add_fields! { "key1" => "hello" }
+            set_verbosity(Level::Info).expect("set_verbosity");
         }
     })) {
-        Ok(_) => panic!("test case exceeded the maximum log generation, but there was no panic"),
+        Ok(_) => panic!("test case exceeded the maximum log KV nesting, but there was no panic"),
         Err(err) => {
             if let Some(msg) = err.downcast_ref::<&'static str>() {
-                assert_eq!(*msg, EXCEEDED_MAX_LOG_GENERATION_ERROR);
+                assert_eq!(
+                    *msg,
+                    LoggerWithKvNestingTracking::EXCEEDED_MAX_NESTING_ERROR
+                );
             } else if let Some(msg) = err.downcast_ref::<String>() {
-                assert_eq!(*msg, EXCEEDED_MAX_LOG_GENERATION_ERROR);
+                assert_eq!(
+                    *msg,
+                    LoggerWithKvNestingTracking::EXCEEDED_MAX_NESTING_ERROR
+                );
             } else {
-                panic!("test case exceeded the maximum log generation, but the panic was not castable to the expected type");
+                panic!("test case exceeded the maximum log KV nesting, but the panic was not castable to the expected type");
             }
         }
     }
 }
 
-// Negative version of above test. If we're just under the limit, we shouldn't
-// get a panic, and we also shouldn't stack overflow. This helps us make sure
-// we didn't set the limit too high. For example, if we set the limit to be
-// 1,000,000, then having this test here would make sure that it doesn't
-// cause a stack overflow at 999,990. And if it did cause a stack overflow at
-// 999,990, then this test would make sure we notice that and don't set the
-// limit that high!
+// Negative version of above test. If we're just under the limit, we shouldn't get a panic, and we
+// also shouldn't stack overflow. This helps us make sure we didn't set the limit too high. For
+// example, if we set the limit to be 1,000,000, then having this test here would make sure that it
+// doesn't cause a stack overflow at 999,990. And if it did cause a stack overflow at 999,990, then
+// this test would make sure we notice that and don't set the limit that high!
 #[with_test_telemetry(test)]
-fn test_not_exceed_limit_num_generations(_ctx: TestTelemetryContext) {
-    for _ in 1..(MAX_LOG_GENERATION - 10) {
+fn test_not_exceed_limit_kv_nesting(_ctx: TestTelemetryContext) {
+    for _ in 0..((LoggerWithKvNestingTracking::MAX_NESTING / 2) - 5) {
         add_fields! { "key1" => "hello" }
+        set_verbosity(Level::Info).expect("set_verbosity");
     }
 }


### PR DESCRIPTION
I did PR #47 in the way that I did it, because I was trying to keep the externally visible API the same. There was a public function, slog_logger(), which promised to return an `Arc<RwLock<Logger>>`. So that meant we had to *have* an  `Arc<RwLock<Logger>>` lying around. This constrained the design and made things grosser than they might otherwise have been.

It has been pointed out that we're already in the situation where the next release we do is going to need to be a major version bump, *anyway*. So we might as well revisit this, and do it the less-gross way that (slightly) breaks API compatibility.

We can minimize the extent to which we break API compatibility by having slog_logger() return a `Arc<RwLock<impl Deref<Target = Logger>>>`. This is nearly the same thing as it used to be.

This PR consists of two commits; one that reverts PR #47, and one that puts the functionality back in the new way. If you are reviewing it, you can either review the PR as a whole (which will show you the diff vs current main branch) or you can review only the second of the two commits (which will show you the diff vs how things looked prior to PR #47). I have tried to keep both sets of aesthetic considerations in mind while preparing this PR.