### PR TITLE
Allow pattern-based routes in TelemetryServer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "5.6.5"
+version = "5.7.0"
 repository = "https://github.com/cloudflare/foundations"
 edition = "2024"
 authors = ["Cloudflare"]
@@ -39,8 +39,8 @@ check-cfg = [
 [workspace.dependencies]
 anyhow = "1.0.102"
 backtrace = "0.3.76"
-foundations = { version = "5.6.5", path = "./foundations", default-features = false }
-foundations-macros = { version = "=5.6.5", path = "./foundations-macros", default-features = false }
+foundations = { version = "5.7.0", path = "./foundations", default-features = false }
+foundations-macros = { version = "=5.7.0", path = "./foundations-macros", default-features = false }
 bindgen = { version = "0.72.1", default-features = false }
 cc = "1.2.61"
 cf-rustracing = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ annotate-snippets = "0.12.15"
 # and the minver CI job fails compiling slog-term.
 chrono = "0.4.44"
 encoding_rs_io = "0.1.7"
+is-terminal = "0.4.8"
 local-ip-address = "0.6.12"
 lock_api = "0.4.14"
 log = "0.4.29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ hyper-util = { version = "0.1.20", default-features = false }
 indexmap = "2.14.0"
 ipnetwork = { version = "0.21.1", features = ["serde"] }
 libc = "0.2.186"
+matchit = "0.9.2"
 nix = "0.31.2"
 once_cell = "1.21.4"
 tonic = { version = "0.14.5", default-features = false }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 
+5.7.0
+- 2026-05-11 fix: rustix 0.36 breaks under nightly
+- 2026-05-07 Allow pattern-based routes in TelemetryServer
+- 2026-04-27 chore: Release
+- 2026-04-27 Configure cargo-release for separately-versioned crates
+- 2026-04-27 Extract sentry hook into separate foundations-sentry crate
+- 2026-04-24 Update dependencies.
+
 5.6.5
+- 2026-04-23 Release 5.6.5
 - 2026-04-23 fix: Revert initialization of metrics in telemetry testing
 - 2026-04-23 fix: Use `num_tasks` setting for Jaeger trace reporter tasks
 

--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -269,6 +269,7 @@ ahash = { workspace = true, optional = true }
 annotate-snippets = { workspace = true, optional = true }
 chrono = { workspace = true, optional = true }
 encoding_rs_io = { workspace = true, optional = true }
+is-terminal = { workspace = true, optional = true }
 local-ip-address = { workspace = true, optional = true }
 lock_api = { workspace = true, optional = true }
 log = { workspace = true, optional = true }

--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -101,6 +101,7 @@ telemetry-server = [
     "dep:tokio",
     "tokio/net",
     "dep:futures-util",
+    "dep:matchit",
 ]
 
 # Enables telemetry reporting over gRPC
@@ -193,6 +194,10 @@ panic_on_frozen_logger = []
 # Enables panicking when too much nesting is reached on the logger
 panic_on_too_much_logger_nesting = []
 
+# Enables pattern-based routing in `telemetry-server`. If this is not enabled,
+# pattern characters will be interpreted literally.
+telemetry-server-pattern-routing = []
+
 # Enables compatibility with `tracing-rs` by adding the ability to configure a
 # logging drain that forwards logs
 tracing-rs-compat = ["dep:tracing-slog"]
@@ -224,6 +229,7 @@ hyper = { workspace = true, optional = true, features = ["http1", "server"] }
 hyper-util = { workspace = true, optional = true, features = ["tokio"] }
 indexmap = { workspace = true, optional = true, features = ["serde"] }
 libc = { workspace = true, optional = true }
+matchit = { workspace = true, optional = true }
 once_cell = { workspace = true, optional = true }
 opentelemetry-proto = { workspace = true, optional = true, features = ["gen-tonic-messages", "trace"] }
 parking_lot = { workspace = true, optional = true }

--- a/foundations/src/telemetry/server/mod.rs
+++ b/foundations/src/telemetry/server/mod.rs
@@ -158,7 +158,8 @@ impl TelemetryServerFuture {
                 .map_err(|err| anyhow::anyhow!(err))?;
         }
 
-        let router = Router::new(custom_routes, Arc::clone(&settings));
+        let router = Router::new(custom_routes, Arc::clone(&settings))
+            .context("building telemetry server router")?;
 
         let listener = match &settings.server.addr {
             ListenAddr::Tcp(addr) => {

--- a/foundations/src/telemetry/server/router.rs
+++ b/foundations/src/telemetry/server/router.rs
@@ -2,6 +2,7 @@
 use super::memory_profiling;
 #[cfg(feature = "memory-profiling")]
 use super::pprof_symbol;
+use crate::BootstrapResult;
 #[cfg(feature = "metrics")]
 use crate::telemetry::metrics;
 use crate::telemetry::reexports::http_body_util::{BodyExt, Empty, Full, combinators::BoxBody};
@@ -31,8 +32,54 @@ pub type TelemetryRouteHandler = Box<
         + Sync
         + 'static,
 >;
+type RouteHandlerShared = Arc<
+    dyn Fn(Request<Incoming>, Arc<TelemetrySettings>) -> TelemetryRouteHandlerFuture
+        + Send
+        + Sync
+        + 'static,
+>;
 
 /// A telemetry server route descriptor.
+///
+/// There can be only one route handler per (Method, Path) pair. If there is a
+/// collision, the first route to be inserted wins. This includes built-in routes,
+/// which are inserted before any custom routes. The current set of built-in routes
+/// are:
+/// - `/health`
+/// - `/metrics` (`metrics` feature)
+/// - `/pprof/heap` (`memory-profiling` feature)
+/// - `/pprof/heap_stats` (`memory-profiling` feature)
+/// - `/pprof/symbol` (`memory-profiling` feature)
+/// - `/debug/traces` (`tracing` feature)
+///
+/// New built-in routes may be added from time to time. We reserve the `/foundations/`
+/// prefix for this purpose, but other paths may be used if there are existing conventions
+/// for a feature (such as `/pprof/*` and `/metrics`.)
+///
+/// # Pattern-Based Routing
+///
+/// If the optional `telemetry-server-pattern-routing` feature is enabled,
+/// [`TelemetryServerRoute`]s can include parameters in their `path` attributes.
+/// (If the feature is disabled, `path` is interpreted entirely literally.) Parameters
+/// are delimited by single curly braces, i.e. `{my_param}`. To include a literal curly
+/// brace in a pattern-based path, escape it by duplicating it: `{ -> {{` and `} -> }}`.
+///
+/// For routing, paths are split into segments delimited by `/`. Each segment may be
+/// either:
+/// - A static string, like `/foo`.
+/// - A named parameter, like `/{my_param}`. Prefixes and suffixes can be added as
+///   well (`/foo{my_param}bar`).
+/// - A catch-all parameter, like `/{*rest}`. This is only allowed at the end of the
+///   path.
+///
+/// Note that this allows patterns to be overlapping. For the exact details on conflict
+/// handling and priority, see the [`matchit`](matchit#conflict-rules) docs. In essence,
+/// static segments take precedence over parameters, and named parameters take precedence
+/// over catch-all parameters.
+///
+/// We do not pass the parsed parameters to the `handler` function (to keep the route
+/// interface as simply as possible.) If necessary, the handler has to re-parse the
+/// request's path itself.
 pub struct TelemetryServerRoute {
     /// URL path of the route.
     pub path: String,
@@ -44,27 +91,27 @@ pub struct TelemetryServerRoute {
     pub handler: TelemetryRouteHandler,
 }
 
-struct RouteMap(HashMap<Method, HashMap<String, Arc<TelemetryRouteHandler>>>);
+struct Routes(HashMap<Method, matchit::Router<RouteHandlerShared>>);
 
-impl RouteMap {
-    fn new(custom_routes: Vec<TelemetryServerRoute>) -> Self {
-        let mut map = RouteMap(Default::default());
+impl Routes {
+    fn new(custom_routes: Vec<TelemetryServerRoute>) -> BootstrapResult<Self> {
+        let mut map = Self(Default::default());
 
-        map.init_built_in_routes();
+        map.init_built_in_routes()?;
 
         for route in custom_routes {
-            map.set(route);
+            map.set(route)?;
         }
 
-        map
+        Ok(map)
     }
 
-    fn init_built_in_routes(&mut self) {
+    fn init_built_in_routes(&mut self) -> BootstrapResult<()> {
         self.set(TelemetryServerRoute {
             path: "/health".into(),
             methods: vec![Method::GET],
             handler: Box::new(|_, _| async { into_response("text/plain", Ok("")) }.boxed()),
-        });
+        })?;
 
         #[cfg(feature = "metrics")]
         self.set(TelemetryServerRoute {
@@ -79,7 +126,7 @@ impl RouteMap {
                 }
                 .boxed()
             }),
-        });
+        })?;
 
         #[cfg(all(target_os = "linux", feature = "memory-profiling"))]
         self.set(TelemetryServerRoute {
@@ -94,7 +141,7 @@ impl RouteMap {
                 }
                 .boxed()
             }),
-        });
+        })?;
 
         #[cfg(all(target_os = "linux", feature = "memory-profiling"))]
         self.set(TelemetryServerRoute {
@@ -109,7 +156,7 @@ impl RouteMap {
                 }
                 .boxed()
             }),
