### PR TITLE
Add #[with_removal] attribute to #[metrics] macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,18 @@ publish = false
 [profile.release]
 debug = 1
 
+[workspace.lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(foundations_generic_telemetry_wrapper)',
+    'cfg(foundations_unstable)',
+    'cfg(tokio_unstable)',
+    # for docs.rs builds only
+    'cfg(foundations_docsrs)',
+    # slog feature
+    'cfg(integer128)',
+]
+
 [workspace.dependencies]
 anyhow = "1.0.75"
 foundations = { version = "5.3.0", path = "./foundations" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ pin-project-lite = "0.2.16"
 proc-macro2 = { version = "1", default-features = false }
 prometheus = { version = "0.14", default-features = false }
 prometheus-client = "0.18"
-prometools = "0.2.2"
+prometools = "0.2.3"
 rand = "0.9"
 percent-encoding = "2.3"
 quote = "1"

--- a/foundations-macros/Cargo.toml
+++ b/foundations-macros/Cargo.toml
@@ -15,6 +15,9 @@ settings_deny_unknown_fields_by_default = []
 [lib]
 proc-macro = true
 
+[lints]
+workspace = true
+
 [dependencies]
 darling = { workspace = true }
 proc-macro2 = { workspace = true }

--- a/foundations-macros/src/span_fn.rs
+++ b/foundations-macros/src/span_fn.rs
@@ -1,6 +1,3 @@
-// NOTE: required to allow `foundations_generic_telemetry_wrapper` cfg
-#![allow(unexpected_cfgs)]
-
 use crate::common::parse_optional_trailing_meta_list;
 use darling::FromMeta;
 use proc_macro::TokenStream;

--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -181,6 +181,9 @@ rustdoc-args = ["--cfg", "foundations_docsrs", "--cfg", "tokio_unstable", "--cfg
 # to rustc, or else dependencies will not be enabled, and the docs build will fail.
 rustc-args = ["--cfg", "tokio_unstable", "--cfg", "foundations_unstable", "--cfg", "foundations_generic_telemetry_wrapper"]
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace", "std"] }
 foundations-macros = { workspace = true, optional = true, default-features = false }

--- a/foundations/src/lib.rs
+++ b/foundations/src/lib.rs
@@ -64,9 +64,6 @@
 //! [OpenTelemetry]: https://opentelemetry.io/
 //! [gRPC]: https://grpc.io/
 //! [`settings`]: crate::settings::Settings
-
-// NOTE: required to allow cfgs like `tokio_unstable` on nightly which is used in tests.
-#![allow(unexpected_cfgs)]
 #![warn(missing_docs)]
 #![cfg_attr(foundations_docsrs, feature(doc_cfg))]
 

--- a/foundations/tests/metrics.rs
+++ b/foundations/tests/metrics.rs
@@ -6,6 +6,9 @@ mod regular {
     pub fn requests() -> Counter;
     #[optional]
     pub fn optional() -> Counter;
+    #[cfg(foundations_unstable)]
+    #[with_removal]
+    pub fn dynamic(label: &'static str) -> Counter;
 }
 
 #[metrics(unprefixed)]
@@ -22,6 +25,16 @@ fn metrics_unprefixed() {
     library::calls().inc();
     library::optional().inc();
 
+    #[cfg(foundations_unstable)]
+    {
+        regular::dynamic("foo").inc();
+        regular::dynamic("bar").inc();
+
+        assert!(regular::dynamic_remove("foo"));
+        assert!(!regular::dynamic_remove("baz"));
+        regular::dynamic_clear();
+    }
+
     let settings = MetricsSettings {
         service_name_format: ServiceNameFormat::MetricPrefix,
         report_optional: false,
@@ -31,6 +44,7 @@ fn metrics_unprefixed() {
     // Global prefix defaults to "undefined" if not initialized
     assert!(metrics.contains("\nundefined_regular_requests 1\n"));
     assert!(!metrics.contains("\nundefined_regular_optional"));
+    assert!(!metrics.contains("\nundefined_regular_dynamic"));
     assert!(metrics.contains("\nlibrary_calls 1\n"));
     assert!(!metrics.contains("\nlibrary_optional"));
 }


### PR DESCRIPTION
`#[with_removal]` generates two additional functions that allow to
remove individual label sets from a metric family as well as clear the
family completely. This is useful when metrics are used for dynamic
data, such as peer RTT in a P2P system.

The feature is hidden behind `cfg(foundations_unstable)`, which allows
us to iterate on the API in the future. Both proc-macro unit tests as
well as an integration test are included in the change.

Tests on this PR will fail until nox/prometools#6 is merged and released, which
exposes the necessary `Family` APIs to implement this feature.