### PR TITLE
Add `unprefixed` flag to `#[metrics]` macro

### DIFF
--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -54,6 +54,9 @@ pub fn collect(settings: &MetricsSettings) -> Result<String> {
 /// name becomes `<global prefix>_<module name>_<bodyless function name>`and function's
 /// Rust doc comment is reported as metric description to Prometheus.
 ///
+/// The `<global_prefix>` can be disabled by passing the `unprefixed` flag to the macro
+/// invocation, like `#[metrics(unprefixed)]`. The module name is a mandatory prefix.
+///
 /// # Labels
 /// Arguments of the bodyless functions become labels for that metric.
 ///
@@ -84,7 +87,6 @@ pub fn collect(settings: &MetricsSettings) -> Result<String> {
 /// Metrics marked with `#[optional]` are collected in a separate registry and reported only if
 /// `collect_optional` argument of [`collect`] is set to `true`, or, in case the [telemetry server]
 /// is used, if [`MetricsSettings::report_optional`] is set to `true`.
-///
 ///
 /// Can be used for heavy-weight metrics (e.g. with high cardinality) that don't need to be reported
 /// on a regular basis.

--- a/foundations/tests/metrics.rs
+++ b/foundations/tests/metrics.rs
@@ -1,0 +1,36 @@
+use foundations::telemetry::metrics::{self, metrics, Counter};
+use foundations::telemetry::settings::{MetricsSettings, ServiceNameFormat};
+
+#[metrics]
+mod regular {
+    pub fn requests() -> Counter;
+    #[optional]
+    pub fn optional() -> Counter;
+}
+
+#[metrics(unprefixed)]
+mod library {
+    pub fn calls() -> Counter;
+    #[optional]
+    pub fn optional() -> Counter;
+}
+
+#[test]
+fn metrics_unprefixed() {
+    regular::requests().inc();
+    regular::optional().inc();
+    library::calls().inc();
+    library::optional().inc();
+
+    let settings = MetricsSettings {
+        service_name_format: ServiceNameFormat::MetricPrefix,
+        report_optional: false,
+    };
+    let metrics = metrics::collect(&settings).expect("metrics should be collectable");
+
+    // Global prefix defaults to "undefined" if not initialized
+    assert!(metrics.contains("\nundefined_regular_requests 1\n"));
+    assert!(!metrics.contains("\nundefined_regular_optional"));
+    assert!(metrics.contains("\nlibrary_calls 1\n"));
+    assert!(!metrics.contains("\nlibrary_optional"));
+}


### PR DESCRIPTION
This change is twofold. First, it refactors the registry selection in `metrics::internal::Registries` to use boolean flags rather than separate methods to select a registry to use. As part of this, we add a combination of flags to return a registry without the global service name prefix that is normally present.

Second, we add a new `unprefixed` argument to the `metrics` proc-macro. If present, this argument causes all metrics in the associated module to be registered in the registry mentioned above. This works for both the "main" and the "optional" registry.

I've added both a proc-macro expansion test and an integration test to validate the flag's functionality.