### PR TITLE
feat: add LogOutput::Custom variant for user-provided slog drains

### DIFF
--- a/foundations/src/telemetry/log/init.rs
+++ b/foundations/src/telemetry/log/init.rs
@@ -121,6 +121,9 @@ pub(crate) fn init(
         (LogOutput::TracingRsCompat, _) => AsyncDrain::new(tracing_slog::TracingSlogDrain {})
             .chan_size(CHANNEL_SIZE)
             .build_with_guard(),
+        (LogOutput::Custom(drain), _) => AsyncDrain::new(Arc::clone(drain))
+            .chan_size(CHANNEL_SIZE)
+            .build_with_guard(),
     };
 
     let root_drain = wrap_root_drain(settings, async_drain.fuse());

--- a/foundations/src/telemetry/log/testing.rs
+++ b/foundations/src/telemetry/log/testing.rs
@@ -93,6 +93,32 @@ pub(crate) fn create_test_log(
     (log, log_records)
 }
 
+/// Create a test log with a custom drain installed in addition to the test drain
+pub(crate) fn create_test_log_for_custom(
+    settings: &LoggingSettings,
+    custom_drain: crate::telemetry::settings::CustomDrain,
+) -> (LoggerWithKvNestingTracking, TestLogRecords) {
+    let log_records = Arc::new(RwLock::new(vec![]));
+
+    let drain = TestLogDrain {
+        records: Arc::clone(&log_records),
+        forward: Some(custom_drain),
+    };
+    let drain = wrap_root_drain(settings, drain);
+
+    let logger = build_log_with_drain(settings.verbosity, slog::o!(), Arc::clone(&drain));
+    let log = LoggerWithKvNestingTracking::new(logger);
+
+    let _ = LogHarness::override_for_testing(LogHarness {
+        root_log: Arc::new(ParkingRwLock::new(log.clone())),
+        root_drain: drain,
+        settings: settings.clone(),
+        log_scope_stack: Default::default(),
+    });
+
+    (log, log_records)
+}
+
 /// Create a test log with a tracing-rs compat drain installed in addition to the test drain
 #[cfg(feature = "tracing-rs-compat")]
 pub(crate) fn create_test_log_for_tracing_compat(

--- a/foundations/src/telemetry/log/testing.rs
+++ b/foundations/src/telemetry/log/testing.rs
@@ -2,7 +2,9 @@ use crate::telemetry::log::init::{LogHarness, build_log_with_drain, wrap_root_dr
 use crate::telemetry::log::internal::LoggerWithKvNestingTracking;
 use crate::telemetry::settings::LoggingSettings;
 use parking_lot::RwLock as ParkingRwLock;
-use slog::{Discard, Drain, KV, Key, Level, Never, OwnedKVList, Record, Serializer};
+use slog::{
+    Drain, KV, Key, Level, Never, OwnedKVList, Record, SendSyncRefUnwindSafeDrain, Serializer,
+};
 use std::fmt::Arguments;
 use std::sync::{Arc, RwLock};
 
@@ -69,40 +71,18 @@ where
     }
 }
 