-        });
+        })?;
 
         #[cfg(feature = "memory-profiling")]
         self.set(TelemetryServerRoute {
@@ -124,7 +171,7 @@ impl RouteMap {
                 }
                 .boxed()
             }),
-        });
+        })?;
 
         #[cfg(feature = "tracing")]
         self.set(TelemetryServerRoute {
@@ -139,25 +186,44 @@ impl RouteMap {
                 }
                 .boxed()
             }),
-        });
+        })?;
+
+        Ok(())
     }
 
-    fn set(&mut self, route: TelemetryServerRoute) {
-        let handler = Arc::new(route.handler);
+    #[allow(unused_mut, reason = "conditional mutation")]
+    fn set(&mut self, mut route: TelemetryServerRoute) -> BootstrapResult<()> {
+        let handler = Arc::from(route.handler);
+
+        #[cfg(not(feature = "telemetry-server-pattern-routing"))]
+        {
+            // Escape parameter delimiters so `matchit` interprets them literally
+            route.path = route.path.replace('{', "{{").replace('}', "}}");
+        }
 
         for method in route.methods {
-            self.0
+            let res = self
+                .0
                 .entry(method)
                 .or_default()
-                .entry(route.path.clone())
-                .or_insert(Arc::clone(&handler));
+                .insert(route.path.clone(), Arc::clone(&handler));
+
+            match res {
+                Ok(()) => {}
+                // Exact matches were allowed and ignored historically. Any other errors
+                // should be reported up.
+                Err(matchit::InsertError::Conflict { with }) if with == route.path => {}
+                Err(e) => anyhow::bail!("tried to insert route `{}`, but {}", &route.path, e),
+            }
         }
+
+        Ok(())
     }
 }
 
 #[derive(Clone)]
 pub(super) struct Router {
-    routes: Arc<RouteMap>,
+    routes: Arc<Routes>,
     settings: Arc<TelemetrySettings>,
 }
 
@@ -165,11 +231,11 @@ impl Router {
     pub(super) fn new(
         custom_routes: Vec<TelemetryServerRoute>,
         settings: Arc<TelemetrySettings>,
-    ) -> Self {
-        Self {
-            routes: Arc::new(RouteMap::new(custom_routes)),
+    ) -> BootstrapResult<Self> {
+        Ok(Self {
+            routes: Arc::new(Routes::new(custom_routes)?),
             settings,
-        }
+        })
     }
 
     async fn handle_request(&self, req: Request<Incoming>) -> Response<TelemetryRouteBody> {
@@ -188,7 +254,7 @@ impl Router {
             .routes
             .0
             .get(req.method())
-            .and_then(|e| e.get(&path.to_string()))
+            .and_then(|r| Some(r.at(&path).ok()?.value))
         else {
             return res
                 .status(StatusCode::NOT_FOUND)


### PR DESCRIPTION
Routing is provided by `matchit`. By default (without the optional
`telemetry-server-pattern-routing` feature enabled) we escape all
parameter delimiters, which results in exact match routing as we had
before.

With the feature enabled, we pass the routes to `matchit` as-is,
allowing users to define routes with dynamic segments in them.

Includes a release commit for `foundations 5.7.0`.