### PR TITLE
Support loading multiple YAML config files

### DIFF
--- a/foundations/src/cli.rs
+++ b/foundations/src/cli.rs
@@ -69,9 +69,9 @@ impl<S: Settings> Cli<S> {
             .author(service_info.author)
             .about(service_info.description)
             .arg(
-                Arg::new("config")
+                Arg::new(USE_CONFIG_OPT_ID)
                     .required_unless_present(GENERATE_CONFIG_OPT_ID)
-                    .action(ArgAction::Set)
+                    .action(ArgAction::Append)
                     .long("config")
                     .short('c')
                     .help("Specifies the config to run the service with"),
@@ -125,8 +125,8 @@ fn get_settings<S: Settings>(arg_matches: &ArgMatches) -> BootstrapResult<S> {
         return Ok(settings);
     }
 
-    if let Some(path) = arg_matches.get_one::<String>(USE_CONFIG_OPT_ID) {
-        return crate::settings::from_file(path).map_err(|e| anyhow!(e));
+    if let Some(paths) = arg_matches.get_many::<String>(USE_CONFIG_OPT_ID) {
+        return crate::settings::from_files(paths.map(|p| p.as_str())).map_err(|e| anyhow!(e));
     }
 
     unreachable!("clap should require config options to be present")

--- a/foundations/src/settings/mod.rs
+++ b/foundations/src/settings/mod.rs
@@ -497,13 +497,37 @@ pub fn from_yaml_str<T: Settings>(data: impl AsRef<str>) -> BootstrapResult<T> {
     Ok(serde_path_to_error::deserialize(value)?)
 }
 
-/// Parse settings from YAML file.
+/// Parse settings from a YAML file.
 ///
 /// Note: [YAML key references] will be merged during parsing.
 ///
 /// [YAML key references]: https://yaml.org/type/merge.html
 pub fn from_file<T: Settings>(path: impl AsRef<Path>) -> BootstrapResult<T> {
-    let data = std::fs::read_to_string(path)?;
+    from_files([path])
+}
+
+/// Parse settings from YAML file(s).
+///
+/// Note: [YAML key references] will be merged during parsing.
+///
+/// [YAML key references]: https://yaml.org/type/merge.html
+pub fn from_files<T, I, P>(paths: I) -> BootstrapResult<T>
+where
+    T: Settings,
+    I: IntoIterator<Item = P>,
+    P: AsRef<Path>,
+{
+    let mut data = String::new();
+
+    for path in paths {
+        let file_data = std::fs::read_to_string(path)?;
+
+        if !data.is_empty() && !data.ends_with('\n') {
+            data.push('\n');
+        }
+
+        data.push_str(&file_data);
+    }
 
     from_yaml_str(data)
 }


### PR DESCRIPTION
The concatenation of the files produces the resulting configuration. File boundaries will be separated by a newline.