### PR TITLE
fix: Initialize metrics first in telemetry testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "5.6.3"
+version = "5.6.4"
 repository = "https://github.com/cloudflare/foundations"
 edition = "2024"
 authors = ["Cloudflare"]
@@ -38,8 +38,8 @@ check-cfg = [
 [workspace.dependencies]
 anyhow = "1.0.75"
 backtrace = "0.3"
-foundations = { version = "5.6.3", path = "./foundations" }
-foundations-macros = { version = "=5.6.3", path = "./foundations-macros", default-features = false }
+foundations = { version = "5.6.4", path = "./foundations" }
+foundations-macros = { version = "=5.6.4", path = "./foundations-macros", default-features = false }
 bindgen = { version = "0.72", default-features = false }
 cc = "1.0"
 cf-rustracing = "1.3"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 
+5.6.4
+- 2026-04-09 fix: Initialize metrics first in telemetry testing
+- 2026-04-21 Regression test for uninitialized metrics in foundations' testing framework
+
 5.6.3
+- 2026-04-16 Release 5.6.3
 - 2026-04-16 fix: Default back to serde_yaml, with serde-saphyr opt-in
 - 2026-04-16 foundations: fix 'occured' -> 'occurred' in doc comment
 

--- a/foundations/src/telemetry/metrics/init.rs
+++ b/foundations/src/telemetry/metrics/init.rs
@@ -8,13 +8,14 @@ use crate::telemetry::settings::MetricsSettings;
 /// Must be called before any use of metrics defined
 /// by the `metrics` proc macro attribute.
 pub(crate) fn init(service_info: &ServiceInfo, settings: &MetricsSettings) {
-    Registries::init(service_info, settings);
+    let first_install = Registries::init(service_info, settings);
+    if first_install {
+        report_info(BuildInfo {
+            version: service_info.version,
+        });
 
-    report_info(BuildInfo {
-        version: service_info.version,
-    });
-
-    report_info(RuntimeInfo {
-        pid: std::process::id(),
-    });
+        report_info(RuntimeInfo {
+            pid: std::process::id(),
+        });
+    }
 }

--- a/foundations/src/telemetry/metrics/internal.rs
+++ b/foundations/src/telemetry/metrics/internal.rs
@@ -39,22 +39,30 @@ pub struct Registries {
 }
 
 impl Registries {
-    pub(super) fn init(service_info: &ServiceInfo, settings: &MetricsSettings) {
+    pub(super) fn init(service_info: &ServiceInfo, settings: &MetricsSettings) -> bool {
         let service_name = MetricsServiceName::new(
             &service_info.name_in_metrics,
             settings.service_name_format.clone(),
         );
 
+        let mut first_install = false;
+
         // FIXME(nox): Due to prometheus-client 0.18 not supporting the creation of
         // registries with specific label values, we use `MetricsServiceName::Label`
         // directly in `Registries::get_subsystem`.
-        REGISTRIES.get_or_init(|| Registries {
-            main: Default::default(),
-            opt: Default::default(),
-            info: Default::default(),
-            service_name,
-            extra_producers: Default::default(),
+        REGISTRIES.get_or_init(|| {
+            let regs = Registries {
+                main: Default::default(),
+                opt: Default::default(),
+                info: Default::default(),
+                service_name,
+                extra_producers: Default::default(),
+            };
+            first_install = true;
+            regs
         });
+
+        first_install
     }
 
     pub(super) fn collect(buffer: &mut Vec<u8>, collect_optional: bool) -> Result<()> {

--- a/foundations/src/telemetry/testing.rs
+++ b/foundations/src/telemetry/testing.rs
@@ -48,6 +48,12 @@ pub struct TestTelemetryContext {
 
 impl TestTelemetryContext {
     pub(crate) fn new() -> Self {
+        #[cfg(feature = "metrics")]
+        {
+            let service_info = crate::service_info!();
+            super::metrics::init::init(&service_info, &Default::default());
+        }
+
         #[cfg(feature = "logging")]
         let (log, log_records) = {
             create_test_log(&LoggingSettings {

--- a/foundations/tests/metrics.rs
+++ b/foundations/tests/metrics.rs
@@ -1,5 +1,7 @@
+use foundations::service_info;
 use foundations::telemetry::metrics::{self, Counter, metrics};
-use foundations::telemetry::settings::{MetricsSettings, ServiceNameFormat};
+use foundations::telemetry::settings::{MetricsSettings, ServiceNameFormat, TelemetrySettings};
+use foundations::telemetry::{TelemetryConfig, TelemetryContext};
 
 #[metrics]
 mod regular {
@@ -47,4 +49,28 @@ fn metrics_unprefixed() {
     assert!(!metrics.contains("\nundefined_regular_dynamic"));
     assert!(metrics.contains("\nlibrary_calls 1\n"));
     assert!(!metrics.contains("\nlibrary_optional"));
+}
+
+#[tokio::test]
+async fn test_context_cooperates_with_init() {
+    let _ctx = TelemetryContext::test();
+
+    let service_info = service_info!();
+    let settings = TelemetrySettings::default();
+    let config = TelemetryConfig {
+        service_info: &service_info,
+        settings: &settings,
+        custom_server_routes: vec![],
+    };
+    foundations::telemetry::init(config)
+        .expect("telemetry init should succeed under TestTelemetryContext");
+
+    regular::requests().inc();
+    library::calls().inc();
+
+    let metrics = metrics::collect(&settings.metrics).expect("metrics should be collectable");
+
+    // `TelemetryContext::test()` should initialize metrics registry with default service_info!()
+    assert!(metrics.contains("\nfoundations_regular_requests 1\n"));
+    assert!(metrics.contains("\nlibrary_calls 1\n"));
 }


### PR DESCRIPTION
Other subsystems may register metrics during initialization
(specifically, `tracing_max_queue_size` right now). Not initializing
metrics causes the `REGISTRIES` singleton to be defaulted when a metric
is registered beforehand.

This is similar to #193, but for `TelemetryContext::test()`.

Includes a regression test and a release commit for `foundations 5.6.4`.