### PR TITLE
Re-export http-body-util under telemetry reexports

### DIFF
--- a/foundations/src/telemetry/mod.rs
+++ b/foundations/src/telemetry/mod.rs
@@ -156,6 +156,7 @@ pub use self::server::{
 #[cfg(feature = "telemetry-server")]
 /// Re-exported crates which are used in public `telemetry` APIs.
 pub mod reexports {
+    pub use http_body_util;
     pub use hyper;
 }
 

--- a/foundations/src/telemetry/server/router.rs
+++ b/foundations/src/telemetry/server/router.rs
@@ -2,12 +2,11 @@
 use super::memory_profiling;
 #[cfg(feature = "metrics")]
 use crate::telemetry::metrics;
+use crate::telemetry::reexports::http_body_util::{BodyExt, Empty, Full, combinators::BoxBody};
 use crate::telemetry::settings::TelemetrySettings;
 #[cfg(feature = "tracing")]
 use crate::telemetry::tracing;
 use futures_util::future::{BoxFuture, FutureExt};
-use http_body_util::combinators::BoxBody;
-use http_body_util::{BodyExt, Empty, Full};
 use hyper::body::{Bytes, Incoming};
 use hyper::service::Service;
 use hyper::{Method, Request, Response, StatusCode, header};

--- a/foundations/tests/telemetry_server.rs
+++ b/foundations/tests/telemetry_server.rs
@@ -3,10 +3,12 @@ use foundations::telemetry::settings::{
 };
 use foundations::telemetry::{
     TelemetryConfig, TelemetryContext, TelemetryRouteBody, TelemetryServerRoute,
-    reexports::hyper::{Method, Response},
+    reexports::{
+        http_body_util::{BodyExt, Full},
+        hyper::{Method, Response},
+    },
 };
 use futures_util::FutureExt;
-use http_body_util::{BodyExt, Full};
 use std::future::IntoFuture;
 use std::net::{Ipv4Addr, SocketAddr};
 


### PR DESCRIPTION
TelemetryRouteBody aliases `BoxBody` from `http-body-util`. However, to construct `BoxBody` we still need something which implements `Body`. The tests use `Full` from `http-body-util`.

follows from https://github.com/cloudflare/foundations/pull/116. I'm open to the idea that perhaps we should also just alias `Full` or add a constructor to `TelemetryRouteBody` but i erred towards exporting the entire crate given that `hyper` is already exported. 