### PR TITLE
Expose active traces through telemetry server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ foundations = { version = "4.0.0", path = "./foundations" }
 foundations-macros = { version = "4.0.0", path = "./foundations-macros" }
 bindgen = { version = "0.68.1", default-features = false }
 cc = "1.0"
-cf-rustracing = "1.0.1"
+cf-rustracing = "1.1"
 cf-rustracing-jaeger = "1.1"
 clap = "4.4"
 darling = "0.20.10"
@@ -79,6 +79,3 @@ neli = "0.6.4"
 neli-proc-macros = "0.1.3"
 parking_lot_core = "0.9.9"
 thiserror = "1.0.56"
-
-[patch.crates-io]
-cf-rustracing = { git = "https://github.com/cbranch/rustracing.git", rev = "c81f98643547e31d920c73a440c382690bc2cde1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,3 +79,6 @@ neli = "0.6.4"
 neli-proc-macros = "0.1.3"
 parking_lot_core = "0.9.9"
 thiserror = "1.0.56"
+
+[patch.crates-io]
+cf-rustracing = { git = "https://github.com/cbranch/rustracing.git", rev = "c81f98643547e31d920c73a440c382690bc2cde1" }

--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -116,6 +116,7 @@ tracing = [
     "dep:futures-util",
     "dep:tokio",
     "dep:serde",
+    "dep:slab",
 ]
 
 # Enables metrics functionality.

--- a/foundations/src/telemetry/log/field_filtering.rs
+++ b/foundations/src/telemetry/log/field_filtering.rs
@@ -97,7 +97,7 @@ macro_rules! filter {
     }};
 }
 
-impl<'s, F: Filter> Serializer for FieldFilteringSerializer<'s, F> {
+impl<F: Filter> Serializer for FieldFilteringSerializer<'_, F> {
     fn emit_arguments(&mut self, key: Key, val: &Arguments) -> slog::Result {
         filter!(self.emit_arguments(key, val))
     }

--- a/foundations/src/telemetry/telemetry_context.rs
+++ b/foundations/src/telemetry/telemetry_context.rs
@@ -32,7 +32,7 @@ pub struct WithTelemetryContext<'f, T> {
     ctx: TelemetryContext,
 }
 
-impl<'f, T> Future for WithTelemetryContext<'f, T> {
+impl<T> Future for WithTelemetryContext<'_, T> {
     type Output = T;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -51,7 +51,7 @@ pub struct WithTelemetryContextLocal<'f, T> {
     ctx: TelemetryContext,
 }
 
-impl<'f, T> Future for WithTelemetryContextLocal<'f, T> {
+impl<T> Future for WithTelemetryContextLocal<'_, T> {
     type Output = T;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/foundations/src/telemetry/tracing/init.rs
+++ b/foundations/src/telemetry/tracing/init.rs
@@ -27,6 +27,9 @@ static NOOP_HARNESS: Lazy<TracingHarness> = Lazy::new(|| {
 
         #[cfg(feature = "testing")]
         test_tracer_scope_stack: Default::default(),
+
+        #[cfg(feature = "telemetry-server")]
+        active_roots: Default::default(),
     }
 });
 
