### PR TITLE
More expressive error for EMSGSIZE from Jaeger reporter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ governor = "0.6"
 hyper = { version = "0.14", default-features = false }
 indexmap = "2.0.0"
 ipnetwork = "0.20"
+libc = "0.2"
 once_cell = "1.5"
 tonic = { version = "0.11.0", default-features = false }
 opentelemetry-proto = "0.5.0"

--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -122,6 +122,7 @@ tracing = [
     "dep:tokio",
     "dep:serde",
     "dep:slab",
+    "dep:libc",
 ]
 
 # Enables metrics functionality.
@@ -184,6 +185,7 @@ hyper = { workspace = true, optional = true, features = [
     "server",
 ] }
 indexmap = { workspace = true, optional = true, features = ["serde"] }
+libc = { workspace = true, optional = true }
 once_cell = { workspace = true, optional = true }
 opentelemetry-proto = { workspace = true, optional = true, features = ["gen-tonic-messages", "trace"] }
 parking_lot = { workspace = true, optional = true }


### PR DESCRIPTION
We observe around 22k `EMSGSIZE` errors per day in production and don't have any information to investigate further. By adding the span name as well as some tag and log information, we should be able to pin down which trace spans are excessively large and limit those in our code.

This error can only occur with the Jaeger UDP transport, since OTLP uses gRPC which doesn't limit message size.