### PR TITLE
Add compile-time validation for histogram buckets in foundations-macros

### DIFF
--- a/foundations-macros/src/metrics/validation.rs
+++ b/foundations-macros/src/metrics/validation.rs
@@ -1,0 +1,62 @@
+use syn::{Error, Expr, ExprLit, ExprStruct, Lit, Member, Result};
+
+/// Validates that histogram bucket values are strictly increasing.
+/// Returns an error if the buckets are not valid.
+pub fn validate_histogram_buckets(expr: &ExprStruct) -> Result<()> {
+    // Extract the buckets field from the HistogramBuilder struct
+    let buckets_field = expr
+        .fields
+        .iter()
+        .find(|field| {
+            if let Member::Named(ident) = &field.member {
+                ident == "buckets"
+            } else {
+                false
+            }
+        })
+        .ok_or_else(|| Error::new_spanned(expr, "HistogramBuilder must have a 'buckets' field"))?;
+
+    // Extract the array expression from the buckets field
+    let array_expr = match &buckets_field.expr {
+        Expr::Reference(ref_expr) => match &*ref_expr.expr {
+            Expr::Array(array) => array,
+            // For non-array literals (like variables or function calls), skip validation
+            _ => return Ok(()),
+        },
+        // For non-reference expressions, skip validation
+        _ => return Ok(()),
+    };
+
+    // Extract the f64 values from the array
+    let mut values = Vec::new();
+    for elem in &array_expr.elems {
+        if let Expr::Lit(ExprLit {
+            lit: Lit::Float(lit_float),
+            ..
+        }) = elem
+        {
+            let value = lit_float.base10_parse::<f64>()?;
+            values.push((value, lit_float.span()));
+        } else {
+            // For non-float literals (like variables or expressions), skip validation
+            return Ok(());
+        }
+    }
+
+    // Check if the buckets are strictly increasing
+    if !values.is_empty() {
+        let mut prev_value = values[0].0;
+        for (i, (value, span)) in values.iter().enumerate().skip(1) {
+            if *value <= prev_value {
+                let message = format!(
+                    "Histogram buckets must be strictly increasing. Found invalid bucket at position {}: {} <= {}",
+                    i, value, prev_value
+                );
+                return Err(Error::new(*span, message));
+            }
+            prev_value = *value;
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
I recently had a bug in a service using foundations where the buckets in my histogram were not in ascending order because of a typo. Instead of this being detected and handled in any way, I just had a broken metric.

This change adds compile time checks when using the metrics proc macro to, if the buckets are provided directly, check the ordering. It doesn't check if they're passed from a variable or function or any other method, and I think the only way to do that would be runtime validation - the binary would consistently fail to start immediately, but have kept this constrained to a compile-time check for now to get thoughts/feedback.