### PR TITLE
Fix telemetry meta-features and telemetry-server build

### DIFF
--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -69,14 +69,14 @@ telemetry = [
     "telemetry-server",
     "client-telemetry",
     "telemetry-otlp-grpc",
-    "dep:futures-util",
 ]
 
 # Enables a subset of telemetry features suitable for usage in clients.
-client-telemetry = ["logging", "metrics", "tracing", "dep:futures-util"]
+client-telemetry = ["logging", "metrics", "tracing"]
 
 # Enables the telemetry server.
 telemetry-server = [
+    "logging",
     "dep:http-body-util",
     "dep:hyper",
     "dep:hyper-util",
@@ -84,10 +84,12 @@ telemetry-server = [
     "dep:percent-encoding",
     "dep:serde",
     "dep:tokio",
+    "tokio/net",
+    "dep:futures-util",
 ]
 
 # Enables telemetry reporting over gRPC
-telemetry-otlp-grpc = ["dep:tonic", "tonic/prost", "dep:tokio", "dep:hyper"]
+telemetry-otlp-grpc = ["dep:tonic", "tonic/prost", "dep:tokio", "tokio/net", "dep:hyper"]
 
 # Enables experimental tokio runtime metrics
 tokio-runtime-metrics = [

--- a/foundations/src/lib.rs
+++ b/foundations/src/lib.rs
@@ -77,9 +77,9 @@ pub mod settings;
 #[cfg(any(
     feature = "logging",
     feature = "metrics",
-    feature = "telemetry",
     feature = "tracing",
     feature = "memory-profiling",
+    feature = "telemetry-server",
 ))]
 pub mod telemetry;
 

--- a/foundations/src/telemetry/server/mod.rs
+++ b/foundations/src/telemetry/server/mod.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "metrics")]
-use super::metrics;
 use super::settings::TelemetrySettings;
 use crate::addr::ListenAddr;
 use crate::telemetry::log;

--- a/foundations/src/telemetry/server/router.rs
+++ b/foundations/src/telemetry/server/router.rs
@@ -1,7 +1,7 @@
 #[cfg(all(target_os = "linux", feature = "memory-profiling"))]
 use super::memory_profiling;
 #[cfg(feature = "metrics")]
-use super::metrics;
+use crate::telemetry::metrics;
 use crate::telemetry::settings::TelemetrySettings;
 #[cfg(feature = "tracing")]
 use crate::telemetry::tracing;


### PR DESCRIPTION
- `telemetry` and `client-telemetry` should only enable other features
- `telmetry-server` by itself should cause the telemetry server to be built. This requires enabling `mod telemetry`.
- Add missing dependencies to `telemetry-server` and `telemetry-otlp-grpc` features.