### PR TITLE
Provide metrics::add_extra_producer() to enable external metrics [v3.x]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
       - fmt
       - check-features
       - test
-      - minimal-versions
     steps:
       - run: exit 0
 
@@ -47,43 +46,6 @@ jobs:
         env:
           RUSTDOCFLAGS: --cfg docsrs -Dwarnings --cfg tokio_unstable --cfg foundations_unstable
           RUSTFLAGS: --cfg docsrs -Dwarnings --cfg tokio_unstable --cfg foundations_unstable
-
-  # based on tokio minver cbecm
-  minimal-versions:
-    name: minimal-versions
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
-      - name: Install Nightly Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: nightly
-      - name: Install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
-      - uses: Swatinem/rust-cache@v2
-      - name: Check minimal versions
-        env:
-          # empty those flags!
-          RUSTFLAGS:
-        run: |
-          # Remove dev-dependencies from Cargo.toml to prevent the next `cargo update`
-          # from determining minimal versions based on dev-dependencies.
-          cargo hack --remove-dev-deps --workspace
-          # Update Cargo.lock to minimal version dependencies.
-          cargo update -Z minimal-versions
-          cargo hack check --all-features --ignore-private
-      - name: Check minimal versions with unstable features
-        env:
-          RUSTFLAGS: --cfg tokio_unstable --cfg foundations_unstable
-        run: |
-          # Remove dev-dependencies from Cargo.toml to prevent the next `cargo update`
-          # from determining minimal versions based on dev-dependencies.
-          cargo hack --remove-dev-deps --workspace
-          # Update Cargo.lock to minimal version dependencies.
-          cargo update -Z minimal-versions
-          cargo hack check --all-features --ignore-private
 
   deny:
     name: Cargo deny checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - "v[0-9]+.*"
   push:
     branches:
       - main
+      - "v[0-9]+.*"
 
 env:
   RUSTFLAGS: -Dwarnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ bindgen = { version = "0.68.1", default-features = false }
 cc = "1.0"
 clap = "4.4"
 crossbeam-channel = "0.5"
-darling = "0.20"
+darling = "0.20.10"
 erased-serde = "0.3.28"
 futures-util = "0.3.28"
 governor = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [
     "foundations",
     "foundations-macros",
     "examples",
-    "tools/gen-syscall-enum"
+    "tools/gen-syscall-enum",
 ]
 resolver = "2"
 
@@ -31,7 +31,7 @@ bindgen = { version = "0.68.1", default-features = false }
 cc = "1.0"
 clap = "4.4"
 crossbeam-channel = "0.5"
-darling = "0.14.4"
+darling = "0.20"
 erased-serde = "0.3.28"
 futures-util = "0.3.28"
 governor = "0.6"
@@ -51,8 +51,8 @@ quote = "1"
 regex = "1.8"
 reqwest = { version = "0.11", default-features = false }
 routerify = "3"
-socket2 = { version = "0.5.3", features = [ "all" ] }
-syn = "1"
+socket2 = { version = "0.5.3", features = ["all"] }
+syn = "2"
 serde = "1"
 serde_path_to_error = "0.1.15"
 serde_yaml = "0.8.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "3.3.0"
+version = "3.4.0"
 repository = "https://github.com/cloudflare/foundations"
 edition = "2021"
 authors = ["Cloudflare"]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,17 @@
