### PR TITLE
Add ability for logging to record tracing span log entries

### DIFF
--- a/foundations/src/telemetry/log/testing.rs
+++ b/foundations/src/telemetry/log/testing.rs
@@ -1,4 +1,4 @@
-use crate::telemetry::log::init::{apply_filters_to_drain, LogHarness};
+use crate::telemetry::log::init::{build_log_with_drain, LogHarness};
 use crate::telemetry::log::internal::LoggerWithKvNestingTracking;
 use crate::telemetry::settings::LoggingSettings;
 use parking_lot::RwLock as ParkingRwLock;
@@ -69,7 +69,7 @@ pub(crate) fn create_test_log(
         records: Arc::clone(&log_records),
     };
 
-    let drain = Arc::new(apply_filters_to_drain(drain, settings));
+    let drain = Arc::new(build_log_with_drain(settings, slog::o!(), drain));
     let log = LoggerWithKvNestingTracking::new(Logger::root(Arc::clone(&drain), slog::o!()));
 
     let _ = LogHarness::override_for_testing(LogHarness {

--- a/foundations/src/telemetry/log/tracing_drain.rs
+++ b/foundations/src/telemetry/log/tracing_drain.rs
@@ -1,0 +1,80 @@
+use slog::{Drain, Never, OwnedKVList, Record, Serializer, KV};
+
+use crate::telemetry::tracing;
+
+pub(crate) struct TracingFilteringDrain<D: Drain<Err = Never>> {
+    inner: D,
+}
+
+impl<D: Drain<Err = Never>> TracingFilteringDrain<D> {
+    pub(crate) fn new(inner: D) -> Self {
+        Self { inner }
+    }
+}
+
+impl<D: Drain<Err = Never>> Drain for TracingFilteringDrain<D> {
+    type Ok = ();
+    type Err = D::Err;
+
+    fn log(&self, record: &Record, values: &OwnedKVList) -> Result<Self::Ok, Self::Err> {
+        if tracing::rustracing_span().is_some() {
+            self.inner.log(record, values).map(|_| ())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+pub(crate) struct TracingDrain {}
+
+impl TracingDrain {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Drain for TracingDrain {
+    type Ok = ();
+    type Err = Never;
+
+    fn log(&self, record: &Record, values: &OwnedKVList) -> Result<Self::Ok, Self::Err> {
+        let mut serializer = TracingValueSerializer::new();
+        serializer.add_field("name".to_string(), record.module().to_string());
+        serializer.add_field(
+            "level".to_string(),
+            record.level().as_short_str().to_string(),
+        );
+        serializer.add_field("msg".to_string(), record.msg().to_string());
+        values.serialize(record, &mut serializer).unwrap();
+        serializer.store();
+        Ok(())
+    }
+}
+
+struct TracingValueSerializer {
+    fields: Vec<(String, String)>,
+}
+
+impl TracingValueSerializer {
+    pub(crate) fn new() -> Self {
+        // We know we're expecting at least name/level/msg next
+        let fields = Vec::<(String, String)>::with_capacity(3);
+        Self { fields }
+    }
+
+    pub(crate) fn add_field(&mut self, key: String, val: String) {
+        self.fields.push((key, val));
+    }
+
+    pub(crate) fn store(self) {
+        tracing::add_span_log_fields!(self.fields);
+    }
+}
+
+impl Serializer for TracingValueSerializer {
+    fn emit_arguments(&mut self, key: slog::Key, val: &std::fmt::Arguments<'_>) -> slog::Result {
+        let value = val.to_string();
+        self.fields.push((key.to_string(), value));
+        Ok(())
+    }
+}

--- a/foundations/src/telemetry/settings/logging.rs
+++ b/foundations/src/telemetry/settings/logging.rs
@@ -39,6 +39,10 @@ pub struct LoggingSettings {
 
     /// Configure log volume metrics.
     pub log_volume_metrics: LogVolumeMetricSettings,
+
+    /// Settings to allow additionally emitting logs to trace spans
+    #[cfg(feature = "tracing")]
+    pub trace_emission: TraceEmissionSettings,
 }
 
 /// Log output destination.
@@ -93,6 +97,19 @@ impl Deref for LogVerbosity {
 pub struct LogVolumeMetricSettings {
     /// Whether to enable log volume metrics
     pub enabled: bool,
+}
+
+/// Trace logging settings
+///
+/// If enabled, logs can be emitted as span log entries if the current context
+/// is traced. Unlike the main output, these will not be rate limited.
+#[cfg_attr(feature = "settings", settings(crate_path = "crate"))]
+#[cfg_attr(not(feature = "settings"), derive(Clone, Debug, Default))]
+pub struct TraceEmissionSettings {
+    /// Whether to enable logging to trace spans
+    pub enabled: bool,
+    /// The verbosity of logs to emit to trace spans
+    pub verbosity: LogVerbosity,
 }
 
 #[cfg(feature = "settings")]

--- a/foundations/src/telemetry/tracing/mod.rs
+++ b/foundations/src/telemetry/tracing/mod.rs
@@ -479,8 +479,9 @@ macro_rules! __add_span_tags {
 
 /// Adds log fields to the current span.
 ///
-/// Log entries need to be provided as comma-separated `"field" => "value"` pairs there. Fields and
-/// values can be strings or string slices.
+/// Log entries can be provided eother as comma-separated `"field" => "value"` pairs,
+/// or an [iterable] over `("key", value)` tuples. Fields and values can be strings or
+/// string slices.
 ///
 /// # Examples
 /// ```
@@ -531,6 +532,7 @@ macro_rules! __add_span_tags {
 ///     }]
 /// );
 /// ```
+/// [iterable]: std::iter::IntoIterator
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __add_span_log_fields {
@@ -540,6 +542,15 @@ macro_rules! __add_span_log_fields {
                 $(
                     builder.field(($field, $val));
                 )+
+            });
+        });
+    };
+    ( $fields:expr ) => {
+        $crate::telemetry::tracing::internal::write_current_span(|span| {
+            span.log(|builder| {
+                for (name, val) in $fields.into_iter() {
+                    builder.field((name, val));
+                }
             });
         });
     };


### PR DESCRIPTION
In large environments with separate logging and tracing pipelines, identifying pertinent log information for a trace can involve searching in an entirely different store, which may be subject to its own sampling and rate limiting. For these situations, the log lines generate specifically whilst the traced action is executed are particularly high value in providing additional context.

This change adds trace emission options for the logging module, which allow enabling emitting logs from traces at a separately specified verbosity level, which can be changed the same was as we can with set_verbosity.

To fully specify log fields, add_span_log_fn is added as a macro to the tracing module, at a cost of losing the full abstraction over rustracing.

Fixes #58 