### PR TITLE
OXY-1404: Revert most of #60 and expose get_current_thread_seccomp_mode

### DIFF
--- a/foundations/src/security/mod.rs
+++ b/foundations/src/security/mod.rs
@@ -48,9 +48,8 @@ mod sys {
 }
 
 use self::internal::RawRule;
-use crate::{BootstrapError, BootstrapResult};
-use anyhow::{anyhow, bail};
-use std::fmt::Display;
+use crate::BootstrapResult;
+use anyhow::bail;
 use sys::PR_GET_SECCOMP;
 
 pub use self::syscalls::Syscall;
@@ -99,46 +98,6 @@ impl ArgCmpValue {
 impl<T: Into<u64>> From<T> for ArgCmpValue {
     fn from(val: T) -> Self {
         Self(val.into())
-    }
-}
-
-/// Errors that can be produced when initializing sandboxing using
-/// [`enable_syscall_sandboxing`]
-#[derive(Debug)]
-pub enum SandboxingInitializationError {
-    /// Sandboxing has already been initialized on the current thread
-    /// with the given [`SeccompMode`]
-    AlreadyInitialized(SeccompMode),
-
-    /// Some other error occurred during initialization
-    Other(BootstrapError),
-}
-
-impl Display for SandboxingInitializationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SandboxingInitializationError::AlreadyInitialized(mode) => write!(
-                f,
-                "seccomp has already been initialized and is in mode {:?}",
-                mode
-            ),
-            SandboxingInitializationError::Other(e) => e.fmt(f),
-        }
-    }
-}
-
-impl From<BootstrapError> for SandboxingInitializationError {
-    fn from(err: BootstrapError) -> Self {
-        SandboxingInitializationError::Other(err)
-    }
-}
-
-impl From<SandboxingInitializationError> for BootstrapError {
-    fn from(value: SandboxingInitializationError) -> Self {
-        match value {
-            SandboxingInitializationError::Other(e) => e,
-            e @ SandboxingInitializationError::AlreadyInitialized(_) => anyhow!("{}", e),
-        }
     }
 }
 
@@ -356,7 +315,7 @@ pub enum SeccompMode {
 }
 
 /// Enables [seccomp]-based syscall sandboxing in the current thread and all the threads spawned
-/// by it, if the current thread does not already have sandboxing enabled.
+/// by it.
 ///
 /// Calling the function early in the `main` function effectively enables seccomp for the whole
 /// process.
@@ -365,10 +324,6 @@ pub enum SeccompMode {
 /// provided [`ViolationAction`]. [`allow_list`] macro can be used to conveniently construct lists
 /// of allowed syscalls. In addition, the crate provides [`common_syscall_allow_lists`] that can be
 /// merged into the user-provided allow lists.
-///
-/// To setup sandboxing on a thread has already been sandboxed, use
-/// [`enable_syscall_sandboxing_ignore_existing`] on a thread allowing the `prctl` and `seccomp`
-/// syscalls.
 ///
 /// [seccomp]: https://man7.org/linux/man-pages/man2/seccomp.2.html
 ///
@@ -407,30 +362,6 @@ pub enum SeccompMode {
 /// let _ = TcpListener::bind("127.0.0.1:0");
 /// ```
 pub fn enable_syscall_sandboxing(
-    violation_action: ViolationAction,
-    exception_rules: &Vec<Rule>,
-) -> Result<(), SandboxingInitializationError> {
-    let current_mode = get_current_thread_seccomp_mode()?;
-    if current_mode != SeccompMode::None {
-        return Err(SandboxingInitializationError::AlreadyInitialized(
-            current_mode,
-        ));
-    }
-
-    enable_syscall_sandboxing_ignore_existing(violation_action, exception_rules)
-        .map_err(|e| e.into())
-}
-
-/// Attempts to enable [seccomp]-based syscall sandboxing in the current thread and all
-/// the threads spawned by it, regardless of whether this thread is already sandboxed.
-///
-/// If called after sandboxing was previously set up, this will likely violate rules
-/// not configured to allow the `prctl` and `seccomp` syscalls.
-///
-/// See [`enable_syscall_sandboxing`] for more details.
-///
-/// [seccomp]: https://man7.org/linux/man-pages/man2/seccomp.2.html
-pub fn enable_syscall_sandboxing_ignore_existing(
     violation_action: ViolationAction,
     exception_rules: &Vec<Rule>,
 ) -> BootstrapResult<()> {
@@ -529,7 +460,7 @@ pub fn forbid_x86_64_cpu_cycle_counter() {
 /// ```
 ///
 /// [prctl(PR_GET_SECCOMP)]: https://linuxman7.org/linux/man-pages/man2/PR_GET_SECCOMP.2const.html
-fn get_current_thread_seccomp_mode() -> BootstrapResult<SeccompMode> {
+pub fn get_current_thread_seccomp_mode() -> BootstrapResult<SeccompMode> {
     let current_seccomp_mode = unsafe { sys::prctl(PR_GET_SECCOMP as i32) };
     match current_seccomp_mode {
         0 => Ok(SeccompMode::None),


### PR DESCRIPTION
(copied from #72's description) While updating Oxy with foundations 4.0, I discovered a flaw with the previous approach: [docker](https://docs.docker.com/engine/security/seccomp/#pass-a-profile-for-a-container), by default, uses seccomp to block 44 system calls. This means that, with the approach used in https://github.com/cloudflare/foundations/pull/60, code calling enable_syscall_sandboxing would get an error because seccomp is already active if it happened to be running inside a docker container - even though it could still safely call enable_syscall_sandboxing.

As described in https://github.com/cloudflare/foundations/pull/60, the original motivation for that change was because of the use of the [tokio::runtime::Builder::on_thread_start](https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.on_thread_start) hook leading to double seccomp initialization. This hook was used to ensure that any threads initialized before seccomp is configured on the main thread also had seccomp active, but it led to a risk of double seccomp initialization leading to a crash.

This PR rolls back most of the changes in #60, instead simply exposing the `get_current_thread_seccomp_mode` method so applications can decide for themselves how to handle these scenarios. In our case, we'll use it to log a warning if we're about to enable seccomp and it's already enabled.
