### PR TITLE
Release foundations 5.7.2 and foundations-sentry 1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "5.7.1"
+version = "5.7.2"
 repository = "https://github.com/cloudflare/foundations"
 edition = "2024"
 authors = ["Cloudflare"]
@@ -39,8 +39,8 @@ check-cfg = [
 [workspace.dependencies]
 anyhow = "1.0.102"
 backtrace = "0.3.76"
-foundations = { version = "5.7.1", path = "./foundations", default-features = false }
-foundations-macros = { version = "=5.7.1", path = "./foundations-macros", default-features = false }
+foundations = { version = "5.7.2", path = "./foundations", default-features = false }
+foundations-macros = { version = "=5.7.2", path = "./foundations-macros", default-features = false }
 bindgen = { version = "0.72.1", default-features = false }
 cc = "1.2.61"
 cf-rustracing = "1.3.0"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,9 @@
 
+5.7.2
+- 2026-06-05 fix: strip plain release commits from RELEASE_NOTES.md
+- 2026-06-02 Gracefully degrade on metrics encoding failures
+- 2026-05-29 Add NoFlushPanicIntegration for sentry
+
 5.7.1
 - 2026-05-19 chore: Exclude prefixed tags from git-cliff
 - 2026-05-18 feedback: -D clippy::clone_on_ref_ptr
@@ -10,10 +15,8 @@
 - 2026-05-13 ci(semgrep): pin token to contents: read
 
 5.7.0
-- 2026-05-11 chore: Release
 - 2026-05-11 fix: rustix 0.36 breaks under nightly
 - 2026-05-07 Allow pattern-based routes in TelemetryServer
-- 2026-04-27 chore: Release
 - 2026-04-27 Configure cargo-release for separately-versioned crates
 - 2026-04-27 Extract sentry hook into separate foundations-sentry crate
 - 2026-04-24 Update dependencies.

--- a/cliff.toml
+++ b/cliff.toml
@@ -17,7 +17,8 @@ footer = ""
 [git]
 conventional_commits = false
 commit_parsers = [
-  { message = "^Pull request", skip = true }
+  { message = "^Pull request", skip = true },
+  { message = "^chore: Release$", skip = true },
 ]
 filter_commits = false
 tag_pattern = "^v[0-9]*"

--- a/foundations-sentry/Cargo.toml
+++ b/foundations-sentry/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "foundations-sentry"
 description = "Foundations companion crate with Sentry integrations"
-version = "1.0.0"
+version = "1.1.0"
 edition = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }

--- a/foundations-sentry/RELEASE_NOTES.md
+++ b/foundations-sentry/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 
-1.0.0
+1.1.0
+- 2026-05-29 Add NoFlushPanicIntegration for sentry
+
+foundations-sentry-v1.0.0
 - 2026-04-27 Configure cargo-release for separately-versioned crates
 - 2026-04-27 Extract sentry hook into separate foundations-sentry crate
 


### PR DESCRIPTION
### foundations 5.7.2
- Fixed: Metrics whose `EncodeMetric` implementation returns an `Err` result at runtime don't cause the `/metrics` endpoint to return a 500 status code anymore. Instead, a wrapper inside foundations swallows the error and logs it at WARN level. The output is rewound to the last written newline to ensure it remains OpenMetrics compliant.

### foundations-sentry 1.1.0
- Added: `foundations_sentry::panic::NoFlushPanicIntegration` is a variant of sentry's default panic handler integration which emits the same events, but without an explicit flush after each panic. This significantly reduces the time spent inside the panic handler, but at the cost of losing events if the process aborts due to double-panic.