### PR TITLE
Add dep:tokio to feature telemetry-server

### DIFF
--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -83,6 +83,7 @@ telemetry-server = [
     "dep:socket2",
     "dep:percent-encoding",
     "dep:serde",
+    "dep:tokio",
 ]
 
 # Enables telemetry reporting over gRPC


### PR DESCRIPTION
`telemetry/server/*.rs` use tokio but this dependency wasn't declared.

This is a breaking change between v4 -> v5