-pub(crate) fn create_test_log(
+pub(crate) fn create_test_log<D>(
     settings: &LoggingSettings,
-) -> (LoggerWithKvNestingTracking, TestLogRecords) {
+    forward: Option<D>,
+) -> (LoggerWithKvNestingTracking, TestLogRecords)
+where
+    D: SendSyncRefUnwindSafeDrain<Ok = (), Err = Never> + 'static,
+{
     let log_records = Arc::new(RwLock::new(vec![]));
 
-    let drain: TestLogDrain<Discard> = TestLogDrain {
+    let drain: TestLogDrain<D> = TestLogDrain {
         records: Arc::clone(&log_records),
-        forward: None,
-    };
-    let drain = wrap_root_drain(settings, drain);
-
-    let logger = build_log_with_drain(settings.verbosity, slog::o!(), Arc::clone(&drain));
-    let log = LoggerWithKvNestingTracking::new(logger);
-
-    let _ = LogHarness::override_for_testing(LogHarness {
-        root_log: Arc::new(ParkingRwLock::new(log.clone())),
-        root_drain: drain,
-        settings: settings.clone(),
-        log_scope_stack: Default::default(),
-    });
-
-    (log, log_records)
-}
-
-/// Create a test log with a custom drain installed in addition to the test drain
-pub(crate) fn create_test_log_for_custom(
-    settings: &LoggingSettings,
-    custom_drain: crate::telemetry::settings::CustomDrain,
-) -> (LoggerWithKvNestingTracking, TestLogRecords) {
-    let log_records = Arc::new(RwLock::new(vec![]));
-
-    let drain = TestLogDrain {
-        records: Arc::clone(&log_records),
-        forward: Some(custom_drain),
+        forward,
     };
     let drain = wrap_root_drain(settings, drain);
 
@@ -131,25 +111,5 @@ pub(crate) fn create_test_log_for_tracing_compat(
         crate::telemetry::settings::LogOutput::TracingRsCompat
     ));
 
-    let base_drain = TracingSlogDrain {};
-
-    let log_records = Arc::new(RwLock::new(vec![]));
-
-    let drain = TestLogDrain {
-        records: Arc::clone(&log_records),
-        forward: Some(base_drain.fuse()),
-    };
-    let drain = wrap_root_drain(settings, drain);
-
-    let logger = build_log_with_drain(settings.verbosity, slog::o!(), Arc::clone(&drain));
-    let log = LoggerWithKvNestingTracking::new(logger);
-
-    let _ = LogHarness::override_for_testing(LogHarness {
-        root_log: Arc::new(ParkingRwLock::new(log.clone())),
-        root_drain: drain,
-        settings: settings.clone(),
-        log_scope_stack: Default::default(),
-    });
-
-    (log, log_records)
+    create_test_log(settings, Some(TracingSlogDrain {}.fuse()))
 }

--- a/foundations/src/telemetry/settings/logging.rs
+++ b/foundations/src/telemetry/settings/logging.rs
@@ -3,24 +3,22 @@ use crate::utils::feature_use;
 
 use std::path::PathBuf;
 
-#[cfg(feature = "logging")]
-use std::sync::Arc;
+feature_use!(cfg(feature = "logging"), {
+    use slog::{Never, SendSyncRefUnwindSafeDrain};
+    use std::sync::Arc;
 
-#[cfg(feature = "logging")]
-use slog::{Never, SendSyncRefUnwindSafeDrain};
+    // NOTE: we technically don't need a feature gate here, but if we don't add
+    // it then docs don't mark this re-export as available on when `logging` is
+    // enabled.
+    pub use slog::Level;
 
-/// A custom slog drain for use with [`LogOutput::Custom`].
-#[cfg(feature = "logging")]
-pub type CustomDrain = Arc<dyn SendSyncRefUnwindSafeDrain<Ok = (), Err = Never>>;
+    /// A custom slog drain for use with [`LogOutput::Custom`].
+    pub type CustomDrain = Arc<dyn SendSyncRefUnwindSafeDrain<Ok = (), Err = Never>>;
+});
 
 feature_use!(cfg(feature = "settings"), {
     use crate::settings::settings;
 });
-
-// NOTE: we technically don't need a feature gate here, but if we don't add it then docs don't
-// mark this re-export as available on when `logging` is enabled.
-#[cfg(feature = "logging")]
-pub use slog::Level;
 
 /// Logging settings.
 #[cfg_attr(feature = "settings", settings(crate_path = "crate"))]

--- a/foundations/src/telemetry/settings/logging.rs
+++ b/foundations/src/telemetry/settings/logging.rs
@@ -3,6 +3,16 @@ use crate::utils::feature_use;
 
 use std::path::PathBuf;
 
+#[cfg(feature = "logging")]
+use std::sync::Arc;
+
+#[cfg(feature = "logging")]
+use slog::{Never, SendSyncRefUnwindSafeDrain};
+
+/// A custom slog drain for use with [`LogOutput::Custom`].
+#[cfg(feature = "logging")]
+pub type CustomDrain = Arc<dyn SendSyncRefUnwindSafeDrain<Ok = (), Err = Never>>;
+
 feature_use!(cfg(feature = "settings"), {
     use crate::settings::settings;
 });
@@ -39,8 +49,11 @@ pub struct LoggingSettings {
 }
 
 /// Log output destination.
-#[cfg_attr(feature = "settings", settings(crate_path = "crate"))]
-#[cfg_attr(not(feature = "settings"), derive(Clone, Debug, Default))]
+#[cfg_attr(
+    feature = "settings",
+    settings(crate_path = "crate", impl_debug = false)
+)]
+#[cfg_attr(not(feature = "settings"), derive(Clone, Default))]
 pub enum LogOutput {
     /// Write log to terminal.
     #[default]
@@ -58,6 +71,48 @@ pub enum LogOutput {
     ///verbosity will not be respected
     #[cfg(feature = "tracing-rs-compat")]
     TracingRsCompat,
+
+    /// User-provided drain. Not serializable — set programmatically only.
+    ///
+    /// [`LogFormat`] is ignored for this variant; the custom drain is responsible for its
+    /// own formatting. All other [`LoggingSettings`] (verbosity, field redaction, rate
+    /// limiting) still apply.
+    ///
+    /// # Examples
+    ///
+    /// Combine a terminal drain with a JSON file drain:
+    ///
+    /// ```ignore
+    /// use slog::{Drain, Duplicate};
+    /// use slog_term::{FullFormat, TermDecorator};
+    /// use slog_json::Json;
+    /// use std::fs::File;
+    /// use std::sync::Arc;
+    ///
+    /// let term = FullFormat::new(TermDecorator::new().build()).build().fuse();
+    /// let file = File::create("/var/log/app.json").unwrap();
+    /// let json = Json::new(file).build().fuse();
+    /// let combined = Duplicate::new(term, json).fuse();
+    ///
+    /// settings.logging.output = LogOutput::Custom(Arc::new(combined));
+    /// ```
+    #[cfg(feature = "logging")]
+    #[cfg_attr(feature = "settings", serde(skip))]
+    Custom(CustomDrain),
+}
+
+impl std::fmt::Debug for LogOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Terminal => write!(f, "Terminal"),
+            Self::Stderr => write!(f, "Stderr"),
+            Self::File(path) => f.debug_tuple("File").field(path).finish(),
+            #[cfg(feature = "tracing-rs-compat")]
+            Self::TracingRsCompat => write!(f, "TracingRsCompat"),
+            #[cfg(feature = "logging")]
+            Self::Custom(_) => write!(f, "Custom(...)"),
+        }
+    }
 }
 
 /// Format of the log output.

