### PR TITLE
Fix regression that causes unconditional rebuilds

### DIFF
--- a/foundations/build.rs
+++ b/foundations/build.rs
@@ -175,7 +175,9 @@ mod security {
             .allowlist_var("PR_GET_SECCOMP")
             .allowlist_var("PR_SET_NAME")
             .derive_default(true)
-            .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+            .parse_callbacks(Box::new(
+                bindgen::CargoCallbacks::new().rerun_on_header_files(false),
+            ))
             .generate()
             .unwrap()
             .write_to_file(out_dir.join("security_sys.rs"))


### PR DESCRIPTION
561158b changed build.rs to use CargoCallbacks with the option to issue rerun directive for input headers set to true. This causes a unconditional rebuilds of the crate because one of the input headers (seccomp.h) is generated in build.rs.

This changes the option back to false to fix the rebuilds.