### PR TITLE
Support slog's  dynamic keys feature in log field filters

### DIFF
--- a/foundations/src/telemetry/log/field_dedup.rs
+++ b/foundations/src/telemetry/log/field_dedup.rs
@@ -29,7 +29,10 @@ pub(crate) struct FieldDedupFilter {
 impl Filter for FieldDedupFilter {
     #[inline]
     fn filter(&mut self, key: &Key) -> bool {
-        self.seen_keys.insert(*key)
+        // With `dynamic-keys`, Key is an owned struct and needs cloning.
+        // Without it, Key is `&'static str` (Copy), and clone on `&&str` copies the reference.
+        #[allow(suspicious_double_ref_op)]
+        self.seen_keys.insert(key.clone())
     }
 }
 

--- a/foundations/src/telemetry/log/field_redact.rs
+++ b/foundations/src/telemetry/log/field_redact.rs
@@ -39,7 +39,7 @@ pub(crate) struct FieldRedactFilter {
 impl Filter for FieldRedactFilter {
     #[inline]
     fn filter(&mut self, key: &Key) -> bool {
-        !self.redacted_keys.contains(*key)
+        !self.redacted_keys.contains::<str>(key.as_ref())
     }
 }
 


### PR DESCRIPTION
The field_redact and field_dedup filters use operations on slog::Key that assume it is Copy or that &str: Borrow<Key> holds. With slog's dynamic-keys feature enabled, Key becomes an owned struct wrapping Cow<'static, str>, breaking both assumptions. Use key.as_ref() with a turbofish for redact (disambiguates the AsRef target) and key.clone() for dedup (works for both Copy and Clone key types). Both changes are backwards-compatible when dynamic-keys is not enabled.