### PR TITLE
Ignore itertools in minimal-versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
           cargo hack --remove-dev-deps --workspace
           # Update Cargo.lock to minimal version dependencies.
           cargo update -Z minimal-versions
+          cargo update -p itertools # 0.10 is broken
           cargo hack check --all-features --ignore-private
       - name: Check minimal versions with unstable features
         env:
@@ -83,6 +84,7 @@ jobs:
           cargo hack --remove-dev-deps --workspace
           # Update Cargo.lock to minimal version dependencies.
           cargo update -Z minimal-versions
+          cargo update -p itertools # 0.10 is broken
           cargo hack check --all-features --ignore-private
 
   deny:


### PR DESCRIPTION
prost-derive allows an old version that contains a no-longer-allowed syntax.