### PR TITLE
Allow opting out of settings deny_unknown_fields for foundations internal structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ debug = 1
 [workspace.dependencies]
 anyhow = "1.0.75"
 foundations = { version = "4.0.0", path = "./foundations" }
-foundations-macros = { version = "4.0.0", path = "./foundations-macros" }
+foundations-macros = { version = "4.0.0", path = "./foundations-macros", default-features = false }
 bindgen = { version = "0.68.1", default-features = false }
 cc = "1.0"
 cf-rustracing = "1.0.1"

--- a/foundations-macros/Cargo.toml
+++ b/foundations-macros/Cargo.toml
@@ -8,6 +8,10 @@ authors = { workspace = true }
 license = { workspace = true }
 readme = "../README.md"
 
+[features]
+default = ["settings_deny_unknown_fields_by_default"]
+settings_deny_unknown_fields_by_default = []
+
 [lib]
 proc-macro = true
 

--- a/foundations-macros/src/settings.rs
+++ b/foundations-macros/src/settings.rs
@@ -45,7 +45,7 @@ impl Options {
     }
 
     fn default_deny_unknown_fields() -> bool {
-        true
+        cfg!(feature = "settings_deny_unknown_fields_by_default")
     }
 }
 

--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -39,6 +39,7 @@ platform-common-default = [
     "telemetry",
     "cli",
     "testing",
+    "settings_deny_unknown_fields_by_default",
 ]
 
 # A subset of features that can be used both on server and client sides. Useful for libraries
@@ -54,6 +55,9 @@ settings = [
     "dep:yaml-merge-keys",
     "dep:indexmap",
 ]
+
+# Whether settings structs annotated with `#[settings]` will, by default, error on unknown fields.
+settings_deny_unknown_fields_by_default = ["foundations-macros?/settings_deny_unknown_fields_by_default"]
 
 # Enables all the telemetry-related features ("logging", "metrics", "tracing", "telemetry-server").
 telemetry = [
@@ -162,7 +166,7 @@ rustc-args = ["--cfg", "tokio_unstable", "--cfg", "foundations_unstable"]
 
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace", "std"] }
-foundations-macros = { workspace = true, optional = true }
+foundations-macros = { workspace = true, optional = true, default-features = false }
 cf-rustracing = { workspace = true, optional = true }
 cf-rustracing-jaeger = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }

--- a/foundations/src/lib.rs
+++ b/foundations/src/lib.rs
@@ -17,7 +17,7 @@
 //! Check out [examples] for an example of how all these components can be used together.
 //!
 //! # Features
-//! Foundations can take of all aspects of service bootstrapping, but also can be used as a component
+//! Foundations can take care of all aspects of service bootstrapping, but also can be used as a component
 //! library in a modular fashion by enabling or disabling [Cargo features]:
 //!
 //! - **default**: All features are enabled by default.
@@ -26,6 +26,7 @@
 //! - **server-client-common-default**: A subset of features that can be used both on server and client sides.
 //!   Useful for libraries that can be used either way.
 //! - **settings**: Enables serializable documented settings functionality.
+//! - **settings_deny_unknown_fields_by_default**: Whether settings structs annotated with the [`settings`] attribute macro will, by default, error on unknown fields.
 //! - **telemetry**: Enables all the telemetry-related features (**metrics**, **logging**, **tracing**, **telemetry-server**).
 //! - **telemetry-otlp-grpc**: Enables [OpenTelemetry] reporting via [gRPC].
 //! - **telemetry-server**: Enables the telemetry server.
@@ -55,6 +56,7 @@
 //! [examples]: https://github.com/cloudflare/foundations/tree/main/examples
 //! [OpenTelemetry]: https://opentelemetry.io/
 //! [gRPC]: https://grpc.io/
+//! [`settings`]: crate::settings::Settings
 
 // NOTE: required to allow cfgs like `tokio_unstable` on nightly which is used in tests.
 #![allow(unexpected_cfgs)]

--- a/migration_guide_4.0.0.md
+++ b/migration_guide_4.0.0.md
@@ -15,7 +15,7 @@ This leaves users of foundations two choices:
 1. Update configs to remove unused keys. This will involve:  
    1. Remove keys fields that are fully unused  
    2. Move keys that were used purely for YAML anchors inline to their first use. For example, for the case in Apollo linked above, it would instead be something like  
-2. Opt out of this feature by updating the settings struct annotation from `#[settings]` to `#[settings(deny_unknown_fields = false)]`
+2. Opt out of this feature by updating individual settings struct annotations from `#[settings]` to `#[settings(deny_unknown_fields = false)]`, or by opting out of default features and not using the foundations feature "settings_deny_unknown_fields_by_default".
 
 ### ZTC-1648: Avoid heap profiling crash by eagerly starting long-lived profiling thread (PR [\#54](https://github.com/cloudflare/foundations/pull/54/files))
 


### PR DESCRIPTION
Following up on #49 

It's been realized that there is no existing way to opt out of `deny_unknown_fields` for the settings structs defined within foundations itself. This adds a way to do that - by settings `default-features = false` in `Cargo.toml` and not passing the new `settings_deny_unknown_fields_by_default` feature.

This keeps it enabled by default, but gives users of foundations a way to disable this feature. When the feature is not passed, since it only controls the default structs that don't specify, it is still possible to opt specific settings structs into this check.