### PR TITLE
Cleanup tags when OTLP sink is used

### DIFF
--- a/foundations/src/telemetry/otlp_conversion/common.rs
+++ b/foundations/src/telemetry/otlp_conversion/common.rs
@@ -2,20 +2,10 @@ use crate::ServiceInfo;
 use opentelemetry_proto::tonic as otlp;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-pub(super) fn convert_service_info_to_instrumentation_scope(
-    service_info: &ServiceInfo,
-) -> otlp::common::v1::InstrumentationScope {
-    otlp::common::v1::InstrumentationScope {
-        name: service_info.name.to_string(),
-        version: service_info.version.to_string(),
-        ..Default::default()
-    }
-}
-
 pub(super) fn convert_service_info_to_resource(
     service_info: &ServiceInfo,
 ) -> otlp::resource::v1::Resource {
-    let service_name_attr = otlp::common::v1::KeyValue {
+    let service_name = otlp::common::v1::KeyValue {
         key: "service.name".to_string(),
         value: Some(otlp::common::v1::AnyValue {
             value: Some(otlp::common::v1::any_value::Value::StringValue(
@@ -24,8 +14,17 @@ pub(super) fn convert_service_info_to_resource(
         }),
     };
 
+    let service_version = otlp::common::v1::KeyValue {
+        key: "service.version".to_string(),
+        value: Some(otlp::common::v1::AnyValue {
+            value: Some(otlp::common::v1::any_value::Value::StringValue(
+                service_info.version.to_string(),
+            )),
+        }),
+    };
+
     otlp::resource::v1::Resource {
-        attributes: vec![service_name_attr],
+        attributes: vec![service_name, service_version],
         dropped_attributes_count: 0,
         entity_refs: vec![],
     }


### PR DESCRIPTION
* Remove `otel.status` if it's just "OK" as it is not really helpful.
* Remove `otel.scope.name` as it just mirrors service name as a tag.
* Replace `otel.scope.version` with a process level `service.version`, which is more a appropriate and a stable version.