### PR TITLE
chore: add passive sampling option to tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ foundations = { version = "3", path = "./foundations" }
 foundations-macros = { version = "3", path = "./foundations-macros" }
 bindgen = { version = "0.68.1", default-features = false }
 cc = "1.0"
-cf-rustracing = "1.0"
+cf-rustracing = "1.0.1"
 cf-rustracing-jaeger = "1.1"
 clap = "4.4"
 darling = "0.20.10"

--- a/foundations/src/telemetry/tracing/internal.rs
+++ b/foundations/src/telemetry/tracing/internal.rs
@@ -2,14 +2,14 @@ use super::init::TracingHarness;
 use super::StartTraceOptions;
 use rand::{self, Rng};
 
-use crate::telemetry::tracing::rate_limit::RateLimitingProbabilisticSampler;
+use cf_rustracing::sampler::BoxSampler;
 use cf_rustracing::tag::Tag;
 use cf_rustracing_jaeger::span::{Span, SpanContext, SpanContextState};
 use std::borrow::Cow;
 use std::error::Error;
 use std::sync::Arc;
 
-pub(crate) type Tracer = cf_rustracing::Tracer<RateLimitingProbabilisticSampler, SpanContextState>;
+pub(crate) type Tracer = cf_rustracing::Tracer<BoxSampler<SpanContextState>, SpanContextState>;
 
 #[derive(Debug, Clone)]
 pub(crate) struct SharedSpan {

--- a/foundations/src/telemetry/tracing/mod.rs
+++ b/foundations/src/telemetry/tracing/mod.rs
@@ -216,7 +216,7 @@ pub struct StartTraceOptions {
     ///
     /// Can be used to enforce trace sampling by providing `Some(1.0)` value.
     ///
-    /// [sampling ratio]: crate::telemetry::settings::TracingSettings::sampling_ratio
+    /// [sampling ratio]: crate::telemetry::settings::ActiveSamplingSettings::sampling_ratio
     /// [tracing initializaion]: crate::telemetry::init
     pub override_sampling_ratio: Option<f64>,
 }

--- a/foundations/src/telemetry/tracing/rate_limit.rs
+++ b/foundations/src/telemetry/tracing/rate_limit.rs
@@ -1,4 +1,4 @@
-use crate::telemetry::settings::TracingSettings;
+use crate::telemetry::settings::ActiveSamplingSettings;
 use cf_rustracing::sampler::Sampler;
 use cf_rustracing::span::CandidateSpan;
 use cf_rustracing::{sampler::ProbabilisticSampler, Result};
@@ -26,7 +26,7 @@ impl Default for RateLimitingProbabilisticSampler {
 impl RateLimitingProbabilisticSampler {
     /// If `sampling_rate` is not in the range `0.0...1.0`,
     /// it will return an error with the kind `ErrorKind::InvalidInput`.
-    pub(crate) fn new(settings: &TracingSettings) -> Result<Self> {
+    pub(crate) fn new(settings: &ActiveSamplingSettings) -> Result<Self> {
         let rate_limiter = if settings.rate_limit.enabled {
             settings
                 .rate_limit


### PR DESCRIPTION
When we have many services in the same flow, we want to defer the sampling logic to the parent service (which will defer to the root service in the end).

The PassiveSampler is really good for that, as it will only sample traces that have one external reference. This assumes that the parent service will send the trace info to stitch, if we should keep it, and won't, if we should discard it. This is what some of our services do already today, and it would really help us onboard to foundations!

This needs https://github.com/cloudflare/rustracing/pull/2 merged & `cf-rustracing` bumped in order to compile and work fine.