### PR TITLE
Resolve Clippy lints from Rust 1.86 and 1.87

### DIFF
--- a/foundations/src/telemetry/log/internal.rs
+++ b/foundations/src/telemetry/log/internal.rs
@@ -65,7 +65,7 @@ impl LoggerWithKvNestingTracking {
                     None // avoid further nesting
                 }
             }
-            Self::MAX_NESTING..=u32::MAX => None, // avoid further nesting
+            _ => None, // avoid further nesting
         }
     }
 }

--- a/foundations/src/telemetry/log/retry_writer.rs
+++ b/foundations/src/telemetry/log/retry_writer.rs
@@ -60,10 +60,7 @@ impl Write for RetryPipeWriter {
             }
             attempts += 1;
         }
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            "retry attempts exhausted",
-        ))
+        Err(io::Error::other("retry attempts exhausted"))
     }
 
     /// Flushes the file. On *nix this does nothing.


### PR DESCRIPTION
These lints are currently causing CI on PRs (like https://github.com/cloudflare/foundations/pull/121) to fail