### PR TITLE
Fix accidental 4.0 breaking changes and run example in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,19 @@ jobs:
           RUSTFLAGS: -Dwarnings --cfg tokio_unstable --cfg foundations_unstable
           _RJEM_MALLOC_CONF: prof:true
 
+  run-example-dry-run:
+    name: Run example (dry run)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run example (dry run)
+        run: cargo run --example http_server -- --dry-run --config examples/http_server/example_conf.yaml
+
   test:
     name: Test
     runs-on: ${{ matrix.os }}

--- a/examples/http_server/example_conf.yaml
+++ b/examples/http_server/example_conf.yaml
@@ -3,23 +3,25 @@
 telemetry:
   # Distributed tracing settings
   tracing:
-    # Enables tracing.
-    enabled: true
+    # Disables tracing.
+    enabled: false
     # The output for the collected traces.
     output:
       open_telemetry_grpc:
         endpoint_url: "http://localhost:4317"
-    # Sampling ratio.
-    #
-    # This can be any fractional value between `0.0` and `1.0`.
-    # Where `1.0` means "sample everything", and `0.0` means "don't sample anything".
-    sampling_ratio: 1.0
-    # Settings for rate limiting emission of traces
-    rate_limit:
-      # Whether to enable rate limiting of events
-      enabled: false
-      # Maximum number of events that can be emitted per second
-      max_events_per_second: 0
+    sampling_strategy:
+      active:
+        # Sampling ratio.
+        #
+        # This can be any fractional value between `0.0` and `1.0`.
+        # Where `1.0` means "sample everything", and `0.0` means "don't sample anything".
+        sampling_ratio: 1.0
+        # Settings for rate limiting emission of traces
+        rate_limit:
+          # Whether to enable rate limiting of events
+          enabled: false
+          # Maximum number of events that can be emitted per second
+          max_events_per_second: 0
   # Logging settings.
   logging:
     # Specifies log output.

--- a/foundations/src/telemetry/server.rs
+++ b/foundations/src/telemetry/server.rs
@@ -50,7 +50,9 @@ pub(super) fn init(
 
     // Eagerly init the memory profiler so it gets set up before syscalls are sandboxed with seccomp.
     #[cfg(all(target_os = "linux", feature = "memory-profiling"))]
-    memory_profiling::profiler(Arc::clone(&settings)).map_err(|err| anyhow!(err))?;
+    if settings.memory_profiler.enabled {
+        memory_profiling::profiler(Arc::clone(&settings)).map_err(|err| anyhow!(err))?;
+    }
 
     let router = create_router(&settings, custom_routes)?;
     let addr = settings.server.addr;

--- a/foundations/src/telemetry/settings/logging.rs
+++ b/foundations/src/telemetry/settings/logging.rs
@@ -72,17 +72,23 @@ pub enum LogFormat {
 #[derive(Copy, Default)]
 pub enum LogVerbosity {
     /// See [`slog::Level::Critical`].
+    #[cfg_attr(feature = "settings", serde(rename = "CRITICAL"))]
     Critical,
     /// See [`slog::Level::Error`].
+    #[cfg_attr(feature = "settings", serde(rename = "ERROR"))]
     Error,
     /// See [`slog::Level::Warning`].
+    #[cfg_attr(feature = "settings", serde(rename = "WARN"))]
     Warning,
     /// See [`slog::Level::Info`].
     #[default]
+    #[cfg_attr(feature = "settings", serde(rename = "INFO"))]
     Info,
     /// See [`slog::Level::Debug`].
+    #[cfg_attr(feature = "settings", serde(rename = "DEBUG"))]
     Debug,
     /// See [`slog::Level::Trace`].
+    #[cfg_attr(feature = "settings", serde(rename = "TRACE"))]
     Trace,
 }
 


### PR DESCRIPTION
This addresses two accidental breaking changes:
1. Introduced in #14: Config deserialization previously expected log level to be all caps (e.g., "TRACE", matching [slog](https://docs.rs/slog/latest/src/slog/lib.rs.html#2079)), but are now expected to be lowercase (since foundations adds the serde attribute `rename_all="snake_case"` to enums). So deserialization of existing configs would break
2. Introduced in #54: If an app has the "memory-profiling" feature enabled, but the settings disable memory profiling, server init would fail because the returned profiler would be None

This also adds adds a step to CI that does a "dry run" of the example to validate the example config, to help catch breaking config changes going forward