### PR TITLE
Release 5.6.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "5.6.1"
+version = "5.6.2"
 repository = "https://github.com/cloudflare/foundations"
 edition = "2024"
 authors = ["Cloudflare"]
@@ -38,8 +38,8 @@ check-cfg = [
 [workspace.dependencies]
 anyhow = "1.0.75"
 backtrace = "0.3"
-foundations = { version = "5.6.1", path = "./foundations" }
-foundations-macros = { version = "=5.6.1", path = "./foundations-macros", default-features = false }
+foundations = { version = "5.6.2", path = "./foundations" }
+foundations-macros = { version = "=5.6.2", path = "./foundations-macros", default-features = false }
 bindgen = { version = "0.72", default-features = false }
 cc = "1.0"
 cf-rustracing = "1.3"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 
+5.6.2
+- 2026-04-09 Support slog's  feature in log field filters
+
 5.6.1
+- 2026-04-09 Release 5.6.1
 - 2026-04-09 fix: Initialize metrics first among telemetry subsystems
 
 5.6.0


### PR DESCRIPTION
### Fixed
- slog's `dynamic-keys` feature switches out its `Key` type for one that implements only a subset of the traits of `&'static str`. We updated the logging field filters to be compatible with both types. (#194)