### PR TITLE
telemetry: remove Box::pin from WithTelemetryContext

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ once_cell = "1.5"
 tonic = { version = "0.13", default-features = false }
 opentelemetry-proto = "0.30"
 parking_lot = "0.12"
+pin-project-lite = "0.2.16"
 proc-macro2 = { version = "1", default-features = false }
 prometheus = { version = "0.14", default-features = false }
 prometheus-client = "0.18"

--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -175,10 +175,10 @@ tracing-rs-compat = ["dep:tracing-slog"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs", "--cfg", "tokio_unstable", "--cfg", "foundations_unstable"]
+rustdoc-args = ["--cfg", "docsrs", "--cfg", "tokio_unstable", "--cfg", "foundations_unstable", "--cfg", "foundations_generic_telemetry_wrapper"]
 # it's necessary to _also_ pass `--cfg tokio_unstable` and `--cfg foundations_unstable`
 # to rustc, or else dependencies will not be enabled, and the docs build will fail.
-rustc-args = ["--cfg", "tokio_unstable", "--cfg", "foundations_unstable"]
+rustc-args = ["--cfg", "tokio_unstable", "--cfg", "foundations_unstable", "--cfg", "foundations_generic_telemetry_wrapper"]
 
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace", "std"] }
@@ -235,6 +235,7 @@ parking_lot_core = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
 tower = { workspace = true, optional = true }
+pin-project-lite = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tikv-jemalloc-ctl = { workspace = true, optional = true, features = [

--- a/foundations/src/lib.rs
+++ b/foundations/src/lib.rs
@@ -43,6 +43,13 @@
 //! - **cli**: Enables command line interface (CLI) functionality. Implicitly enabled **settings**
 //!   feature.
 //!
+//! # Generic telemetry
+//! Foundations currently box the future with TelemetryContext by default. A default generic
+//! wrapper is gated behind `--cfg foundations_generic_telemetry_wrapper`.
+//!
+//! To enable this, you must add `--cfg foundations_generic_telemetry_wrapper` to your RUSTFLAGS
+//! environment variable.
+//!
 //! # Unstable Features
 //! Foundations has unstable features which are gated behind `--cfg foundations_unstable`:
 //!


### PR DESCRIPTION
In async heavy code, Box::pin contributes a large percentage of allocation time. We can switch to pin_project to remove Box::pin usage here.

This allows user to skip the boxing step and save a memory allocation.
This is configure with `generic=true` in attribute. For example

```
 #[span_fn("async_trait_span", generic = true)]
```