--- a/foundations/src/telemetry/testing.rs
+++ b/foundations/src/telemetry/testing.rs
@@ -88,6 +88,22 @@ impl TestTelemetryContext {
         self.log_records = log_records;
     }
 
+    /// Overrides the logging settings on the test telemetry context with a custom drain.
+    ///
+    /// Records are forwarded to the custom drain **and** captured for assertions via
+    /// [`log_records`][Self::log_records].
+    #[cfg(feature = "logging")]
+    pub fn set_custom_log_drain(
+        &mut self,
+        logging_settings: LoggingSettings,
+        custom_drain: super::settings::CustomDrain,
+    ) {
+        use crate::telemetry::log::testing::create_test_log_for_custom;
+        let (log, log_records) = create_test_log_for_custom(&logging_settings, custom_drain);
+        *self.inner.log.write() = log;
+        self.log_records = log_records;
+    }
+
     /// Overrides the logging settings on the test telemetry context with the tracing-rs compat
     /// layer. The `logging_settings` provided must use the [tracing compat] output format
     ///

--- a/foundations/src/telemetry/testing.rs
+++ b/foundations/src/telemetry/testing.rs
@@ -50,10 +50,13 @@ impl TestTelemetryContext {
     pub(crate) fn new() -> Self {
         #[cfg(feature = "logging")]
         let (log, log_records) = {
-            create_test_log(&LoggingSettings {
-                verbosity: LogVerbosity::Trace,
-                ..Default::default()
-            })
+            create_test_log(
+                &LoggingSettings {
+                    verbosity: LogVerbosity::Trace,
+                    ..Default::default()
+                },
+                None::<slog::Discard>,
+            )
         };
 
         #[cfg(feature = "tracing")]
@@ -83,7 +86,7 @@ impl TestTelemetryContext {
     /// with the settings
     #[cfg(feature = "logging")]
     pub fn set_logging_settings(&mut self, logging_settings: LoggingSettings) {
-        let (log, log_records) = { create_test_log(&logging_settings) };
+        let (log, log_records) = { create_test_log(&logging_settings, None::<slog::Discard>) };
         *self.inner.log.write() = log;
         self.log_records = log_records;
     }
@@ -98,8 +101,7 @@ impl TestTelemetryContext {
         logging_settings: LoggingSettings,
         custom_drain: super::settings::CustomDrain,
     ) {
-        use crate::telemetry::log::testing::create_test_log_for_custom;
-        let (log, log_records) = create_test_log_for_custom(&logging_settings, custom_drain);
+        let (log, log_records) = create_test_log(&logging_settings, Some(custom_drain));
         *self.inner.log.write() = log;
         self.log_records = log_records;
     }

--- a/foundations/tests/custom_drain.rs
+++ b/foundations/tests/custom_drain.rs
@@ -26,7 +26,7 @@ impl Drain for CapturingDrain {
 fn custom_drain_receives_log_records(mut ctx: TestTelemetryContext) {
     let messages = Arc::new(Mutex::new(Vec::new()));
     let drain = CapturingDrain {
-        messages: messages.clone(),
+        messages: Arc::clone(&messages),
     };
 
     ctx.set_custom_log_drain(LoggingSettings::default(), Arc::new(drain));

--- a/foundations/tests/custom_drain.rs
+++ b/foundations/tests/custom_drain.rs
@@ -1,0 +1,42 @@
+use std::sync::{Arc, Mutex};
+
+use foundations::telemetry::log::error;
+use foundations::telemetry::settings::LoggingSettings;
+use foundations::telemetry::TestTelemetryContext;
+use foundations_macros::with_test_telemetry;
+use slog::{Drain, Never, OwnedKVList, Record};
+
+struct CapturingDrain {
+    messages: Arc<Mutex<Vec<String>>>,
+}
+
+impl Drain for CapturingDrain {
+    type Ok = ();
+    type Err = Never;
+
+    fn log(&self, record: &Record, _: &OwnedKVList) -> Result<(), Never> {
+        self.messages
+            .lock()
+            .unwrap()
+            .push(format!("{}", record.msg()));
+        Ok(())
+    }
+}
+
+#[with_test_telemetry(test)]
+fn custom_drain_receives_log_records(mut ctx: TestTelemetryContext) {
+    let messages = Arc::new(Mutex::new(Vec::new()));
+    let drain = CapturingDrain {
+        messages: messages.clone(),
+    };
+
+    ctx.set_custom_log_drain(LoggingSettings::default(), Arc::new(drain));
+
+    error!("hello from custom drain");
+
+    let msgs = messages.lock().unwrap();
+    assert!(
+        msgs.iter().any(|m| m.contains("hello from custom drain")),
+        "custom drain did not receive the expected log record; got: {msgs:?}"
+    );
+}

--- a/foundations/tests/custom_drain.rs
+++ b/foundations/tests/custom_drain.rs
@@ -1,8 +1,8 @@
 use std::sync::{Arc, Mutex};
 
+use foundations::telemetry::TestTelemetryContext;
 use foundations::telemetry::log::error;
 use foundations::telemetry::settings::LoggingSettings;
-use foundations::telemetry::TestTelemetryContext;
 use slog::{Drain, Never, OwnedKVList, Record};
 
 struct CapturingDrain {

--- a/foundations/tests/custom_drain.rs
+++ b/foundations/tests/custom_drain.rs
@@ -3,7 +3,6 @@ use std::sync::{Arc, Mutex};
 use foundations::telemetry::log::error;
 use foundations::telemetry::settings::LoggingSettings;
 use foundations::telemetry::TestTelemetryContext;
-use foundations_macros::with_test_telemetry;
 use slog::{Drain, Never, OwnedKVList, Record};
 
 struct CapturingDrain {
@@ -23,7 +22,7 @@ impl Drain for CapturingDrain {
     }
 }
 
-#[with_test_telemetry(test)]
+#[foundations::telemetry::with_test_telemetry(test)]
 fn custom_drain_receives_log_records(mut ctx: TestTelemetryContext) {
     let messages = Arc::new(Mutex::new(Vec::new()));
     let drain = CapturingDrain {


### PR DESCRIPTION
Add a Custom variant to LogOutput that accepts an Arc<dyn CustomDrain>.  This allows users to provide their own slog drain (e.g., for Sentry integration) without needing wrapper macros or other workarounds.

The custom drain:
- Receives the same downstream wrapping as built-in drains (field dedup, field redaction, etc.)
- Is not serializable (must be set in code, not YAML)
- Ignores LogFormat (responsible for its own formatting)

The Custom variant uses Arc<dyn ...> instead of Box<dyn ...> because:

1. LogOutput must be Clone because LoggingSettings is cloned in telemetry::init(). Box<dyn ...> is not Clone.

2. telemetry::init() receives &LoggingSettings. A Box cannot be moved out of a shared reference, but an Arc can be cheaply cloned from one. Changing init() to take ownership would be a breaking API change.

Co–authored–by: Claude Opus 4.6