### PR TITLE
Support configuring behaviour when excessive log nesting is reached

### DIFF
--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -40,6 +40,7 @@ platform-common-default = [
     "cli",
     "testing",
     "settings_deny_unknown_fields_by_default",
+    "panic_on_too_much_logger_nesting",
 ]
 
 # A subset of features that can be used both on server and client sides. Useful for libraries
@@ -156,6 +157,9 @@ cli = ["settings", "dep:clap"]
 
 # Enables testing-related functionality.
 testing = ["dep:foundations-macros"]
+
+# Enables panicking when too much nesting is reached on the logger
+panic_on_too_much_logger_nesting = []
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Previously, reaching too much log nesting caused foundations to panic. This allows disabling that behaviour and instead logging an error. It will only log when the threshold is passed, from then on it'll only ignore the nesting operation (i.e. the logger will remain unchanged).