### PR TITLE
Remove doc_auto_cfg to clear errors on nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
         run: |
           cargo doc --lib --no-deps --all-features --document-private-items
         env:
-          RUSTDOCFLAGS: --cfg docsrs -Dwarnings --cfg tokio_unstable --cfg foundations_unstable
-          RUSTFLAGS: --cfg docsrs -Dwarnings --cfg tokio_unstable --cfg foundations_unstable
+          RUSTDOCFLAGS: --cfg foundations_docsrs -Dwarnings --cfg tokio_unstable --cfg foundations_unstable
+          RUSTFLAGS: --cfg foundations_docsrs -Dwarnings --cfg tokio_unstable --cfg foundations_unstable
 
   # based on tokio minver cbecm
   minimal-versions:

--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -177,7 +177,7 @@ tracing-rs-compat = ["dep:tracing-slog"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs", "--cfg", "tokio_unstable", "--cfg", "foundations_unstable", "--cfg", "foundations_generic_telemetry_wrapper"]
+rustdoc-args = ["--cfg", "foundations_docsrs", "--cfg", "tokio_unstable", "--cfg", "foundations_unstable", "--cfg", "foundations_generic_telemetry_wrapper"]
 # it's necessary to _also_ pass `--cfg tokio_unstable` and `--cfg foundations_unstable`
 # to rustc, or else dependencies will not be enabled, and the docs build will fail.
 rustc-args = ["--cfg", "tokio_unstable", "--cfg", "foundations_unstable", "--cfg", "foundations_generic_telemetry_wrapper"]

--- a/foundations/src/lib.rs
+++ b/foundations/src/lib.rs
@@ -68,7 +68,7 @@
 // NOTE: required to allow cfgs like `tokio_unstable` on nightly which is used in tests.
 #![allow(unexpected_cfgs)]
 #![warn(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(foundations_docsrs, feature(doc_cfg))]
 
 mod utils;
 

--- a/foundations/src/lib.rs
+++ b/foundations/src/lib.rs
@@ -68,7 +68,6 @@
 // NOTE: required to allow cfgs like `tokio_unstable` on nightly which is used in tests.
 #![allow(unexpected_cfgs)]
 #![warn(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod utils;

--- a/foundations/src/telemetry/mod.rs
+++ b/foundations/src/telemetry/mod.rs
@@ -81,7 +81,7 @@ pub mod settings;
     foundations_unstable
 ))]
 #[cfg_attr(
-    docsrs,
+    foundations_docsrs,
     doc(cfg(all(
         feature = "tokio-runtime-metrics",
         tokio_unstable,


### PR DESCRIPTION
```
error[E0557]: feature has been removed
  --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/socket2-0.6.0/src/lib.rs:57:29
   |
57 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
   |                             ^^^^^^^^^^^^ feature has been removed
   |
   = note: removed in CURRENT_RUSTC_VERSION; see <https://github.com/rust-lang/rust/pull/138907> for more information
   = note: merged into `doc_cfg`
```