### PR TITLE
ZTC-2169: Allow use of memory-profiling feature with no other features

### DIFF
--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -145,6 +145,7 @@ memory-profiling = [
     "dep:tikv-jemalloc-ctl",
     "dep:tempfile",
     "dep:tokio",
+    "dep:serde",
     "jemalloc",
 ]
 

--- a/foundations/src/lib.rs
+++ b/foundations/src/lib.rs
@@ -76,7 +76,8 @@ pub mod settings;
     feature = "logging",
     feature = "metrics",
     feature = "telemetry",
-    feature = "tracing"
+    feature = "tracing",
+    feature = "memory-profiling",
 ))]
 pub mod telemetry;
 


### PR DESCRIPTION
For our service, we only want to use the `memory-profiling` feature, but not the other telemetry-related features. However, currently, the `telemetry` module is not compiled if `memory-profiling` is enabled but none of the others are.

This updates the conditional compilation so that, using only the `memory-profiling` feature, the `MemoryProfiler` can be accessed.