### PR TITLE
Release 5.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "5.7.0"
+version = "5.7.1"
 repository = "https://github.com/cloudflare/foundations"
 edition = "2024"
 authors = ["Cloudflare"]
@@ -39,8 +39,8 @@ check-cfg = [
 [workspace.dependencies]
 anyhow = "1.0.102"
 backtrace = "0.3.76"
-foundations = { version = "5.7.0", path = "./foundations", default-features = false }
-foundations-macros = { version = "=5.7.0", path = "./foundations-macros", default-features = false }
+foundations = { version = "5.7.1", path = "./foundations", default-features = false }
+foundations-macros = { version = "=5.7.1", path = "./foundations-macros", default-features = false }
 bindgen = { version = "0.72.1", default-features = false }
 cc = "1.2.61"
 cf-rustracing = "1.3.0"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 
+5.7.1
+- 2026-05-19 chore: Exclude prefixed tags from git-cliff
+- 2026-05-18 feedback: -D clippy::clone_on_ref_ptr
+- 2026-05-18 feedback: formatting
+- 2026-05-18 feedback: create_test_log
+- 2026-05-18 feedback: fqn macro
+- 2026-05-18 feedback: feature_use
+- 2026-05-14 feat: add LogOutput::Custom variant for user-provided slog drains
+- 2026-05-13 ci(semgrep): pin token to contents: read
+
 5.7.0
+- 2026-05-11 chore: Release
 - 2026-05-11 fix: rustix 0.36 breaks under nightly
 - 2026-05-07 Allow pattern-based routes in TelemetryServer
 - 2026-04-27 chore: Release

--- a/cliff.toml
+++ b/cliff.toml
@@ -20,5 +20,5 @@ commit_parsers = [
   { message = "^Pull request", skip = true }
 ]
 filter_commits = false
-tag_pattern = "v[0-9]*"
+tag_pattern = "^v[0-9]*"
 sort_commits = "newest"


### PR DESCRIPTION
### Added
- A new `LogOutput::Custom` variant allows users to programatically specify their own `slog::Drain` implementation for advanced use cases, like duplicating logs to multiple downstream drains. (#206)