### PR TITLE
Re-export Hyper types used in public API

### DIFF
--- a/examples/http_server/main.rs
+++ b/examples/http_server/main.rs
@@ -15,12 +15,15 @@ use self::settings::{EndpointSettings, HttpServerSettings, ResponseSettings};
 use anyhow::anyhow;
 use foundations::cli::{Arg, ArgAction, Cli};
 use foundations::settings::collections::Map;
-use foundations::telemetry::{self, log, tracing, TelemetryConfig, TelemetryContext};
+use foundations::telemetry::{
+    self,
+    hyper::{Body, Request, Response},
+    log, tracing, TelemetryConfig, TelemetryContext,
+};
 use foundations::BootstrapResult;
 use futures_util::stream::{FuturesUnordered, StreamExt};
 use hyper::server::conn::Http;
 use hyper::service::service_fn;
-use hyper::{Body, Request, Response};
 use std::convert::Infallible;
 use std::net::{SocketAddr, TcpListener as StdTcpListener};
 use std::sync::Arc;

--- a/foundations/src/telemetry/mod.rs
+++ b/foundations/src/telemetry/mod.rs
@@ -119,6 +119,12 @@ pub use self::memory_profiler::MemoryProfiler;
 #[cfg(feature = "telemetry-server")]
 pub use self::server::{TelemetryRouteHandler, TelemetryRouteHandlerFuture, TelemetryServerRoute};
 
+#[cfg(feature = "telemetry-server")]
+/// Re-exported types from Hyper which are used in foundations public API
+pub mod hyper {
+    pub use hyper::{Body, Method, Request, Response};
+}
+
 pub use self::driver::TelemetryDriver;
 pub use self::telemetry_context::{
     TelemetryContext, WithTelemetryContext, WithTelemetryContextLocal,

--- a/foundations/src/telemetry/server.rs
+++ b/foundations/src/telemetry/server.rs
@@ -4,11 +4,12 @@ use super::settings::TelemetrySettings;
 #[cfg(feature = "tracing")]
 use super::tracing;
 use crate::BootstrapResult;
+use crate::telemetry::hyper::{Body, Method, Request, Response};
 use anyhow::Context as _;
 use futures_util::future::{BoxFuture, FutureExt};
 use hyper::server::conn::{AddrIncoming, AddrStream};
 use hyper::service::Service;
-use hyper::{header, Body, Method, Request, Response, Server, StatusCode};
+use hyper::{header, Server, StatusCode};
 use percent_encoding::percent_decode_str;
 use socket2::{Domain, SockAddr, Socket, Type};
 use std::collections::HashMap;

--- a/foundations/tests/telemetry_server.rs
+++ b/foundations/tests/telemetry_server.rs
@@ -1,9 +1,11 @@
 use foundations::telemetry::settings::{
     LivenessTrackingSettings, TelemetryServerSettings, TelemetrySettings, TracingSettings,
 };
-use foundations::telemetry::{TelemetryConfig, TelemetryContext, TelemetryServerRoute};
+use foundations::telemetry::{
+    hyper::{Method, Response},
+    TelemetryConfig, TelemetryContext, TelemetryServerRoute,
+};
 use futures_util::FutureExt;
-use hyper::{Method, Response};
 use std::net::{Ipv4Addr, SocketAddr};
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Foundations uses Hyper types in it's public API for `TelemetryServerRoute` which means any users will need to add an explicit dependency on the same version of hyper and ensure it stays matching. Re-exporting the types will allow users to explicitly use the same types as foundations is using.