### PR TITLE
Enable usage of telemetry-server on its own

### DIFF
--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -83,7 +83,7 @@ telemetry-server = [
     "dep:socket2",
     "dep:percent-encoding",
     "dep:serde",
-    "dep:tokio",
+    "tokio/net",
 ]
 
 # Enables telemetry reporting over gRPC


### PR DESCRIPTION
When enabling the telemetry-server feature with no or few other features, the server may not be enabled correctly, or may fail to compile in the case where your crate doesn't need/enable the "net" feature in tokio.