+
+3.4.0
+- 2024-10-07 Disable minimal-versions check until it can be fixed
+- 2024-08-12 Fix seccomp violation in MemoryProfiler introduce by Rust 1.80.0 std
+- 2024-07-24 Rename depricated tokio metric
+- 2024-08-06 Make clippy happy
+- 2024-10-07 Backport allow of unexpected cfgs
+- 2024-07-22 Bump syn and darling (closes #50)
+- 2024-10-03 Let GitHub run CI actions for version branches (#73)
+- 2024-09-21 Provide metrics::add_extra_producer() to enable external metrics
+- 2024-03-26 Improve metrics bind error message
+
 3.3.0
+- 2024-03-21 Release 3.3.0
 - 2024-03-21 Fix new lints
 - 2024-03-19 Construct metrics registry with default() when name_in_metrics is empty
 - 2024-03-10 Fix paths in gen-syscall-enum tool

--- a/foundations-macros/src/common.rs
+++ b/foundations-macros/src/common.rs
@@ -1,7 +1,9 @@
+use darling::ast::NestedMeta;
+use quote::ToTokens as _;
 use syn::parse::{Parse, ParseStream, Parser};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::{Attribute, NestedMeta, Token};
+use syn::{Attribute, Ident, Token};
 
 pub(crate) type Result<T> = std::result::Result<T, syn::Error>;
 
@@ -34,11 +36,12 @@ where
     T: Parse,
 {
     let parser = |input: ParseStream| {
+        let _name = input.parse::<Ident>()?;
         let _equal_token = input.parse::<Token![=]>()?;
         input.parse::<T>()
     };
 
-    parser.parse2(attr.tokens)
+    parser.parse2(attr.meta.to_token_stream())
 }
 
 #[cfg(test)]

--- a/foundations-macros/src/info_metric/mod.rs
+++ b/foundations-macros/src/info_metric/mod.rs
@@ -5,8 +5,7 @@ use proc_macro2::Span;
 use quote::{quote, ToTokens};
 use syn::punctuated::Punctuated;
 use syn::{
-    parse_macro_input, parse_quote, Attribute, AttributeArgs, Ident, LitStr, Path, Token, Type,
-    Visibility,
+    parse_macro_input, parse_quote, Attribute, Ident, LitStr, Path, Token, Type, Visibility,
 };
 
 mod parsing;
@@ -63,11 +62,8 @@ struct FieldAttrs {
 }
 
 pub(crate) fn expand(args: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(args as MacroArgs);
     let mod_ = parse_macro_input!(item as Struct);
-    let args = match MacroArgs::from_list(&parse_macro_input!(args as AttributeArgs)) {
-        Ok(args) => args,
-        Err(e) => return e.write_errors().into(),
-    };
 
     expand_from_parsed(args, mod_)
         .unwrap_or_else(|e| e.to_compile_error())

--- a/foundations-macros/src/info_metric/parsing.rs
+++ b/foundations-macros/src/info_metric/parsing.rs
@@ -19,6 +19,7 @@ impl Parse for MacroArgs {
         }
 
         let meta_list = parse_meta_list(&input)?;
+
         Ok(Self::from_list(&meta_list)?)
     }
 }
@@ -30,9 +31,11 @@ impl Parse for Struct {
             let mut doc = "".to_owned();
 
             for attr in attrs {
-                if attr.path.is_ident("cfg") {
+                let path = attr.path();
+
+                if path.is_ident("cfg") {
                     cfg.push(attr);
-                } else if attr.path.is_ident("doc") {
+                } else if path.is_ident("doc") {
                     doc.push_str(&parse_attr_value::<LitStr>(attr)?.value());
                 } else {
                     return error(&attr, STRUCT_ATTR_ERROR);
@@ -76,13 +79,15 @@ impl Parse for Field {
             let mut attrs = FieldAttrs::default();
 
             for attr in raw_attrs {
-                if attr.path.is_ident("serde") {
+                let path = attr.path();
+
+                if path.is_ident("serde") {
                     if attrs.serde.is_some() {
                         return error(&attr, DUPLICATE_SERDE_ATTR_ERROR);
                     }
 
                     attrs.serde = Some(attr);
-                } else if attr.path.is_ident("serde_as") {
+                } else if path.is_ident("serde_as") {
                     if attrs.serde_as.is_some() {
                         return error(&attr, DUPLICATE_SERDE_AS_ATTR_ERROR);
                     }

--- a/foundations-macros/src/metrics/mod.rs
+++ b/foundations-macros/src/metrics/mod.rs
@@ -4,8 +4,8 @@ use proc_macro2::Span;
 use quote::{quote, ToTokens};
 use syn::punctuated::Punctuated;
 use syn::{
-    parse_macro_input, parse_quote, Attribute, AttributeArgs, ExprStruct, Ident, LitStr, Path,
-    Token, Type, Visibility,
+    parse_macro_input, parse_quote, Attribute, ExprStruct, Ident, LitStr, Path, Token, Type,
+    Visibility,
 };
 
 mod parsing;
@@ -77,11 +77,8 @@ enum ArgMode {
 }
 
 pub(crate) fn expand(args: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(args as MacroArgs);
     let mod_ = parse_macro_input!(item as Mod);
-    let args = match MacroArgs::from_list(&parse_macro_input!(args as AttributeArgs)) {
-        Ok(args) => args,
-        Err(e) => return e.write_errors().into(),
-    };
 
     expand_from_parsed(args, mod_).into()
 }

--- a/foundations-macros/src/span_fn.rs
+++ b/foundations-macros/src/span_fn.rs
@@ -130,7 +130,7 @@ fn expand_from_parsed(args: Args, item_fn: ItemFn) -> TokenStream2 {
 
 fn try_async_trait_fn_rewrite(args: &Args, body: &Block) -> Option<TokenStream2> {
     let (last_expr_fn_call, last_expr_fn_call_args) = match body.stmts.last()? {
-        Stmt::Expr(Expr::Call(ExprCall { func, args, .. })) => (func, args),
+        Stmt::Expr(Expr::Call(ExprCall { func, args, .. }), ..) => (func, args),
         _ => return None,
     };
 

--- a/foundations/src/lib.rs
+++ b/foundations/src/lib.rs
@@ -53,6 +53,8 @@
 //! [jemalloc]: https://github.com/jemalloc/jemalloc
 //! [examples]: https://github.com/cloudflare/foundations/tree/main/examples
 
+// NOTE: required to allow cfgs like `tokio_unstable` on nightly which is used in tests.
+#![allow(unexpected_cfgs)]
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/foundations/src/lib.rs
+++ b/foundations/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! - **default**: All features are enabled by default.
 //! - **platform-common-default**: The same as **default**, but excludes platform-specific features,
-//! such as **security**.
+//!   such as **security**.
 //! - **server-client-common-default**: A subset of features that can be used both on server and client sides.
 //!   Useful for libraries that can be used either way.
 //! - **settings**: Enables serializable documented settings functionality.
@@ -35,11 +35,11 @@
 //! - **testing**: Enables testing-related functionality.
 //! - **security**: Enables security features. Available only on Linux (x86_64, aarch64).
 //! - **jemalloc**: Enables [jemalloc] memory allocator which is known to perform much better than
-//! system allocators for long living service.
+//!   system allocators for long living service.
 //! - **memory-profiling**: Enables memory profiling functionality and telemetry. Implicity enables
-//!  **jemalloc** feature.
+//!   **jemalloc** feature.
 //! - **cli**: Enables command line interface (CLI) functionality. Implicitly enabled **settings**
-//! feature.
+//!   feature.
 //!
 //! # Unstable Features
 //! Foundations has unstable features which are gated behind `--cfg foundations_unstable`:

--- a/foundations/src/security/common_syscall_allow_lists.rs
+++ b/foundations/src/security/common_syscall_allow_lists.rs
@@ -17,6 +17,13 @@ allow_list! {
         sched_getaffinity,
         madvise, // memory allocation
         mprotect,
+        // NOTE: rust 1.80.0 std library introduced an assertion that uses `fcntl`:
+        // https://github.com/rust-lang/rust/commit/38ded129236f112a7421f311aeb8ca750b661443
+        // it's later has been changed to debug-only assertion:
+        // https://github.com/rust-lang/rust/commit/1ba00d9cb2fcfef464b6a188fa3a7543c66eecaa,
+        // so we allow this syscall only in debug mode.
+        #[cfg(debug_assertions)]
+        fcntl,
         prctl if [ ArgCmp::Equal { arg_idx: 0, value: PR_SET_NAME.into() } ] // tokio-runtime thread name
     ]
 }

--- a/foundations/src/security/mod.rs
+++ b/foundations/src/security/mod.rs
@@ -328,8 +328,6 @@ pub enum Rule {
 /// use foundations::security::{enable_syscall_sandboxing, ViolationAction, allow_list};
 /// use foundations::security::common_syscall_allow_lists::SERVICE_BASICS;
 /// use std::net::TcpListener;
-/// use std::panic;
-/// use std::thread;
 ///
 /// allow_list! {
 ///    static ALLOW_BIND = [

--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -3,7 +3,7 @@
 //! Foundations provides simple and ergonomic interface to [Prometheus] metrics:
 //! - Use [`metrics`] macro to define regular metrics.
 //! - Use [`report_info`] function to register service information metrics (metrics, whose value is
-//! persistent during the service lifetime, e.g. software version).
+//!   persistent during the service lifetime, e.g. software version).
 //! - Use [`collect`] method to obtain metrics report programmatically.
 //! - Use [telemetry server] to expose a metrics endpoint.
 //!

--- a/foundations/src/telemetry/tokio_runtime_metrics/metrics.rs
+++ b/foundations/src/telemetry/tokio_runtime_metrics/metrics.rs
@@ -15,7 +15,7 @@ pub(super) mod tokio_runtime_core {
     pub fn blocking_threads(runtime_name: &Option<Arc<str>>, runtime_id: Option<usize>) -> Gauge;
 
     /// Current number of active tasks on the runtime.
-    pub fn active_tasks(runtime_name: &Option<Arc<str>>, runtime_id: Option<usize>) -> Gauge;
+    pub fn num_alive_tasks(runtime_name: &Option<Arc<str>>, runtime_id: Option<usize>) -> Gauge;
 
     /// Current number of idle blocking threads on the runtime which aren't doing anything.
     ///

--- a/foundations/src/telemetry/tokio_runtime_metrics/mod.rs
+++ b/foundations/src/telemetry/tokio_runtime_metrics/mod.rs
@@ -11,7 +11,7 @@
 //! |:-------------------------------------------------|:--------------------------------------------------------------------|:---------------------------------------|
 //! | tokio_runtime_workers                            | [`tokio::runtime::RuntimeMetrics::num_workers`]                     | runtime_name?, runtime_id?             |
 //! | tokio_runtime_blocking_threads                   | [`tokio::runtime::RuntimeMetrics::num_blocking_threads`]            | runtime_name?, runtime_id?             |
-//! | tokio_runtime_active_tasks                       | [`tokio::runtime::RuntimeMetrics::active_tasks_count`]              | runtime_name?, runtime_id?             |
+//! | tokio_runtime_num_alive_tasks                    | [`tokio::runtime::RuntimeMetrics::num_alive_tasks`]                 | runtime_name?, runtime_id?             |
 //! | tokio_runtime_idle_blocking_threads              | [`tokio::runtime::RuntimeMetrics::num_idle_blocking_threads`]       | runtime_name?, runtime_id?             |
 //! | tokio_runtime_remote_schedules_total             | [`tokio::runtime::RuntimeMetrics::remote_schedule_count`]           | runtime_name?, runtime_id?             |
 //! | tokio_runtime_budget_forced_yields_total         | [`tokio::runtime::RuntimeMetrics::budget_forced_yield_count`]       | runtime_name?, runtime_id?             |

--- a/foundations/src/telemetry/tokio_runtime_metrics/runtime_handle.rs
+++ b/foundations/src/telemetry/tokio_runtime_metrics/runtime_handle.rs
@@ -27,8 +27,8 @@ impl RuntimeHandle {
         tokio_runtime_core::blocking_threads(&self.runtime_name, self.runtime_id)
             .set(metrics.num_blocking_threads() as u64);
 
-        tokio_runtime_core::active_tasks(&self.runtime_name, self.runtime_id)
-            .set(metrics.active_tasks_count() as u64);
+        tokio_runtime_core::num_alive_tasks(&self.runtime_name, self.runtime_id)
+            .set(metrics.num_alive_tasks() as u64);
 
         tokio_runtime_core::idle_blocking_threads(&self.runtime_name, self.runtime_id)
             .set(metrics.num_idle_blocking_threads() as u64);


### PR DESCRIPTION
Same as #66, but rebased on top of v3.3.0.