### PR TITLE
Report metrics format as openmetrics to allow exemplars

### DIFF
--- a/foundations/src/telemetry/server.rs
+++ b/foundations/src/telemetry/server.rs
@@ -74,7 +74,7 @@ impl RouteMap {
             handler: Box::new(|_, settings| {
                 async move {
                     into_response(
-                        "text/plain; version=0.0.4",
+                        "application/openmetrics-text; version=1.0.0; charset=utf-8",
                         metrics::collect(&settings.metrics),
                     )
                 }


### PR DESCRIPTION
This is what `prometheus_client` crate expects you to report.

See: https://github.com/prometheus/client_rust/blob/v0.18.1/examples/actix-web.rs#L40