### PR TITLE
Use a dash instead of a dot in bonk model name

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -38,7 +38,7 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          model: "cloudflare-ai-gateway/anthropic/claude-opus-4.8"
+          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-8"
           mentions: "/bonk,@ask-bonk"
           permissions: write
           opencode_version: "1.17.7"


### PR DESCRIPTION
The docs say to use `opus-4.8` but every other bonk config seems to use `opus-4-8`.