### PR TITLE
Release 5.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.2.0"
+version = "5.3.0"
 repository = "https://github.com/cloudflare/foundations"
 edition = "2021"
 authors = ["Cloudflare"]
@@ -25,8 +25,8 @@ debug = 1
 
 [workspace.dependencies]
 anyhow = "1.0.75"
-foundations = { version = "5.2.0", path = "./foundations" }
-foundations-macros = { version = "5.2.0", path = "./foundations-macros", default-features = false }
+foundations = { version = "5.3.0", path = "./foundations" }
+foundations-macros = { version = "=5.3.0", path = "./foundations-macros", default-features = false }
 bindgen = { version = "0.72", default-features = false }
 cc = "1.0"
 cf-rustracing = "1.2.1"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 
+5.3.0
+- 2025-11-06 Add `unprefixed` flag to `#[metrics]` macro
+- 2025-11-07 Fix new instance of `clippy::derivable_impls`
+
 5.2.0
+- 2025-10-29 Release 5.2.0
 - 2025-10-28 Cleanup tags when OTLP sink is used
 - 2025-10-28 Don't use `[!Default; 0]: Default` impl (#150)
 


### PR DESCRIPTION
From now on, pin the `foundations-macros` version to the exact same version as `foundations`. The macros crate is an internal detail that is only exposed because of proc-macro separation.