### PR TITLE
Remove default constraint from `Settings` trait

### DIFF
--- a/foundations/src/cli.rs
+++ b/foundations/src/cli.rs
@@ -37,7 +37,7 @@ pub struct Cli<S: Settings> {
     pub arg_matches: ArgMatches,
 }
 
-impl<S: Settings> Cli<S> {
+impl<S: Default + Settings> Cli<S> {
     /// Bootstraps a new command line interface (CLI) for the service.
     ///
     /// `custom_args` argument can be used to add extra service-specific arguments to the CLI.
@@ -116,7 +116,7 @@ fn get_arg_matches(
     })
 }
 
-fn get_settings<S: Settings>(arg_matches: &ArgMatches) -> BootstrapResult<S> {
+fn get_settings<S: Default + Settings>(arg_matches: &ArgMatches) -> BootstrapResult<S> {
     if let Some(path) = arg_matches.get_one::<String>(GENERATE_CONFIG_OPT_ID) {
         let settings = S::default();
 

--- a/foundations/src/settings/mod.rs
+++ b/foundations/src/settings/mod.rs
@@ -341,7 +341,7 @@ pub use foundations_macros::settings;
 /// [`settings`] macro.
 ///
 /// [`settings`]: crate::settings::settings
-pub trait Settings: Default + Clone + Serialize + DeserializeOwned + Debug + 'static {
+pub trait Settings: Clone + Serialize + DeserializeOwned + Debug + 'static {
     /// Add Rust doc comments for the settings fields.
     ///
     /// Docs for each field need to be added to the provided hashmap with the key consisting of the


### PR DESCRIPTION
This required that fields of structs that derive `Settings` implement `Default`, even if a default implementation of the field was provided.

This occurred in particular when trying to use a `NonZero` type within a settings struct:

```rust
pub struct MySettings {
    #[serde(default = "MySettings::default_my_field")]
    pub my_field: NonZeroUsize,
}

impl MySettings {
    fn default_my_field() -> NonZeroUsize {
        return NonZeroUsize::new(1).unwrap()
    }
}
```

Instead, this change moves the `Default` constraint to only where the `Settings` is used with a `Cli`.