### PR TITLE
Bump tonic to v0.14 and opentelemetry to v0.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ darling = "0.21"
 erased-serde = "0.4"
 futures-util = "0.3"
 governor = "0.6"
-http = "1"
+http = "1.1.0"
 http-body-util = "0.1"
 hyper = { version = "1", default-features = false }
 hyper-util = { version = "0.1", default-features = false }
@@ -44,8 +44,9 @@ indexmap = "2.0"
 ipnetwork = { version = "0.21", features = ["serde"] }
 libc = "0.2"
 once_cell = "1.5"
-tonic = { version = "0.13", default-features = false }
-opentelemetry-proto = "0.30"
+tonic = { version = "0.14", default-features = false }
+tonic-prost = { version = "0.14" }
+opentelemetry-proto = "0.31"
 parking_lot = "0.12"
 pin-project-lite = "0.2.16"
 proc-macro2 = { version = "1", default-features = false }

--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -89,7 +89,7 @@ telemetry-server = [
 ]
 
 # Enables telemetry reporting over gRPC
-telemetry-otlp-grpc = ["dep:tonic", "tonic/prost", "dep:tokio", "tokio/net", "dep:hyper"]
+telemetry-otlp-grpc = ["dep:tonic", "dep:tonic-prost", "dep:tokio", "tokio/net", "dep:hyper"]
 
 # Enables experimental tokio runtime metrics
 tokio-runtime-metrics = [
@@ -219,6 +219,7 @@ tracing-slog = { workspace = true, optional = true }
 thread_local = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = ["sync", "rt", "macros"] }
 tonic = { workspace = true, optional = true, features = ["channel"] }
+tonic-prost = { workspace = true, optional = true }
 tikv-jemallocator = { workspace = true, optional = true, features = [
     "profiling",
     "stats",

--- a/foundations/src/telemetry/tracing/output_otlp_grpc.rs
+++ b/foundations/src/telemetry/tracing/output_otlp_grpc.rs
@@ -12,9 +12,9 @@ use opentelemetry_proto::tonic::collector::trace::v1::{
 use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
 use std::time::Duration;
 use tonic::client::Grpc;
-use tonic::codec::ProstCodec;
 use tonic::transport::Channel;
 use tonic::{GrpcMethod, Request};
+use tonic_prost::ProstCodec;
 
 static COLLECTOR_PATH: &str = "/opentelemetry.proto.collector.trace.v1.TraceService/Export";
 static TRACE_SERVICE: &str = "opentelemetry.proto.collector.trace.v1.TraceService";


### PR DESCRIPTION
This lets us deduplicate dependencies downstream.