### PR TITLE
Add cfg(foundations_jemalloc_disable) to opt out of global jemalloc allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ debug = 1
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-    'cfg(foundations_generic_telemetry_wrapper)',
     'cfg(foundations_unstable)',
     'cfg(tokio_unstable)',
+    'cfg(foundations_generic_telemetry_wrapper)',
     # for docs.rs builds only
     'cfg(foundations_docsrs)',
     # slog feature

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ level = "warn"
 check-cfg = [
     'cfg(foundations_unstable)',
     'cfg(tokio_unstable)',
+    'cfg(foundations_jemalloc_disable)',
     'cfg(foundations_generic_telemetry_wrapper)',
     # for docs.rs builds only
     'cfg(foundations_docsrs)',

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "5.7.2"
+version = "5.7.3"
 repository = "https://github.com/cloudflare/foundations"
 edition = "2024"
 authors = ["Cloudflare"]
@@ -40,8 +40,8 @@ check-cfg = [
 [workspace.dependencies]
 anyhow = "1.0.102"
 backtrace = "0.3.76"
-foundations = { version = "5.7.2", path = "./foundations", default-features = false }
-foundations-macros = { version = "=5.7.2", path = "./foundations-macros", default-features = false }
+foundations = { version = "5.7.3", path = "./foundations", default-features = false }
+foundations-macros = { version = "=5.7.3", path = "./foundations-macros", default-features = false }
 bindgen = { version = "0.72.1", default-features = false }
 cc = "1.2.61"
 cf-rustracing = "1.3.0"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,9 @@
 
+5.7.3
+- 2026-06-10 Add cfg(foundations_jemalloc_disable) to opt out of global jemalloc allocator
+- 2026-06-10 Move cfg(foundations_generic_telemetry_wrapper) docs out of lib.rs
+- 2026-06-05 Add actions pipeline for trusted publishing to crates.io
+
 5.7.2
 - 2026-06-05 fix: strip plain release commits from RELEASE_NOTES.md
 - 2026-06-02 Gracefully degrade on metrics encoding failures

--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -204,10 +204,10 @@ tracing-rs-compat = ["dep:tracing-slog"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "foundations_docsrs", "--cfg", "tokio_unstable", "--cfg", "foundations_unstable", "--cfg", "foundations_generic_telemetry_wrapper"]
+rustdoc-args = ["--cfg", "foundations_docsrs", "--cfg", "tokio_unstable", "--cfg", "foundations_unstable"]
 # it's necessary to _also_ pass `--cfg tokio_unstable` and `--cfg foundations_unstable`
 # to rustc, or else dependencies will not be enabled, and the docs build will fail.
-rustc-args = ["--cfg", "tokio_unstable", "--cfg", "foundations_unstable", "--cfg", "foundations_generic_telemetry_wrapper"]
+rustc-args = ["--cfg", "tokio_unstable", "--cfg", "foundations_unstable"]
 
 [lints]
 workspace = true

--- a/foundations/src/lib.rs
+++ b/foundations/src/lib.rs
@@ -39,6 +39,9 @@
 //! - **security**: Enables security features. Available only on Linux (x86_64, aarch64) with the `libclang-dev` package installed (for bindgen).
 //! - **jemalloc**: Enables [jemalloc] memory allocator which is known to perform much better than
 //!   system allocators for long living service.
+//!   - There is an opt-out available by passing `--cfg foundations_jemalloc_disable`
+//!     to rustc (e.g., via `RUSTFLAGS`). This can be used as a workaround for the additive
+//!     nature of features.
 //! - **memory-profiling**: Enables memory profiling functionality and telemetry. Implicity enables
 //!   **jemalloc** feature.
 //! - **cli**: Enables command line interface (CLI) functionality. Implicitly enabled **settings**
@@ -121,16 +124,20 @@ pub mod reexports_for_macros {
 
 /// Global memory allocator backed by [jemalloc].
 ///
-/// This static variable is exposed solely for the documentation purposes and don't need to be used
-/// directly. If **jemalloc** feature is enabled then the service will use jemalloc for all the
-/// memory allocations implicitly.
+/// This static variable is exposed solely for documentation purposes and doesn't need to be used
+/// directly. If the **jemalloc** feature is enabled then the service will use jemalloc for all
+/// memory allocations implicitly. This can be disabled again in final builds by passing
+/// `--cfg foundations_jemalloc_disable` to rustc (e.g., via `RUSTFLAGS`). Doing so is necessary
+/// when the _jemalloc_ feature was mistakenly enabled by a dependency or when debugging with
+/// [Address Sanitizer][asan].
 ///
 /// If no Foundations API is being used by your project, you will need to explicitly link foundations crate
 /// to your project by adding `extern crate foundations;` to your `main.rs` or `lib.rs`, for jemalloc to
 /// be embedded in your binary.
 ///
 /// [jemalloc]: https://github.com/jemalloc/jemalloc
-#[cfg(feature = "jemalloc")]
+/// [asan]: https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html#addresssanitizer
+#[cfg(all(feature = "jemalloc", not(foundations_jemalloc_disable)))]
 #[global_allocator]
 pub static JEMALLOC_MEMORY_ALLOCATOR: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/foundations/src/lib.rs
+++ b/foundations/src/lib.rs
@@ -44,13 +44,6 @@
 //! - **cli**: Enables command line interface (CLI) functionality. Implicitly enabled **settings**
 //!   feature.
 //!
-//! # Generic telemetry
-//! Foundations currently box the future with TelemetryContext by default. A default generic
-//! wrapper is gated behind `--cfg foundations_generic_telemetry_wrapper`.
-//!
-//! To enable this, you must add `--cfg foundations_generic_telemetry_wrapper` to your RUSTFLAGS
-//! environment variable.
-//!
 //! # Unstable Features
 //! Foundations has unstable features which are gated behind `--cfg foundations_unstable`:
 //!

--- a/foundations/src/telemetry/tracing/mod.rs
+++ b/foundations/src/telemetry/tracing/mod.rs
@@ -46,7 +46,10 @@ pub fn get_active_traces() -> String {
 /// call lasts.
 ///
 /// The macro works both for sync and async methods and also for the [async_trait] method
-/// implementations.
+/// implementations. `async fn`s are boxed before wrapping by default, but this can be
+/// bypassed by specifying `generic = true` in the macro invocation. To make `generic` the
+/// default, you can pass `--cfg foundations_generic_telemetry_wrapper` to rustc (e.g., via
+/// `RUSTFLAGS`).
 ///
 /// # Example
 /// ```


### PR DESCRIPTION
Usually our advice would be to not enable the `jemalloc` cargo feature,
but this becomes difficult in large dependency trees where a user may
not necessarily control all dependencies that in turn depend on
foundations. Providing a flag to disable the `#[global_allocator]`
specifically allows such projects to build anyway.

This is also useful to enable ASAN builds, which otherwise wouldn't
cover allocations initiated from Rust.

Includes a release commit for `foundations 5.7.3`.