### PR TITLE
ci(semgrep): pin token to contents: read

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: '0 6 * * *'
 name: Semgrep config
+permissions:
+  contents: read
 jobs:
   semgrep:
     name: semgrep/ci


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to read-only for `semgrep.yml`. The scheduled Semgrep scan only checks out the repo and posts findings to Cloudflare's internal Semgrep instance via `SEMGREP_APP_TOKEN`, so the GitHub token only needs read access to the checkout.

Brings the workflow in line with the existing `permissions: contents: read` block in `ci.yml`. YAML validated with `yaml.safe_load`.