### PR TITLE
Fix bonk workflow by downgrading opencode

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -38,6 +38,7 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-6"
+          model: "cloudflare-ai-gateway/anthropic/claude-opus-4.8"
           mentions: "/bonk,@ask-bonk"
           permissions: write
+          opencode_version: "1.17.7"


### PR DESCRIPTION
The workflow doesnt work. It works in other repos which pin an older opencode version. Opencode 1.17.8 included a change to authorization for CF AI Gateway. Try downgrading to the version before that to see if it fixes the workflow.

Also switches the model to Opus 4.8.