### PR TITLE
OXY-1404: Avoid crashes resulting from double seccomp initialization

### DIFF
--- a/examples/http_server/main.rs
+++ b/examples/http_server/main.rs
@@ -26,6 +26,9 @@ use std::net::{SocketAddr, TcpListener as StdTcpListener};
 use std::sync::Arc;
 use tokio::net::{TcpListener, TcpStream};
 
+#[cfg(target_os = "linux")]
+use foundations::security::SandboxingInitializationError;
+
 #[tokio::main]
 async fn main() -> BootstrapResult<()> {
     // Obtain service information from Cargo.toml
@@ -69,7 +72,7 @@ async fn main() -> BootstrapResult<()> {
     // doesn't include `listen` syscall that we used before to spawn `TcpListener`'s, so if malicious
     // actor attempt to create a new server endpoint the process will terminate.
     #[cfg(target_os = "linux")]
-    sandbox_syscalls()?;
+    sandbox_syscalls().map_err(foundations::BootstrapError::from)?;
 
     // Start serving endpoints.
     let mut endpoint_futures = FuturesUnordered::new();
@@ -240,7 +243,7 @@ async fn respond(
 }
 
 #[cfg(target_os = "linux")]
-fn sandbox_syscalls() -> BootstrapResult<()> {
+fn sandbox_syscalls() -> Result<(), SandboxingInitializationError> {
     use foundations::security::common_syscall_allow_lists::{
         ASYNC, NET_SOCKET_API, SERVICE_BASICS,
     };

--- a/foundations/build.rs
+++ b/foundations/build.rs
@@ -172,6 +172,8 @@ mod security {
             .allowlist_var("SCMP_ACT_ALLOW")
             .allowlist_var("PR_SET_TSC")
             .allowlist_var("PR_TSC_SIGSEGV")
+            .allowlist_var("PR_GET_SECCOMP")
+            .allowlist_var("PR_SET_NAME")
             .derive_default(true)
             .parse_callbacks(Box::new(CargoCallbacks))
             .generate()

--- a/foundations/src/security/common_syscall_allow_lists.rs
+++ b/foundations/src/security/common_syscall_allow_lists.rs
@@ -1,8 +1,6 @@
 //! Predefined allow lists of syscalls for commonly used operations.
 
-use super::{allow_list, ArgCmp};
-
-const PR_SET_NAME: u64 = 15;
+use super::{allow_list, sys, ArgCmp};
 
 allow_list! {
     /// An allow list for basic tokio and Rust std library operations.
@@ -24,7 +22,8 @@ allow_list! {
         // so we allow this syscall only in debug mode.
         #[cfg(debug_assertions)]
         fcntl,
-        prctl if [ ArgCmp::Equal { arg_idx: 0, value: PR_SET_NAME.into() } ] // tokio-runtime thread name
+        prctl if [ ArgCmp::Equal { arg_idx: 0, value: sys::PR_SET_NAME.into() } ], // tokio-runtime thread name
+        prctl if [ ArgCmp::Equal { arg_idx: 0, value: sys::PR_GET_SECCOMP.into() } ] // used for security::get_current_thread_seccomp_mode
     ]
 }
 

--- a/foundations/src/security/mod.rs
+++ b/foundations/src/security/mod.rs
@@ -48,8 +48,10 @@ mod sys {
 }
 
 use self::internal::RawRule;
-use crate::BootstrapResult;
-use anyhow::bail;
+use crate::{BootstrapError, BootstrapResult};
+use anyhow::{anyhow, bail};
+use std::fmt::Display;
+use sys::PR_GET_SECCOMP;
 
 pub use self::syscalls::Syscall;
 
@@ -97,6 +99,46 @@ impl ArgCmpValue {
 impl<T: Into<u64>> From<T> for ArgCmpValue {
     fn from(val: T) -> Self {
         Self(val.into())
+    }
+}
+
+/// Errors that can be produced when initializing sandboxing using
+/// [`enable_syscall_sandboxing`]
+#[derive(Debug)]
+pub enum SandboxingInitializationError {
+    /// Sandboxing has already been initialized on the current thread
+    /// with the given [`SeccompMode`]
+    AlreadyInitialized(SeccompMode),
+
+    /// Some other error occurred during initialization
+    Other(BootstrapError),
+}
+
+impl Display for SandboxingInitializationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SandboxingInitializationError::AlreadyInitialized(mode) => write!(
+                f,
+                "seccomp has already been initialized and is in mode {:?}",
+                mode
+            ),
+            SandboxingInitializationError::Other(e) => e.fmt(f),
+        }
+    }
+}
+
+impl From<BootstrapError> for SandboxingInitializationError {
+    fn from(err: BootstrapError) -> Self {
+        SandboxingInitializationError::Other(err)
+    }
+}
+
+impl From<SandboxingInitializationError> for BootstrapError {
+    fn from(value: SandboxingInitializationError) -> Self {
+        match value {
+            SandboxingInitializationError::Other(e) => e,
+            e @ SandboxingInitializationError::AlreadyInitialized(_) => anyhow!("{}", e),
+        }
     }
 }
 
@@ -296,8 +338,25 @@ pub enum Rule {
     ReturnError(Syscall, RawOsErrorNum, Vec<ArgCmp>),
 }
 
+/// See [PR_GET_SECCOMP]
+///
+/// [PR_GET_SECCOMP]: https://linuxman7.org/linux/man-pages/man2/PR_GET_SECCOMP.2const.html
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum SeccompMode {
+    /// The current thread is not in secure computing mode
+    None = 0,
+
+    /// The current thread is in strict secure computing mode.
+    /// Unused in practice since the syscall to get the value
+    /// would kill your process in strict computing mode.
+    _Strict = 1,
+
+    /// The current thread is in filter mode
+    Filter = 2,
+}
+
 /// Enables [seccomp]-based syscall sandboxing in the current thread and all the threads spawned
-/// by it.
+/// by it, if the current thread does not already have sandboxing enabled.
 ///
 /// Calling the function early in the `main` function effectively enables seccomp for the whole
 /// process.
@@ -306,6 +365,10 @@ pub enum Rule {
 /// provided [`ViolationAction`]. [`allow_list`] macro can be used to conveniently construct lists
 /// of allowed syscalls. In addition, the crate provides [`common_syscall_allow_lists`] that can be
 /// merged into the user-provided allow lists.
+///
+/// To setup sandboxing on a thread has already been sandboxed, use
+/// [`enable_syscall_sandboxing_ignore_existing`] on a thread allowing the `prctl` and `seccomp`
+/// syscalls.
 ///
 /// [seccomp]: https://man7.org/linux/man-pages/man2/seccomp.2.html
 ///
@@ -344,6 +407,30 @@ pub enum Rule {
 /// let _ = TcpListener::bind("127.0.0.1:0");
 /// ```
 pub fn enable_syscall_sandboxing(
+    violation_action: ViolationAction,
+    exception_rules: &Vec<Rule>,
+) -> Result<(), SandboxingInitializationError> {
+    let current_mode = get_current_thread_seccomp_mode()?;
+    if current_mode != SeccompMode::None {
+        return Err(SandboxingInitializationError::AlreadyInitialized(
+            current_mode,
+        ));
+    }
+
+    enable_syscall_sandboxing_ignore_existing(violation_action, exception_rules)
+        .map_err(|e| e.into())
+}
+
+/// Attempts to enable [seccomp]-based syscall sandboxing in the current thread and all
+/// the threads spawned by it, regardless of whether this thread is already sandboxed.
+///
+/// If called after sandboxing was previously set up, this will likely violate rules
+/// not configured to allow the `prctl` and `seccomp` syscalls.
+///
+/// See [`enable_syscall_sandboxing`] for more details.
+///
+/// [seccomp]: https://man7.org/linux/man-pages/man2/seccomp.2.html
+pub fn enable_syscall_sandboxing_ignore_existing(
     violation_action: ViolationAction,
     exception_rules: &Vec<Rule>,
 ) -> BootstrapResult<()> {
@@ -424,6 +511,31 @@ pub fn forbid_x86_64_cpu_cycle_counter() {
             0,
         )
     };
+}
+
+/// Gets the secure computing mode of the current thread.
+///
+/// Uses the [prctl(PR_GET_SECCOMP)] syscall, so calling this without an allow_list such as
+/// the following may violate sandboxing rules if called after [`enable_syscall_sandboxing`].
+///
+/// ```
+/// use foundations::security::{ArgCmp, allow_list, common_syscall_allow_lists::RUST_BASICS};
+///
+/// allow_list! {
+///    pub static MY_ALLOW_LIST = [
+///        ..RUST_BASICS
+///    ]
+/// }
+/// ```
+///
+/// [prctl(PR_GET_SECCOMP)]: https://linuxman7.org/linux/man-pages/man2/PR_GET_SECCOMP.2const.html
+fn get_current_thread_seccomp_mode() -> BootstrapResult<SeccompMode> {
+    let current_seccomp_mode = unsafe { sys::prctl(PR_GET_SECCOMP as i32) };
+    match current_seccomp_mode {
+        0 => Ok(SeccompMode::None),
+        2 => Ok(SeccompMode::Filter),
+        _ => bail!("Unable to determine the current seccomp mode. Perhaps the kernel was not configured with CONFIG_SECCOMP?")
+    }
 }
 
 // NOTE: `#[doc(hidden)]` + `#[doc(inline)]` for `pub use` trick is used to prevent these macros


### PR DESCRIPTION
If a service using foundations accidentally initializes seccomp in a thread that already seccomp initialized, the seccomp violation (depending on configuration) may be violated and crash the process.

An easy way to enter into this scenario is by having a hook in [tokio::runtime::Builder::on_thread_start](https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.on_thread_start) that initializes seccomp for threads that are initialized before the main thread. In this scenario, any threads created from tokio threads (say, inside a tokio task) may lead to a seccomp violation.

This PR uses the syscall `prctl(PR_GET_SECCOMP)` ([PR_GET_SECCOMP](https://linuxman7.org/linux/man-pages/man2/PR_GET_SECCOMP.2const.html)) to find out definitively whether seccomp is already enabled for the current thread. If it is, then the default behavior is to not initialize seccomp again, thus avoiding what may have been a crash otherwise.