### PR TITLE
ci: don't run semgrep so often

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,12 +1,7 @@
 on:
-  pull_request: {}
   workflow_dispatch: {}
-  push: 
-    branches:
-      - main
-      - master
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 6 * * *'
 name: Semgrep config
 jobs:
   semgrep:


### PR DESCRIPTION
the semgrep setup is slow and clogs up the runners queue. minimise the time that we're triggering the builds to once a day.