### PR TITLE
Fix new instance of `clippy::derivable_impls`

### DIFF
--- a/foundations/tests/settings.rs
+++ b/foundations/tests/settings.rs
@@ -128,6 +128,7 @@ enum NoDefaultEnum {
     Variant2,
 }
 
+#[expect(clippy::derivable_impls, reason = "explicit impl for testing")]
 impl Default for NoDefaultEnum {
     fn default() -> Self {
         Self::Variant2


### PR DESCRIPTION
The test explicitly avoids deriving `Default` to make it clear that it's not generated by a macro.