### PR TITLE
OXY-1516: support stderr as a log output target

### DIFF
--- a/foundations/src/telemetry/settings/logging.rs
+++ b/foundations/src/telemetry/settings/logging.rs
@@ -45,6 +45,8 @@ pub enum LogOutput {
     /// Write log to terminal.
     #[default]
     Terminal,
+    /// Write log to [`std::io::Stderr`].
+    Stderr,
     /// Write log to file with the specified path.
     ///
     /// File will be created if it doesn't exist and overwritten otherwise.


### PR DESCRIPTION
This commit adds support for writing logs to stderr. For non-daemonized processes, think CLIs or short-lived tests, its useful to have a separate output stream for our logs.