### PR TITLE
Improve performance of inactive tracing spans

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ cc = "1.0"
 cf-rustracing = "1.2.1"
 cf-rustracing-jaeger = "1.2.2"
 clap = "4.4"
+crossbeam-utils = { version = "0.8", default-features = false }
 darling = "0.21"
 erased-serde = "0.4"
 futures-util = "0.3"

--- a/foundations-macros/src/metrics/mod.rs
+++ b/foundations-macros/src/metrics/mod.rs
@@ -103,8 +103,6 @@ fn expand_from_parsed(args: MacroArgs, extern_: Mod) -> proc_macro2::TokenStream
         fns,
     } = extern_;
 
-    let reexports = quote! { #foundations::reexports_for_macros };
-
     // This should be using `Span::def_site` but it is currently unstable.
     let metrics_struct = Ident::new(&format!("__{mod_name}_Metrics"), Span::call_site());
 
@@ -152,8 +150,8 @@ fn expand_from_parsed(args: MacroArgs, extern_: Mod) -> proc_macro2::TokenStream
             #(#label_set_structs)*
 
             #[allow(non_upper_case_globals)]
-            static #metrics_struct: #reexports::once_cell::sync::Lazy<#metrics_struct> =
-                #reexports::once_cell::sync::Lazy::new(|| {
+            static #metrics_struct: ::std::sync::LazyLock<#metrics_struct> =
+                ::std::sync::LazyLock::new(|| {
                     #init_registry
                     #init_opt_registry
 
@@ -424,8 +422,8 @@ mod tests {
                 struct __empty_Metrics {}
 
                 #[allow(non_upper_case_globals)]
-                static __empty_Metrics: ::foundations::reexports_for_macros::once_cell::sync::Lazy<__empty_Metrics> =
-                    ::foundations::reexports_for_macros::once_cell::sync::Lazy::new(|| { __empty_Metrics {} });
+                static __empty_Metrics: ::std::sync::LazyLock<__empty_Metrics> =
+                    ::std::sync::LazyLock::new(|| { __empty_Metrics {} });
             }
         };
 
@@ -459,8 +457,8 @@ mod tests {
                 }
 
                 #[allow(non_upper_case_globals)]
-                static __oxy_Metrics: tarmac::reexports_for_macros::once_cell::sync::Lazy<__oxy_Metrics> =
-                    tarmac::reexports_for_macros::once_cell::sync::Lazy::new(|| {
+                static __oxy_Metrics: ::std::sync::LazyLock<__oxy_Metrics> =
+                    ::std::sync::LazyLock::new(|| {
                         let registry = &mut *tarmac::telemetry::metrics::internal::Registries::get_subsystem(stringify!(oxy), false, true);
 
                         __oxy_Metrics {
@@ -516,8 +514,8 @@ mod tests {
                 }
 
                 #[allow(non_upper_case_globals)]
-                static __oxy_Metrics: ::foundations::reexports_for_macros::once_cell::sync::Lazy<__oxy_Metrics> =
-                    ::foundations::reexports_for_macros::once_cell::sync::Lazy::new(|| {
+                static __oxy_Metrics: ::std::sync::LazyLock<__oxy_Metrics> =
+                    ::std::sync::LazyLock::new(|| {
                         let opt_registry = &mut *::foundations::telemetry::metrics::internal::Registries::get_subsystem(stringify!(oxy), true, true);
 
                         __oxy_Metrics {
@@ -577,8 +575,8 @@ mod tests {
                 }
 
                 #[allow(non_upper_case_globals)]
-                static __oxy_Metrics: ::foundations::reexports_for_macros::once_cell::sync::Lazy<__oxy_Metrics> =
-                    ::foundations::reexports_for_macros::once_cell::sync::Lazy::new(|| {
+                static __oxy_Metrics: ::std::sync::LazyLock<__oxy_Metrics> =
+                    ::std::sync::LazyLock::new(|| {
                         let registry = &mut *::foundations::telemetry::metrics::internal::Registries::get_subsystem(stringify!(oxy), false, false);
                         let opt_registry = &mut *::foundations::telemetry::metrics::internal::Registries::get_subsystem(stringify!(oxy), true, false);
 
@@ -682,8 +680,8 @@ mod tests {
                 }
 
                 #[allow(non_upper_case_globals)]
-                static __oxy_Metrics: ::foundations::reexports_for_macros::once_cell::sync::Lazy<__oxy_Metrics> =
-                    ::foundations::reexports_for_macros::once_cell::sync::Lazy::new(|| {
+                static __oxy_Metrics: ::std::sync::LazyLock<__oxy_Metrics> =
+                    ::std::sync::LazyLock::new(|| {
                         let registry = &mut *::foundations::telemetry::metrics::internal::Registries::get_subsystem(stringify!(oxy), false, true);
 
                         __oxy_Metrics {
@@ -777,8 +775,8 @@ mod tests {
                 }
 
                 #[allow(non_upper_case_globals)]
-                static __oxy_Metrics: ::foundations::reexports_for_macros::once_cell::sync::Lazy<__oxy_Metrics> =
-                    ::foundations::reexports_for_macros::once_cell::sync::Lazy::new(|| {
+                static __oxy_Metrics: ::std::sync::LazyLock<__oxy_Metrics> =
+                    ::std::sync::LazyLock::new(|| {
                         let registry = &mut *::foundations::telemetry::metrics::internal::Registries::get_subsystem(stringify!(oxy), false, true);
 
                         __oxy_Metrics {

--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -111,6 +111,7 @@ logging = [
     "dep:thread_local",
     "dep:futures-util",
     "dep:serde",
+    "dep:crossbeam-utils",
 ]
 
 # Enables distributed tracing functionality.
@@ -130,6 +131,7 @@ tracing = [
     "dep:slab",
     "dep:libc",
     "dep:http",
+    "dep:crossbeam-utils",
 ]
 
 # Enables metrics functionality.
@@ -188,6 +190,7 @@ foundations-macros = { workspace = true, optional = true, default-features = fal
 cf-rustracing = { workspace = true, optional = true }
 cf-rustracing-jaeger = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
+crossbeam-utils = { workspace = true, optional = true }
 erased-serde = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }
 governor = { workspace = true, optional = true }

--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -102,7 +102,6 @@ tokio-runtime-metrics = [
 # Enables logging functionality.
 logging = [
     "dep:governor",
-    "dep:once_cell",
     "dep:parking_lot",
     "dep:slog-async",
     "dep:slog-json",
@@ -118,7 +117,6 @@ logging = [
 tracing = [
     "dep:foundations-macros",
     "dep:governor",
-    "dep:once_cell",
     "dep:parking_lot",
     "dep:rand",
     "dep:cf-rustracing-jaeger",
@@ -138,7 +136,6 @@ tracing = [
 metrics = [
     "dep:foundations-macros",
     "dep:erased-serde",
-    "dep:once_cell",
     "dep:parking_lot",
     "dep:prometheus-client",
     "dep:prometheus",

--- a/foundations/src/lib.rs
+++ b/foundations/src/lib.rs
@@ -100,7 +100,7 @@ pub mod security;
 pub mod reexports_for_macros {
     #[cfg(feature = "tracing")]
     pub use cf_rustracing;
-    #[cfg(any(feature = "metrics", feature = "security"))]
+    #[cfg(feature = "security")]
     pub use once_cell;
     #[cfg(feature = "metrics")]
     pub use parking_lot;

--- a/foundations/src/telemetry/memory_profiler.rs
+++ b/foundations/src/telemetry/memory_profiler.rs
@@ -7,13 +7,15 @@ use std::fs::File;
 use std::io::Read;
 use std::os::raw::c_char;
 use std::sync::mpsc::{self};
+use std::sync::OnceLock;
 use tempfile::NamedTempFile;
 use tokio::sync::{oneshot, Mutex as AsyncMutex};
 
+// TODO(once_cell_try): replace with `std::sync::OnceLock`
 static PROFILER: OnceCell<Option<MemoryProfiler>> = OnceCell::new();
-static HEAP_PROFILE_REQUEST_SENDER: OnceCell<
+static HEAP_PROFILE_REQUEST_SENDER: OnceLock<
     AsyncMutex<mpsc::Sender<oneshot::Sender<Result<String>>>>,
-> = OnceCell::new();
+> = OnceLock::new();
 
 mod control {
     use super::*;

--- a/foundations/src/telemetry/metrics/internal.rs
+++ b/foundations/src/telemetry/metrics/internal.rs
@@ -1,7 +1,6 @@
 use super::{info_metric, ExtraProducer, InfoMetric};
 use crate::telemetry::settings::{MetricsSettings, ServiceNameFormat};
 use crate::{Result, ServiceInfo};
-use once_cell::sync::OnceCell;
 use prometheus_client::encoding::text::{encode, EncodeMetric};
 use prometheus_client::registry::Registry;
 use prometools::serde::InfoGauge;
@@ -9,8 +8,9 @@ use std::any::TypeId;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ops::DerefMut;
+use std::sync::OnceLock;
 
-static REGISTRIES: OnceCell<Registries> = OnceCell::new();
+static REGISTRIES: OnceLock<Registries> = OnceLock::new();
 
 enum MetricsServiceName {
     Prefix(String),

--- a/foundations/src/telemetry/tracing/mod.rs
+++ b/foundations/src/telemetry/tracing/mod.rs
@@ -236,7 +236,7 @@ pub struct StartTraceOptions {
 ///
 /// Returns `None` if the span is not sampled and don't have associated trace.
 pub fn trace_id() -> Option<String> {
-    span_trace_id(&current_span()?.inner.read())
+    current_span()?.inner.with_read(span_trace_id)
 }
 
 /// Returns tracing state for the current span that can be serialized and passed to other services
@@ -288,9 +288,7 @@ pub fn trace_id() -> Option<String> {
 pub fn state_for_trace_stitching() -> Option<SerializableTraceState> {
     current_span()?
         .inner
-        .read()
-        .context()
-        .map(|c| c.state().clone())
+        .with_read(|s| Some(s.context()?.state().clone()))
 }
 
 /// Returns the value to be used as a W3C traceparent header.


### PR DESCRIPTION
### Improve performance of log/tracing harness access

- Switch to `std::sync::{OnceLock, LazyLock}` for better storage
   efficiency and std's futex-based backend. These are available since
   Rust 1.80.
- Avoid unnecessary LazyLock initialization of `NOOP_HARNESS` if a
   proper harness is configured. Previously, `.unwrap_or(&NOOP_HARNESS)`
   would cause the Deref impl to be called even if the reference was
   never used. (Due to Deref's side effects.)
- Wrap harnesses in crossbeam's `CachePadded` to avoid false sharing
   with other global variables. This is important to ensure OnceLock's
   initialization check is not slowed down by dirty cache lines.

### Remove globally-shared INACTIVE_SPAN RwLock

This RwLock was a heavy contention point in applications that generate a
lot of spans, as every span operation must lock and unlock the RwLock.
Each lock/unlock is an atomic RMW and thus dirties the cache line for
all other cores.

We can avoid the global singleton `INACTIVE_SPAN` entirely with some
changes to our internal `SharedSpanHandle` API.

### Remove internal once_cell usages

There are two spots left where we can't remove once-cell yet:
- In `memory_profiler.rs`, we use `OnceCell::get_or_try_init`. This
   function is not stabilized in std yet.
- The `foundations::security::allow_list` macro generates OnceCell
   instances in user code. Changing this requires a major bump.