### PR TITLE
Release 5.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.0.2"
+version = "5.1.0"
 repository = "https://github.com/cloudflare/foundations"
 edition = "2021"
 authors = ["Cloudflare"]
@@ -25,8 +25,8 @@ debug = 1
 
 [workspace.dependencies]
 anyhow = "1.0.75"
-foundations = { version = "5.0.2", path = "./foundations" }
-foundations-macros = { version = "5.0.2", path = "./foundations-macros", default-features = false }
+foundations = { version = "5.1.0", path = "./foundations" }
+foundations-macros = { version = "5.1.0", path = "./foundations-macros", default-features = false }
 bindgen = { version = "0.72", default-features = false }
 cc = "1.0"
 cf-rustracing = "1.2"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 
+5.1.0
+- 2025-09-30 Add a new SharedSpanHandle::Inactive variant
+- 2025-09-18 Add set_span_finish_callback macro to telemetry::tracing
+- 2025-09-30 Work around broken --cfg docsrs in other crates
+- 2025-09-30 Remove doc_auto_cfg to clear errors on nightly
+- 2025-09-24 Fix rerun directive issuance for build inputs
+
 5.0.2
+- 2025-09-24 Release 5.0.2
 - 2025-09-23 Fix regression that causes unconditional rebuilds
 
 5.0.1


### PR DESCRIPTION
# New Features
- The `set_span_finish_callback!` macro allows associating a callback with a span. The callback runs when the span is dropped. Children inherit their parent span's callback on creation, but it can be removed explicitly with `set_span_finish_callback!(None);`. This is intended to simplify the addition of common tags to a whole tree of spans. (#140)

# Improvements
- Spans that are neither sampled nor subject to liveness tracking are replaced by a sentinel value. For production services, these constitute the _vast_ majority of spans. The creation of such spans does not allocate anymore, which is expected to reduce tracing overhead significantly. (#144)
- foundations now properly recompiles if its `seccomp.h` template changed. (#143)