### PR TITLE
Gracefully degrade on metrics encoding failures

### DIFF
--- a/foundations-macros/src/metrics/mod.rs
+++ b/foundations-macros/src/metrics/mod.rs
@@ -344,7 +344,7 @@ fn metric_init(foundations: &Path, fn_: &ItemFn) -> proc_macro2::TokenStream {
                 #registry,
                 ::std::stringify!(#field_name),
                 str::trim(#doc),
-                ::std::boxed::Box::new(::std::clone::Clone::clone(&metric))
+                #foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
             );
 
             metric
@@ -519,7 +519,7 @@ mod tests {
                                     registry,
                                     ::std::stringify!(connections_total),
                                     str::trim(" Total number of connections"),
-                                    ::std::boxed::Box::new(::std::clone::Clone::clone(&metric))
+                                    tarmac::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
                                 );
 
                                 metric
@@ -576,7 +576,7 @@ mod tests {
                                     opt_registry,
                                     ::std::stringify!(connections_total),
                                     str::trim(" Total number of connections"),
-                                    ::std::boxed::Box::new(::std::clone::Clone::clone(&metric))
+                                    ::foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
                                 );
 
                                 metric
@@ -638,7 +638,7 @@ mod tests {
                                     registry,
                                     ::std::stringify!(requests_total),
                                     str::trim(" Total number of requests"),
-                                    ::std::boxed::Box::new(::std::clone::Clone::clone(&metric))
+                                    ::foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
                                 );
 
                                 metric
@@ -650,7 +650,7 @@ mod tests {
                                     opt_registry,
                                     ::std::stringify!(connections_total),
                                     str::trim(" Total number of connections"),
-                                    ::std::boxed::Box::new(::std::clone::Clone::clone(&metric))
+                                    ::foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
                                 );
 
                                 metric
@@ -742,7 +742,7 @@ mod tests {
                                     registry,
                                     ::std::stringify!(connections_errors_total),
                                     str::trim(" Total number of connection errors"),
-                                    ::std::boxed::Box::new(::std::clone::Clone::clone(&metric))
+                                    ::foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
                                 );
 
                                 metric
@@ -840,7 +840,7 @@ mod tests {
                                     registry,
                                     ::std::stringify!(connections_latency),
                                     str::trim(" Latency of connections"),
-                                    ::std::boxed::Box::new(::std::clone::Clone::clone(&metric))
+                                    ::foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
                                 );
 
                                 metric
@@ -854,7 +854,7 @@ mod tests {
                                     registry,
                                     ::std::stringify!(requests_per_connection),
                                     str::trim(" Number of requests per connection"),
-                                    ::std::boxed::Box::new(::std::clone::Clone::clone(&metric))
+                                    ::foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
                                 );
 
                                 metric
@@ -943,7 +943,7 @@ mod tests {
                                     registry,
                                     ::std::stringify!(requests_total),
                                     str::trim(" Total number of requests"),
-                                    ::std::boxed::Box::new(::std::clone::Clone::clone(&metric))
+                                    ::foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
                                 );
 
                                 metric

--- a/foundations/src/telemetry/metrics/internal.rs
+++ b/foundations/src/telemetry/metrics/internal.rs
@@ -1,7 +1,9 @@
-use super::{ExtraProducer, InfoMetric, info_metric};
+use super::rewind::{RewindState, RewindTo};
+use super::{ExtraProducer, InfoMetric, info_metric, report_nonfatal_collect_error};
 use crate::telemetry::settings::{MetricsSettings, ServiceNameFormat};
 use crate::{Result, ServiceInfo};
-use prometheus_client::encoding::text::{EncodeMetric, encode};
+use prometheus_client::encoding::text::{EncodeMetric, Encoder, SendSyncEncodeMetric, encode};
+use prometheus_client::metrics::MetricType;
 use prometheus_client::registry::Registry;
 use prometools::serde::InfoGauge;
 use std::any::TypeId;
@@ -90,6 +92,7 @@ impl Registries {
 
         for info_metric in info_registry.values() {
             let info_gauge = InfoGauge::new(&**info_metric);
+            let info_gauge = RewindErrorEncode(info_gauge);
 
             registry.register(info_metric.name(), info_metric.help(), info_gauge)
         }
@@ -176,11 +179,50 @@ where
     }
 }
 
-pub(super) fn encode_registry(
-    buffer: &mut Vec<u8>,
-    registry: &Registry<impl EncodeMetric>,
-) -> Result<()> {
-    encode(buffer, registry)?;
+std::thread_local! {
+    static ENCODER_REWIND_STATE: RewindState = const { RewindState::new() };
+}
+
+struct RewindErrorEncode<M>(M);
+
+impl<M: EncodeMetric> EncodeMetric for RewindErrorEncode<M> {
+    fn encode(&self, encoder: Encoder) -> std::io::Result<()> {
+        let mut res = self.0.encode(encoder);
+
+        // If encoding the metric failed, and we are inside a rewindable encoder,
+        // discard the error and rewind the encoder to the last newline to avoid
+        // garbage output.
+        if res.is_err() {
+            let _ = ENCODER_REWIND_STATE.try_with(|s| {
+                if s.is_active() {
+                    s.rewind_to(RewindTo::LastNewline);
+                    let err = std::mem::replace(&mut res, Ok(())).unwrap_err();
+                    report_nonfatal_collect_error(&format_args!(
+                        "encoding metric or family: {err}"
+                    ));
+                }
+            });
+        }
+
+        res
+    }
+
+    #[inline]
+    fn metric_type(&self) -> MetricType {
+        self.0.metric_type()
+    }
+}
+
+/// Wraps a metric in our private error-handling type, without making the type public.
+pub fn wrap_metric(metric: impl SendSyncEncodeMetric + 'static) -> Box<dyn SendSyncEncodeMetric> {
+    Box::new(RewindErrorEncode(metric))
+}
+
+fn encode_registry(buffer: &mut Vec<u8>, registry: &Registry<impl EncodeMetric>) -> Result<()> {
+    ENCODER_REWIND_STATE.with(|s| {
+        let mut writer = s.activate(buffer);
+        encode(&mut writer, registry)
+    })?;
 
     truncate_eof(buffer);
 
@@ -188,7 +230,8 @@ pub(super) fn encode_registry(
 }
 
 fn truncate_eof(buffer: &mut Vec<u8>) {
-    if buffer.ends_with(b"# EOF\n") {
-        buffer.truncate(buffer.len() - b"# EOF\n".len());
+    const EOF_MARKER: &[u8] = b"# EOF\n";
+    if buffer.ends_with(EOF_MARKER) {
+        buffer.truncate(buffer.len() - EOF_MARKER.len());
     }
 }

--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -14,8 +14,10 @@ use crate::Result;
 use prometheus::{Encoder, TextEncoder};
 use serde::Serialize;
 use std::any::TypeId;
+use std::fmt::Display;
 
 mod gauge;
+mod rewind;
 
 pub(super) mod init;
 
@@ -44,7 +46,21 @@ pub fn collect(settings: &MetricsSettings) -> Result<String> {
 
     buffer.extend_from_slice(b"# EOF\n");
 
-    Ok(String::from_utf8(buffer)?)
+    let metrics_str = String::from_utf8(buffer).unwrap_or_else(|err| {
+        report_nonfatal_collect_error(&format_args!("converting raw metrics to string: {err}"));
+        String::from_utf8_lossy(err.as_bytes()).into_owned()
+    });
+    Ok(metrics_str)
+}
+
+#[inline]
+#[track_caller]
+fn report_nonfatal_collect_error(err: &dyn Display) {
+    #[cfg(feature = "logging")]
+    crate::telemetry::log::warn!("non-fatal error while collecting metrics"; "error" => %err);
+
+    #[cfg(not(feature = "logging"))]
+    eprintln!("non-fatal error while collecting metrics: {err}");
 }
 
 /// A macro that allows to define Prometheus metrics.

--- a/foundations/src/telemetry/metrics/rewind.rs
+++ b/foundations/src/telemetry/metrics/rewind.rs
@@ -1,0 +1,161 @@
+use std::cell::Cell;
+use std::io::{self, Write};
+
+#[derive(Default, Clone, Copy)]
+pub(crate) enum RewindTo {
+    #[default]
+    None,
+    LastNewline,
+}
+
+pub(crate) struct RewindState {
+    active: Cell<bool>,
+    rewind_to: Cell<RewindTo>,
+}
+
+impl RewindState {
+    pub(crate) const fn new() -> Self {
+        Self {
+            active: Cell::new(false),
+            rewind_to: Cell::new(RewindTo::None),
+        }
+    }
+
+    #[track_caller]
+    pub(crate) fn activate<'a>(&'a self, buf: &'a mut Vec<u8>) -> RewindableWriter<'a> {
+        let was_active = self.active.replace(true);
+        assert!(!was_active, "this state already has an associated writer");
+
+        self.rewind_to.set(RewindTo::None);
+        RewindableWriter {
+            out: buf,
+            state: self,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn is_active(&self) -> bool {
+        self.active.get()
+    }
+
+    #[inline]
+    pub(crate) fn rewind_to(&self, to: RewindTo) {
+        debug_assert!(self.is_active(), "rewind attempted without writer");
+        self.rewind_to.set(to);
+    }
+
+    fn reset(&self) {
+        self.active.set(false);
+        self.rewind_to.set(RewindTo::None);
+    }
+}
+
+pub(crate) struct RewindableWriter<'a> {
+    out: &'a mut Vec<u8>,
+    state: &'a RewindState,
+}
+
+impl<'a> RewindableWriter<'a> {
+    fn apply_rewind(&mut self) {
+        match self.state.rewind_to.take() {
+            RewindTo::None => {}
+            RewindTo::LastNewline => {
+                if let Some(newline_idx) = self.out.iter().rposition(|v| *v == b'\n') {
+                    // Keep the newline itself in the buffer
+                    self.out.truncate(newline_idx + 1);
+                }
+            }
+        }
+    }
+}
+
+impl Write for RewindableWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.apply_rewind();
+        Write::write(self.out, buf)
+    }
+
+    fn write_vectored(&mut self, bufs: &[io::IoSlice]) -> io::Result<usize> {
+        self.apply_rewind();
+        Write::write_vectored(self.out, bufs)
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.apply_rewind();
+        Write::write_all(self.out, buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.apply_rewind();
+        Write::flush(self.out)
+    }
+}
+
+impl Drop for RewindableWriter<'_> {
+    fn drop(&mut self) {
+        self.apply_rewind();
+        self.state.reset();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    #[should_panic(expected = "this state already has an associated writer")]
+    fn second_writer_panics() {
+        let state = RewindState::new();
+        let mut buf = Vec::new();
+        let mut other_buf = Vec::new();
+
+        let _writer = state.activate(&mut buf);
+        let _other_writer = state.activate(&mut other_buf);
+        // The second activate call should panic
+    }
+
+    #[test]
+    fn rewind_newline() {
+        let state = RewindState::new();
+        let mut buf = b"line 1\nline 2".to_vec();
+
+        {
+            // No rewind initially
+            let mut writer = state.activate(&mut buf);
+            writer.write_all(b" before rewind").unwrap();
+            assert_eq!(writer.out, b"line 1\nline 2 before rewind");
+
+            // Rewind is applied on next write
+            state.rewind_to(RewindTo::LastNewline);
+            writer.write_all(b"different line\nafter rewind").unwrap();
+            assert_eq!(writer.out, b"line 1\ndifferent line\nafter rewind");
+
+            // Rewind is applied on flush
+            state.rewind_to(RewindTo::LastNewline);
+            writer.flush().unwrap();
+            assert_eq!(writer.out, b"line 1\ndifferent line\n");
+
+            // Rewind is cleared after being applied above
+            writer.write_all(b"after clear").unwrap();
+        }
+
+        assert_eq!(buf, b"line 1\ndifferent line\nafter clear");
+    }
+
+    #[test]
+    fn rewind_newline_on_drop() {
+        let state = RewindState::new();
+        let mut buf = Vec::new();
+
+        {
+            let mut writer = state.activate(&mut buf);
+            writer.write_all(b"line 1\nline 2").unwrap();
+
+            // Rewind is also applied when writer drops
+            state.rewind_to(RewindTo::LastNewline);
+        }
+
+        assert_eq!(buf, b"line 1\n");
+    }
+}

--- a/foundations/tests/metrics.rs
+++ b/foundations/tests/metrics.rs
@@ -1,5 +1,5 @@
 use foundations::ServiceInfo;
-use foundations::telemetry::metrics::{self, Counter, metrics};
+use foundations::telemetry::metrics::{self, Counter, Family, metrics};
 use foundations::telemetry::settings::{MetricsSettings, ServiceNameFormat, TelemetrySettings};
 use foundations::telemetry::{TelemetryConfig, TelemetryContext};
 
@@ -18,6 +18,14 @@ mod library {
     pub fn calls() -> Counter;
     #[optional]
     pub fn optional() -> Counter;
+}
+
+#[metrics]
+mod encode_error {
+    pub fn valid() -> Counter;
+    // `String` is not a valid label for a metric family, but since
+    // we use serde to encode labels, this is only detected at runtime.
+    pub fn invalid_label() -> Family<String, Counter>;
 }
 
 #[test]
@@ -49,6 +57,43 @@ fn metrics_unprefixed() {
     assert!(!metrics.contains("\nundefined_regular_dynamic"));
     assert!(metrics.contains("\nlibrary_calls 1\n"));
     assert!(!metrics.contains("\nlibrary_optional"));
+}
+
+#[test]
+fn encode_error_is_skipped() {
+    encode_error::valid().inc();
+    encode_error::invalid_label()
+        .get_or_create(&"bad label".to_owned())
+        .inc();
+    encode_error::invalid_label()
+        .get_or_create(&"another label".to_owned())
+        .inc();
+
+    // Note the absence of values for the `error_invalid_label` family
+    let expected_output = "# HELP undefined_encode_error_valid .
+# TYPE undefined_encode_error_valid counter
+undefined_encode_error_valid 1
+# HELP undefined_encode_error_invalid_label .
+# TYPE undefined_encode_error_invalid_label counter
+";
+
+    let settings = MetricsSettings {
+        service_name_format: ServiceNameFormat::MetricPrefix,
+        report_optional: false,
+    };
+    let metrics = metrics::collect(&settings).expect("metrics should be collectable");
+    dbg!(&metrics);
+
+    // On some OSs, process metrics may be automatically registered.
+    // They will appear last in the output.
+    let metrics_suffix = metrics
+        .strip_prefix(expected_output)
+        .expect("collected metrics should start with expected output");
+    assert!(
+        !metrics_suffix.contains(" undefined_"),
+        "collected metrics contain unexpected output"
+    );
+    assert!(metrics.ends_with("# EOF\n"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
By default, `prometheus-client` aborts metrics collection/encoding on _any_ error. This means one error from the EncodeMetric implementation of a single metric in a Registry makes all the metrics in that Registry unavailable.

To avoid this, we introduce an EncodeMetric wrapper that swallows errors (after reporting them via logging/`eprintln!`.) Due to the way `prometheus-client` is designed, this could leave a partially-written metrics line in the output. We fix this by introducing `RewindableWriter`, a `Write` implementation that we can rewind to the last newline in case we do see an error.

`prometheus-client` does not give us access to the underlying writer in EncodeMetric impls, so we are forced to use a side channel via thread-local storage to activate the rewind behavior.