### PR TITLE
Provide foundations::telemetry::metrics::with_registry()

### DIFF
--- a/foundations/src/telemetry/metrics/internal.rs
+++ b/foundations/src/telemetry/metrics/internal.rs
@@ -15,7 +15,7 @@ static REGISTRIES: OnceCell<Registries> = OnceCell::new();
 pub struct Registries {
     // NOTE: we intentionally use a lock without poisoning here to not
     // panic the threads if they just share telemetry with failed thread.
-    main: parking_lot::RwLock<Registry>,
+    pub(super) main: parking_lot::RwLock<Registry>,
     opt: parking_lot::RwLock<Registry>,
     pub(super) info: parking_lot::RwLock<HashMap<TypeId, Box<dyn ErasedInfoMetric>>>,
     extra_label: Option<(String, String)>,


### PR DESCRIPTION
Currently there is no way to enable third party libraries to register metrics, which is not great. With this new method those libraries can get a `Registry` to register their metrics when they initialize, while still giving the end user control over prefixes and external labels.