### PR TITLE
Fix build on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,7 @@ jobs:
           - arm-android
           - aarch64-ios
           - x86_64-macos
+          - x86_64-windows
         include:
           - apt_packages: ""
           - custom_env: {}
@@ -268,6 +269,13 @@ jobs:
             target: x86_64-apple-darwin
             rust: stable
             os: macos-latest
+
+          - thing: x86_64-windows
+            build_only: true
+            target: x86_64-pc-windows-msvc
+            rust: stable
+            os: windows-latest
+            cargo_args: --no-default-features --features server-client-common-default
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Follow-up to 251d1936cf34ca04809f3cd31d82c3e0eb4c12ce. It looks like `File::from_raw_fd()` is not available on Windows, so work around it.

This also adds a CI build for Windows, though for now we can only enable a minimal set of features (like on Android and iOS) as jemalloc fails to build for example, among other things.