@@ -37,6 +40,9 @@ pub(crate) struct TracingHarness {
 
     #[cfg(feature = "testing")]
     pub(crate) test_tracer_scope_stack: ScopeStack<Tracer>,
+
+    #[cfg(feature = "telemetry-server")]
+    pub(crate) active_roots: crate::telemetry::tracing::live::ActiveRoots,
 }
 
 impl TracingHarness {
@@ -95,6 +101,9 @@ pub(crate) fn init(
 
             #[cfg(feature = "testing")]
             test_tracer_scope_stack: Default::default(),
+
+            #[cfg(feature = "telemetry-server")]
+            active_roots: Default::default(),
         };
 
         let _ = HARNESS.set(harness);

--- a/foundations/src/telemetry/tracing/init.rs
+++ b/foundations/src/telemetry/tracing/init.rs
@@ -59,7 +59,7 @@ impl TracingHarness {
     }
 
     #[cfg(not(feature = "testing"))]
-    pub(crate) fn tracer(&'static self) -> &Tracer {
+    pub(crate) fn tracer(&'static self) -> &'static Tracer {
         &self.tracer
     }
 }

--- a/foundations/src/telemetry/tracing/live/event_output.rs
+++ b/foundations/src/telemetry/tracing/live/event_output.rs
@@ -11,7 +11,7 @@ pub(crate) fn spans_to_trace_events(epoch: SystemTime, spans: &[SharedSpanHandle
     let end_timestamp = epoch
         .elapsed()
         .ok()
-        .and_then(|x| u64::try_from(x.as_nanos()).ok())
+        .and_then(|x| u64::try_from(x.as_micros()).ok())
         .unwrap_or(u64::MAX);
 
     for span in spans {
@@ -24,13 +24,13 @@ pub(crate) fn spans_to_trace_events(epoch: SystemTime, spans: &[SharedSpanHandle
             .start_time()
             .duration_since(epoch)
             .ok()
-            .and_then(|x| u64::try_from(x.as_nanos()).ok())
+            .and_then(|x| u64::try_from(x.as_micros()).ok())
             .unwrap_or_default();
 
         let end_ts = span_ref
             .finish_time()
             .and_then(|x| x.duration_since(epoch).ok())
-            .and_then(|x| u64::try_from(x.as_nanos()).ok())
+            .and_then(|x| u64::try_from(x.as_micros()).ok())
             .unwrap_or(end_timestamp);
 
         log_builder.write_event(&trace_id, name, "", TraceEventType::Begin, start_ts);

--- a/foundations/src/telemetry/tracing/live/event_output.rs
+++ b/foundations/src/telemetry/tracing/live/event_output.rs
@@ -1,0 +1,94 @@
+//! Outputs telemetry spans in Chrome JSON trace format (i.e. the format used by about:tracing).
+use super::SharedSpanHandle;
+use std::time::SystemTime;
+
+/// Outputs a slice of shared spans as a Chrome JSON trace log.
+pub(crate) fn spans_to_trace_events(epoch: SystemTime, spans: &[SharedSpanHandle]) -> String {
+    use cf_rustracing::span::InspectableSpan;
+
+    let mut log_builder = TraceLogBuilder::new();
+
+    let end_timestamp = epoch
+        .elapsed()
+        .ok()
+        .and_then(|x| u64::try_from(x.as_nanos()).ok())
+        .unwrap_or(u64::MAX);
+
+    for span in spans {
+        let span_ref = span.read();
+        let span_state = span_ref.context().unwrap().state();
+        let trace_id = span_state.trace_id().to_string();
+        let name = span_ref.operation_name();
+
+        let start_ts = span_ref
+            .start_time()
+            .duration_since(epoch)
+            .ok()
+            .and_then(|x| u64::try_from(x.as_nanos()).ok())
+            .unwrap_or_default();
+
+        let end_ts = span_ref
+            .finish_time()
+            .and_then(|x| x.duration_since(epoch).ok())
+            .and_then(|x| u64::try_from(x.as_nanos()).ok())
+            .unwrap_or(end_timestamp);
+
+        log_builder.write_event(&trace_id, name, "", TraceEventType::Begin, start_ts);
+        log_builder.write_event(&trace_id, name, "", TraceEventType::End, end_ts);
+    }
+
+    log_builder.finalize(end_timestamp)
+}
+
+#[derive(Copy, Clone)]
+enum TraceEventType {
+    Begin,
+    End,
+}
+
+fn escape(s: &str) -> String {
+    s.escape_default().to_string()
+}
+
+struct TraceLogBuilder {
+    out: String,
+}
+
+impl TraceLogBuilder {
+    fn new() -> Self {
+        TraceLogBuilder {
+            out: "[".to_string(),
+        }
+    }
+
+    fn write_event(
+        &mut self,
+        trace_id: &str,
+        name: &str,
+        category: &str,
+        event_type: TraceEventType,
+        timestamp_us: u64,
+    ) {
+        self.out.push_str(&format!(
+            "{{\"pid\":1,\"name\":\"{}\",\"cat\":\"{}\",\"ph\":\"{}\",\"ts\":{},\"id\":\"{}\"}},",
+            escape(name),
+            escape(category),
+            match event_type {
+                TraceEventType::Begin => "B",
+                TraceEventType::End => "E",
+            },
+            timestamp_us,
+            trace_id,
+        ));
+    }
+
+    fn finalize(mut self, end_timestamp: u64) -> String {
+        self.out.push_str(&format!(
+            "{{\"pid\":1,\"name\":\"Trace dump requested\",\"ph\":\"i\",\"ts\":{},\"s\":\"g\"}}",
+            end_timestamp,
+        ));
+
+        self.out.push(']');
+        self.out
+    }
+}

--- a/foundations/src/telemetry/tracing/live/live_reference_set.rs
+++ b/foundations/src/telemetry/tracing/live/live_reference_set.rs
@@ -1,0 +1,144 @@
+use slab::Slab;
+use std::sync::{Arc, Mutex, Weak};
+
+/// Stores a set of reference-counted objects and allows iteration over them
+/// when requested. When the objects are dropped, they will be removed from
+/// the set.
+///
+/// The objects are wrapped by the `LiveReferenceSet` through its `track`
+/// method.
+pub(crate) struct LiveReferenceSet<T>(Arc<LiveReferenceSetInner<T>>);
+
+/// No default bound on T is required
+impl<T> Default for LiveReferenceSet<T> {
+    fn default() -> Self {
+        LiveReferenceSet(Arc::new(LiveReferenceSetInner {
+            active_set: Default::default(),
+        }))
+    }
+}
+
+struct LiveReferenceSetInner<T> {
+    active_set: Mutex<Slab<Weak<LiveReferenceHandle<T>>>>,
+}
+
+impl<T> LiveReferenceSet<T> {
+    /// Wrap `value` in an `Arc` and track the lifetime of the object.
+    ///
+    /// While the object has strong references, it is possible to obtain a
+    /// reference to it through the `get_live_references` method.
+    pub(crate) fn track(&self, value: T) -> Arc<LiveReferenceHandle<T>> {
+        let set_ref = Arc::clone(&self.0);
+        Arc::new_cyclic(|weak| {
+            let slot = self.0.active_set.lock().unwrap().insert(Weak::clone(weak));
+            LiveReferenceHandle {
+                set_ref,
+                slot,
+                value,
+            }
+        })
+    }
+
+    /// Get references to all live objects tracked by the `LiveReferenceSet`.
+    ///
+    /// Because this object is internally locked, the references are cloned and
+    /// collected into a `Vec`. The assumption is that any operation using
+    /// the references is expensive enough that it should happen outside the critical
+    /// section.
+    pub(crate) fn get_live_references(&self) -> Vec<Arc<LiveReferenceHandle<T>>> {
+        self.0
+            .active_set
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|(_, span)| span.upgrade())
+            .collect()
+    }
+}
+
+/// Wrapper around an object whose lifetime is tracked by `LiveReferenceSet`.
+/// Access to the object is possible via the `Deref` implementation.
+pub(crate) struct LiveReferenceHandle<T> {
+    value: T,
+    set_ref: Arc<LiveReferenceSetInner<T>>,
+    slot: usize,
+}
+
+impl<T> Drop for LiveReferenceHandle<T> {
+    fn drop(&mut self) {
+        self.set_ref.active_set.lock().unwrap().remove(self.slot);
+    }
+}
+
+impl<T> std::ops::Deref for LiveReferenceHandle<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for LiveReferenceHandle<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.value.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct NotifyOnDrop {
+        target: Arc<Mutex<Vec<usize>>>,
+        inner_val: usize,
+    }
+
+    impl Drop for NotifyOnDrop {
+        fn drop(&mut self) {
+            self.target.lock().unwrap().push(self.inner_val);
+        }
+    }
+
+    #[test]
+    fn test_live_references() {
+        let notify_vec = Arc::new(Mutex::new(vec![]));
+        let ref_set = Arc::new(LiveReferenceSet::default());
+
+        // Dropping a returned reference should immediately drop the inner object
+        drop(ref_set.track(NotifyOnDrop {
+            target: Arc::clone(&notify_vec),
+            inner_val: 1,
+        }));
+
+        assert_eq!(&*notify_vec.lock().unwrap(), &[1]);
+        assert_eq!(ref_set.get_live_references().len(), 0);
+
+        // Holding a reference should allow us to get it through the reference set
+        let r1 = ref_set.track(NotifyOnDrop {
+            target: Arc::clone(&notify_vec),
+            inner_val: 2,
+        });
+
+        assert_eq!(&*notify_vec.lock().unwrap(), &[1]);
+        assert_eq!(ref_set.get_live_references()[0].inner_val, 2);
+
+        // Holding a second reference...
+        let r2 = ref_set.track(NotifyOnDrop {
+            target: Arc::clone(&notify_vec),
+            inner_val: 3,
+        });
+
+        assert_eq!(&*notify_vec.lock().unwrap(), &[1]);
+        assert_eq!(ref_set.get_live_references()[0].inner_val, 2);
+        assert_eq!(ref_set.get_live_references()[1].inner_val, 3);
+
+        // then dropping the first
+        drop(r1);
+        assert_eq!(&*notify_vec.lock().unwrap(), &[1, 2]);
+        assert_eq!(ref_set.get_live_references()[0].inner_val, 3);
+
+        drop(r2);
+        assert_eq!(&*notify_vec.lock().unwrap(), &[1, 2, 3]);
+        assert_eq!(ref_set.get_live_references().len(), 0);
+    }
+}

--- a/foundations/src/telemetry/tracing/live/mod.rs
+++ b/foundations/src/telemetry/tracing/live/mod.rs
@@ -1,0 +1,34 @@
+mod event_output;
+mod live_reference_set;
+
+use cf_rustracing_jaeger::span::Span;
+use live_reference_set::{LiveReferenceHandle, LiveReferenceSet};
+use std::sync::Arc;
+use std::time::SystemTime;
+
+type SharedSpanInner = Arc<parking_lot::RwLock<Span>>;
+pub(crate) type SharedSpanHandle = Arc<LiveReferenceHandle<SharedSpanInner>>;
+
+pub(crate) struct ActiveRoots {
+    roots: Arc<LiveReferenceSet<SharedSpanInner>>,
+    start: SystemTime,
+}
+
+impl Default for ActiveRoots {
+    fn default() -> Self {
+        Self {
+            roots: Default::default(),
+            start: SystemTime::now(),
+        }
+    }
+}
+
+impl ActiveRoots {
+    pub(crate) fn get_active_traces(&self) -> String {
+        event_output::spans_to_trace_events(self.start, &self.roots.get_live_references())
+    }
+
+    pub(crate) fn track(&self, value: SharedSpanInner) -> SharedSpanHandle {
+        self.roots.track(value)
+    }
+}

--- a/foundations/src/telemetry/tracing/live/mod.rs
+++ b/foundations/src/telemetry/tracing/live/mod.rs
@@ -10,7 +10,7 @@ type SharedSpanInner = Arc<parking_lot::RwLock<Span>>;
 pub(crate) type SharedSpanHandle = Arc<LiveReferenceHandle<SharedSpanInner>>;
 
 pub(crate) struct ActiveRoots {
-    roots: Arc<LiveReferenceSet<SharedSpanInner>>,
+    roots: LiveReferenceSet<SharedSpanInner>,
     start: SystemTime,
 }
 

--- a/foundations/src/telemetry/tracing/mod.rs
+++ b/foundations/src/telemetry/tracing/mod.rs
@@ -387,7 +387,7 @@ pub fn start_trace(
 ///
 /// [rustracing]: https://crates.io/crates/rustracing
 pub fn rustracing_span() -> Option<Arc<parking_lot::RwLock<Span>>> {
-    current_span().map(|span| span.into_span())
+    current_span().map(|span| span.inner.into())
 }
 
 // NOTE: `#[doc(hidden)]` + `#[doc(inline)]` for `pub use` trick is used to prevent these macros

--- a/foundations/src/telemetry/tracing/mod.rs
+++ b/foundations/src/telemetry/tracing/mod.rs
@@ -7,6 +7,8 @@ pub(crate) mod init;
 #[cfg(any(test, feature = "testing"))]
 pub(crate) mod testing;
 
+#[cfg(feature = "telemetry-server")]
+mod live;
 mod output_jaeger_thrift_udp;
 mod rate_limit;
 
@@ -385,7 +387,7 @@ pub fn start_trace(
 ///
 /// [rustracing]: https://crates.io/crates/rustracing
 pub fn rustracing_span() -> Option<Arc<parking_lot::RwLock<Span>>> {
-    current_span().map(|span| span.inner)
+    current_span().map(|span| span.into_span())
 }
 
 // NOTE: `#[doc(hidden)]` + `#[doc(inline)]` for `pub use` trick is used to prevent these macros

--- a/foundations/src/telemetry/tracing/testing.rs
+++ b/foundations/src/telemetry/tracing/testing.rs
@@ -91,7 +91,7 @@ impl<'s> Iterator for TestTraceIterator<'s> {
     }
 }
 
-impl<'s> FusedIterator for TestTraceIterator<'s> {}
+impl FusedIterator for TestTraceIterator<'_> {}
 
 /// Trace span produced in the [test telemetry context].
 ///


### PR DESCRIPTION
Tracks currently-active spans in a low-overhead manner (relative to the general overhead of tracing, at least). This is particularly useful because even unsampled traces are available to be viewed here.

The model for this functionality is https://pkg.go.dev/golang.org/x/net/trace although there is no built-in viewer here, we expect you to use Chrome's about:tracing or anything that supports the same JSON log format.

This requires more functionality in our rustracing fork so we can get data set on the spans: https://github.com/cloudflare/rustracing/pull/4