### PR TITLE
Bugfix release 5.6.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "5.6.4"
+version = "5.6.5"
 repository = "https://github.com/cloudflare/foundations"
 edition = "2024"
 authors = ["Cloudflare"]
@@ -38,8 +38,8 @@ check-cfg = [
 [workspace.dependencies]
 anyhow = "1.0.75"
 backtrace = "0.3"
-foundations = { version = "5.6.4", path = "./foundations" }
-foundations-macros = { version = "=5.6.4", path = "./foundations-macros", default-features = false }
+foundations = { version = "5.6.5", path = "./foundations" }
+foundations-macros = { version = "=5.6.5", path = "./foundations-macros", default-features = false }
 bindgen = { version = "0.72", default-features = false }
 cc = "1.0"
 cf-rustracing = "1.3"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 
+5.6.5
+- 2026-04-23 fix: Revert initialization of metrics in telemetry testing
+- 2026-04-23 fix: Use `num_tasks` setting for Jaeger trace reporter tasks
+
 5.6.4
+- 2026-04-21 Release 5.6.4
 - 2026-04-09 fix: Initialize metrics first in telemetry testing
 - 2026-04-21 Regression test for uninitialized metrics in foundations' testing framework
 

--- a/foundations/src/telemetry/metrics/internal.rs
+++ b/foundations/src/telemetry/metrics/internal.rs
@@ -127,6 +127,11 @@ impl Registries {
         self.extra_producers.write().push(producer);
     }
 
+    #[cfg(test)]
+    pub fn is_initialized() -> bool {
+        REGISTRIES.get().is_some()
+    }
+
     pub(super) fn get() -> &'static Registries {
         REGISTRIES.get_or_init(|| Registries {
             main: Default::default(),

--- a/foundations/src/telemetry/mod.rs
+++ b/foundations/src/telemetry/mod.rs
@@ -377,11 +377,8 @@ pub fn init(config: TelemetryConfig) -> BootstrapResult<TelemetryDriver> {
 
 #[cfg(test)]
 mod tests {
-    use super::init;
-    use crate::{
-        service_info,
-        telemetry::{TelemetryConfig, is_initialized},
-    };
+    use super::{TelemetryConfig, TelemetryContext, init, is_initialized};
+    use crate::service_info;
 
     #[tokio::test]
     async fn double_init_call_errors() {
@@ -400,5 +397,16 @@ mod tests {
         });
         assert!(second_res.is_err());
         assert!(is_initialized());
+    }
+
+    /// Ensure that `TelemetryContext::test()` does not default-initialize the metrics registry.
+    /// This has caused CI bugs in the past because metrics will be prefixed by `undefined_`.
+    #[test]
+    fn testing_telemetry_metrics_uninit() {
+        let _ctx = TelemetryContext::test();
+        assert!(
+            !super::metrics::internal::Registries::is_initialized(),
+            "metrics::Registries should not be initialized in `TelemetryContext::test`",
+        );
     }
 }

--- a/foundations/src/telemetry/testing.rs
+++ b/foundations/src/telemetry/testing.rs
@@ -48,12 +48,6 @@ pub struct TestTelemetryContext {
 
 impl TestTelemetryContext {
     pub(crate) fn new() -> Self {
-        #[cfg(feature = "metrics")]
-        {
-            let service_info = crate::service_info!();
-            super::metrics::init::init(&service_info, &Default::default());
-        }
-
         #[cfg(feature = "logging")]
         let (log, log_records) = {
             create_test_log(&LoggingSettings {

--- a/foundations/src/telemetry/tracing/init.rs
+++ b/foundations/src/telemetry/tracing/init.rs
@@ -77,16 +77,10 @@ pub(super) fn create_tracer_and_span_rx(
     };
 
     if let Some(cap) = settings.max_queue_size {
-        #[cfg(feature = "metrics")]
-        super::metrics::tracing::max_queue_size().set(cap.get() as u64);
-
         let (consumer, span_rx) = super::channel::channel(cap);
         let tracer = Tracer::with_consumer(sampler, consumer);
         Ok((tracer, span_rx))
     } else {
-        #[cfg(feature = "metrics")]
-        super::metrics::tracing::max_queue_size().set(usize::MAX as u64);
-
         let (consumer, span_rx) = super::channel::unbounded_channel();
         let tracer = Tracer::with_consumer(sampler, consumer);
         Ok((tracer, span_rx))
@@ -122,6 +116,15 @@ pub(crate) fn init(
     // Only spawn the futures if we are actually initializing the harness
     let mut res = Ok(None);
     HARNESS.get_or_init(|| {
+        #[cfg(feature = "metrics")]
+        {
+            let max_queue_size = settings
+                .max_queue_size
+                .map(std::num::NonZeroUsize::get)
+                .unwrap_or(usize::MAX);
+            super::metrics::tracing::max_queue_size().set(max_queue_size as u64);
+        }
+
         res = Ok(futs.initializer);
         for f in futs.workers {
             tokio::spawn(f);

--- a/foundations/src/telemetry/tracing/output_jaeger_thrift_udp.rs
+++ b/foundations/src/telemetry/tracing/output_jaeger_thrift_udp.rs
@@ -33,7 +33,7 @@ pub(super) fn start(
     reporter.add_service_tag(Tag::new("app.version", service_info.version));
     let reporter = Arc::new(reporter);
 
-    let futs: Vec<_> = (0..settings.max_batch_size)
+    let futs: Vec<_> = (0..settings.num_tasks)
         .map(|_| {
             let reporter = Arc::clone(&reporter);
             do_export(reporter, span_rx.clone(), max_batch_size).boxed()

--- a/foundations/tests/metrics.rs
+++ b/foundations/tests/metrics.rs
@@ -1,4 +1,4 @@
-use foundations::service_info;
+use foundations::ServiceInfo;
 use foundations::telemetry::metrics::{self, Counter, metrics};
 use foundations::telemetry::settings::{MetricsSettings, ServiceNameFormat, TelemetrySettings};
 use foundations::telemetry::{TelemetryConfig, TelemetryContext};
@@ -55,7 +55,14 @@ fn metrics_unprefixed() {
 async fn test_context_cooperates_with_init() {
     let _ctx = TelemetryContext::test();
 
-    let service_info = service_info!();
+    let service_info = ServiceInfo {
+        name: "my-bin",
+        name_in_metrics: "my_bin".to_owned(),
+        version: "1.0.0",
+        author: "Foo Bar",
+        description: "An example service",
+    };
+
     let settings = TelemetrySettings::default();
     let config = TelemetryConfig {
         service_info: &service_info,
@@ -70,7 +77,7 @@ async fn test_context_cooperates_with_init() {
 
     let metrics = metrics::collect(&settings.metrics).expect("metrics should be collectable");
 
-    // `TelemetryContext::test()` should initialize metrics registry with default service_info!()
-    assert!(metrics.contains("\nfoundations_regular_requests 1\n"));
+    // Metrics registry should be initialized with explicit ServiceInfo from `foundations::telemetry::init`
+    assert!(metrics.contains("\nmy_bin_regular_requests 1\n"));
     assert!(metrics.contains("\nlibrary_calls 1\n"));
 }


### PR DESCRIPTION
### fix: Revert initialization of metrics in telemetry testing

This partially reverts #199. The attempted fix in that commit uses `service_info!()` to initialize the metrics registries in `TestTelemetryContext::new()`. Cargo sets environment variables separately for each crate being compiled, so `service_info!()` resolved `name_in_metrics` to "foundations". What we wanted is to use the name of the crate being _tested_.

That wouldn't necessarily be correct either, as a crate could set a completely custom `name_in_metrics` in its `foundations::telemetry::init` call. Instead, we now make sure to not initialize the metrics registries altogether. I added a test to enforce this going forward.

###  fix: Use `num_tasks` setting for Jaeger trace reporter tasks

This was accidentally set to `max_batch_size`, and linters didn't notice the unused `num_tasks` setting because the field is `pub`.