### PR TITLE
feat: Add tracing-rs-compat feature with a tracing-rs compatible logging drain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,8 @@ tokio = "1.41.0"
 thread_local = "1.1"
 tikv-jemallocator = "0.5"
 tikv-jemalloc-ctl = "0.5"
+tracing-slog = "0.3.0"
+tracing-subscriber = "0.3"
 yaml-merge-keys = "0.5"
 
 # needed for minver

--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -163,6 +163,10 @@ testing = ["dep:foundations-macros"]
 # Enables panicking when too much nesting is reached on the logger
 panic_on_too_much_logger_nesting = []
 
+# Enables compatibility with `tracing-rs` by adding the ability to configure a
+# logging drain that forwards logs
+tracing-rs-compat = ["dep:tracing-slog"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs", "--cfg", "tokio_unstable", "--cfg", "foundations_unstable"]
@@ -204,6 +208,7 @@ slog-async = { workspace = true, optional = true }
 slog-json = { workspace = true, optional = true }
 slog-term = { workspace = true, optional = true }
 socket2 = { workspace = true, optional = true }
+tracing-slog = { workspace = true, optional = true }
 thread_local = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = ["sync", "rt"] }
 tonic = { workspace = true, optional = true, features = ["channel", "transport"] }
@@ -242,6 +247,7 @@ tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 ipnetwork = { workspace = true }
 nix = { workspace = true , features = ["fs"] }
+tracing-subscriber = { workspace = true }
 
 [build-dependencies]
 bindgen = { workspace = true, features = ["runtime"], optional = true }

--- a/foundations/src/telemetry/log/init.rs
+++ b/foundations/src/telemetry/log/init.rs
@@ -107,6 +107,10 @@ pub(crate) fn init(service_info: &ServiceInfo, settings: &LoggingSettings) -> Bo
             let drain = build_json_log_drain(buf);
             AsyncDrain::new(drain).chan_size(CHANNEL_SIZE).build()
         }
+        #[cfg(feature = "tracing-rs-compat")]
+        (LogOutput::TracingRsCompat, _) => AsyncDrain::new(tracing_slog::TracingSlogDrain {})
+            .chan_size(CHANNEL_SIZE)
+            .build(),
     };
 
     let root_drain = get_root_drain(settings, Arc::new(async_drain.fuse()));

--- a/foundations/src/telemetry/settings/logging.rs
+++ b/foundations/src/telemetry/settings/logging.rs
@@ -51,6 +51,13 @@ pub enum LogOutput {
     ///
     /// File will be created if it doesn't exist and overwritten otherwise.
     File(PathBuf),
+
+    ///Install a logging drain that forwards to `tracing-rs`
+    ///
+    ///WARN: If this output format is used, the settings in [`LoggingSettings`] other than the
+    ///verbosity will not be respected
+    #[cfg(feature = "tracing-rs-compat")]
+    TracingRsCompat,
 }
 
 /// Format of the log output.

--- a/foundations/src/telemetry/testing.rs
+++ b/foundations/src/telemetry/testing.rs
@@ -88,6 +88,18 @@ impl TestTelemetryContext {
         self.log_records = log_records;
     }
 
+    /// Overrides the logging settings on the test telemetry context with the tracing-rs compat
+    /// layer. The `logging_settings` provided must use the [tracing compat] output format
+    ///
+    /// [tracing compat]: super::settings::LogOutput::TracingRsCompat
+    #[cfg(all(feature = "logging", feature = "tracing-rs-compat"))]
+    pub fn set_tracing_rs_log_drain(&mut self, logging_settings: LoggingSettings) {
+        use crate::telemetry::log::testing::create_test_log_for_tracing_compat;
+        let (log, log_records) = { create_test_log_for_tracing_compat(&logging_settings) };
+        *self.inner.log.write() = log;
+        self.log_records = log_records;
+    }
+
     /// Overrides the tracing settings on the test telemetry context, creating a new test tracer
     /// with the settings
     #[cfg(feature = "tracing")]


### PR DESCRIPTION
Services and libraries that use `foundations` for logging must configure how the logs are output. This works well for services that want to forward logs to stdout / stderr for systemd but doesn't work as well for projects using libraries that use this `foundations` logging  as they may have their own complex logging machinery in place.

This PR adds a new feature, `tracing-rs-compat`, that enables the option to use [`tracing-slog`](https://crates.io/crates/tracing-slog) to install a `slog::Drain` that will forward any logs to the currently installed tracing subscriber. This makes it possible for any projects heavily invested in the [`tracing`](https://crates.io/crates/tracing) ecosystem to at least ingest the logs emitted using the logging macros in `foundations`.

Open to any feedback on the design here!