### PR TITLE
User Tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ foundations = { version = "5.7.4", path = "./foundations", default-features = fa
 foundations-macros = { version = "=5.7.4", path = "./foundations-macros", default-features = false }
 bindgen = { version = "0.72.1", default-features = false }
 cc = "1.2.61"
-cf-rustracing = "1.3.0"
+cf-rustracing = "1.4.0"
 cf-rustracing-jaeger = "1.3.0"
 clap = "4.6.1"
 crossbeam-utils = { version = "0.8.21", default-features = false }
@@ -53,6 +53,7 @@ darling = "0.23.0"
 erased-serde = "0.4.10"
 futures-util = "0.3.32"
 governor = "0.10.4"
+hex = "0.4.3"
 http = "1.4.0"
 http-body-util = "0.1.3"
 hyper = { version = "1.9.0", default-features = false }

--- a/foundations-macros/src/span_fn.rs
+++ b/foundations-macros/src/span_fn.rs
@@ -47,6 +47,9 @@ struct Options {
 
     #[darling(default = "Options::default_generic")]
     generic: bool,
+
+    #[darling(default = "Options::default_user")]
+    user: bool,
 }
 
 impl Options {
@@ -60,6 +63,10 @@ impl Options {
 
     fn default_generic() -> bool {
         cfg!(foundations_generic_telemetry_wrapper)
+    }
+
+    fn default_user() -> bool {
+        false
     }
 }
 
@@ -119,9 +126,10 @@ fn expand_from_parsed(args: Args, item_fn: ItemFn) -> TokenStream2 {
         None => try_async_trait_fn_rewrite(&args, &block).unwrap_or_else(|| {
             let span_name = args.span_name.as_tokens();
             let crate_path = &args.options.crate_path;
+            let span_ctor = span_ctor(&args.options);
 
             quote!(
-                let __span = #crate_path::telemetry::tracing::span(#span_name);
+                let __span = #crate_path::telemetry::tracing::#span_ctor(#span_name);
                 #block
             )
         }),
@@ -191,13 +199,24 @@ fn wrap_with_span(args: &Args, block: TokenStream2) -> TokenStream2 {
 
     let span_name = args.span_name.as_tokens();
     let crate_path = &args.options.crate_path;
+    let span_ctor = span_ctor(&args.options);
 
     quote!(
-        #crate_path::telemetry::tracing::span(#span_name)
+        #crate_path::telemetry::tracing::#span_ctor(#span_name)
             .into_context()
             .#apply_fn(#block)
             .await
     )
+}
+
+/// The span constructor to call: `dual_span` when `user = true` (internal + parallel user span),
+/// otherwise `span`.
+fn span_ctor(options: &Options) -> TokenStream2 {
+    if options.user {
+        quote!(dual_span)
+    } else {
+        quote!(span)
+    }
 }
 
 #[cfg(test)]
@@ -225,6 +244,36 @@ mod tests {
         let expected = code_str! {
             fn do_sync<>() -> io::Result<String> {
                 let __span = ::foundations::telemetry::tracing::span("sync_span");
+                {
+                    do_something_else();
+
+                    Ok("foo".into())
+                }
+            }
+        };
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn expand_sync_fn_user() {
+        let args = parse_attr! {
+            #[span_fn("sync_span", user = true)]
+        };
+
+        let item_fn = parse_quote! {
+            fn do_sync() -> io::Result<String> {
+                do_something_else();
+
+                Ok("foo".into())
+            }
+        };
+
+        let actual = expand_from_parsed(args, item_fn).to_string();
+
+        let expected = code_str! {
+            fn do_sync<>() -> io::Result<String> {
+                let __span = ::foundations::telemetry::tracing::dual_span("sync_span");
                 {
                     do_something_else();
 
@@ -285,6 +334,38 @@ mod tests {
         let expected = code_str! {
             async fn do_async<>() -> io::Result<String> {
                 ::foundations::telemetry::tracing::span("async_span")
+                    .into_context()
+                    .apply(async move {{
+                        do_something_else().await;
+
+                        Ok("foo".into())
+                    }})
+                    .await
+            }
+        };
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn expand_async_fn_user() {
+        let args = parse_attr! {
+            #[span_fn("async_span", user = true)]
+        };
+
+        let item_fn = parse_quote! {
+            async fn do_async() -> io::Result<String> {
+                do_something_else().await;
+
+                Ok("foo".into())
+            }
+        };
+
+        let actual = expand_from_parsed(args, item_fn).to_string();
+
+        let expected = code_str! {
+            async fn do_async<>() -> io::Result<String> {
+                ::foundations::telemetry::tracing::dual_span("async_span")
                     .into_context()
                     .apply(async move {{
                         do_something_else().await;

--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -148,6 +148,19 @@ tracing = [
     "dep:crossbeam-utils",
 ]
 
+# Enables distributed user tracing functionality.
+user-tracing = [
+    "tracing",
+    "dep:hex",
+    "dep:hyper",
+    "hyper/client",
+    "dep:hyper-util",
+    "dep:http-body-util",
+    "dep:serde_json",
+    "dep:prost",
+    "tokio/net",
+]
+
 # Enables metrics functionality.
 metrics = [
     "dep:foundations-macros",
@@ -223,6 +236,7 @@ crossbeam-utils = { workspace = true, optional = true }
 erased-serde = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }
 governor = { workspace = true, optional = true }
+hex = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
 http-body-util = { workspace = true, optional = true }
 hyper = { workspace = true, optional = true, features = ["http1", "server"] }
@@ -237,6 +251,7 @@ percent-encoding = { workspace = true, optional = true }
 prometheus = { workspace = true, optional = true, features = ["process"] }
 prometheus-client = { workspace = true, optional = true }
 prometools = { workspace = true, optional = true, features = ["serde"] }
+prost = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive", "rc"] }
 serde_json = { workspace = true, optional = true }

--- a/foundations/src/telemetry/mod.rs
+++ b/foundations/src/telemetry/mod.rs
@@ -73,7 +73,10 @@ mod scope;
 
 mod telemetry_context;
 
-#[cfg(all(feature = "tracing", feature = "telemetry-otlp-grpc"))]
+#[cfg(all(
+    feature = "tracing",
+    any(feature = "telemetry-otlp-grpc", feature = "user-tracing")
+))]
 mod otlp_conversion;
 
 #[cfg(feature = "testing")]
@@ -138,6 +141,12 @@ feature_use!(cfg(feature = "tracing"), {
         use self::tracing::testing::TestTracerScope;
     });
 });
+
+#[cfg(feature = "user-tracing")]
+use self::tracing::UserSpanScope;
+
+#[cfg(all(feature = "user-tracing", feature = "testing"))]
+use self::tracing::testing::UserTestTracerScope;
 
 #[cfg(feature = "logging")]
 use self::log::internal::LogScope;
@@ -260,11 +269,17 @@ pub struct TelemetryScope {
     #[cfg(feature = "tracing")]
     _span_scope: Option<SpanScope>,
 
+    #[cfg(feature = "user-tracing")]
+    _user_span_scope: Option<UserSpanScope>,
+
     // NOTE: certain tracing APIs start a new trace, so we need to scope the test tracer
     // for them to use the tracer from the test scope instead of production tracer in
     // the harness.
     #[cfg(all(feature = "tracing", feature = "testing"))]
     _test_tracer_scope: Option<TestTracerScope>,
+
+    #[cfg(all(feature = "user-tracing", feature = "testing"))]
+    _user_test_tracer_scope: Option<UserTestTracerScope>,
 }
 
 /// Telemetry configuration that is passed to [`init`].
@@ -344,6 +359,16 @@ pub fn init(config: TelemetryConfig) -> BootstrapResult<TelemetryDriver> {
         if let Some(fut) = self::tracing::init::init(config.service_info, &config.settings.tracing)?
         {
             tele_futures.push(fut);
+        }
+    }
+
+    #[cfg(feature = "user-tracing")]
+    {
+        if let Some(user_settings) = &config.settings.user_tracing {
+            let initializer = self::tracing::init::init_user(config.service_info, user_settings)?;
+            if let Some(fut) = initializer {
+                tele_futures.push(fut);
+            }
         }
     }
 

--- a/foundations/src/telemetry/settings/mod.rs
+++ b/foundations/src/telemetry/settings/mod.rs
@@ -6,6 +6,9 @@ mod otlp_grpc_output;
 #[cfg(feature = "tracing")]
 mod tracing;
 
+#[cfg(feature = "user-tracing")]
+mod user_tracing;
+
 #[cfg(feature = "logging")]
 mod logging;
 
@@ -26,6 +29,9 @@ pub use self::otlp_grpc_output::*;
 
 #[cfg(feature = "tracing")]
 pub use self::tracing::*;
+
+#[cfg(feature = "user-tracing")]
+pub use self::user_tracing::*;
 
 #[cfg(feature = "logging")]
 pub use self::logging::*;
@@ -52,6 +58,10 @@ pub struct TelemetrySettings {
     /// Distributed tracing settings
     #[cfg(feature = "tracing")]
     pub tracing: TracingSettings,
+
+    /// Distributed user tracing settings
+    #[cfg(feature = "user-tracing")]
+    pub user_tracing: Option<UserTracingSettings>,
 
     /// Logging settings.
     #[cfg(feature = "logging")]

--- a/foundations/src/telemetry/settings/user_tracing.rs
+++ b/foundations/src/telemetry/settings/user_tracing.rs
@@ -1,0 +1,114 @@
+use std::num::NonZeroUsize;
+
+#[cfg(feature = "settings")]
+use crate::settings::settings;
+
+/// Distributed user tracing settings.
+#[cfg_attr(feature = "settings", settings(crate_path = "crate"))]
+#[cfg_attr(not(feature = "settings"), derive(Clone, Debug, serde::Deserialize))]
+pub struct UserTracingSettings {
+    /// Enables user tracing.
+    #[serde(default = "UserTracingSettings::default_enabled")]
+    pub enabled: bool,
+
+    /// Maximum number of spans to buffer for output. Any spans above
+    /// this limit will be dropped until the queue regains capacity.
+    ///
+    /// The default is to buffer up to 1 million spans in memory. This protects
+    /// services from out-of-memory errors when the output gets heavily backed up.
+    /// To disable the limit entirely, set this setting to `None`.
+    #[serde(default = "UserTracingSettings::default_max_queue_size")]
+    pub max_queue_size: Option<NonZeroUsize>,
+
+    /// The output for the collected user traces.
+    pub output: UserTracesOutput,
+}
+
+#[cfg(not(feature = "settings"))]
+impl Default for UserTracingSettings {
+    fn default() -> Self {
+        Self {
+            enabled: UserTracingSettings::default_enabled(),
+            max_queue_size: UserTracingSettings::default_max_queue_size(),
+            output: Default::default(),
+        }
+    }
+}
+
+impl UserTracingSettings {
+    fn default_enabled() -> bool {
+        false
+    }
+
+    const fn default_max_queue_size() -> Option<NonZeroUsize> {
+        Some(const { NonZeroUsize::new(1_000_000).expect("1_000_000 is not zero") })
+    }
+}
+
+/// The output for the collected user traces.
+#[cfg_attr(
+    feature = "settings",
+    settings(crate_path = "crate", impl_default = false)
+)]
+#[cfg_attr(not(feature = "settings"), derive(Clone, Debug, serde::Deserialize))]
+pub enum UserTracesOutput {
+    /// Send user tracing spans as OTLP over a Unix domain socket to an OTLP endpoint.
+    OtlpUds(OtlpUdsOutputSettings),
+}
+
+impl Default for UserTracesOutput {
+    fn default() -> Self {
+        Self::OtlpUds(Default::default())
+    }
+}
+
+/// [OTLP over UDS] output settings for user tracing.
+///
+/// Sends trace data as protobuf-encoded OTLP over HTTP to a Unix domain socket.
+#[cfg_attr(feature = "settings", settings(crate_path = "crate"))]
+#[cfg_attr(not(feature = "settings"), derive(Clone, Debug, serde::Deserialize))]
+pub struct OtlpUdsOutputSettings {
+    /// Path to the Unix domain socket for the OTLP endpoint.
+    pub socket_path: String,
+
+    /// Name of the header carrying each span's encoded routing.
+    pub routing_header_name: String,
+
+    /// Number of concurrent worker tasks for user trace export.
+    ///
+    /// # Default
+    ///
+    /// Default value is `1`.
+    #[serde(default = "OtlpUdsOutputSettings::default_num_tasks")]
+    pub num_tasks: usize,
+
+    /// Maximum number of spans to drain per batch.
+    ///
+    /// # Default
+    ///
+    /// Default value is `512`.
+    #[serde(default = "OtlpUdsOutputSettings::default_max_batch_size")]
+    pub max_batch_size: usize,
+}
+
+#[cfg(not(feature = "settings"))]
+impl Default for OtlpUdsOutputSettings {
+    fn default() -> Self {
+        Self {
+            socket_path: String::new(),
+            routing_header_name: String::new(),
+            num_tasks: OtlpUdsOutputSettings::default_num_tasks(),
+            max_batch_size: OtlpUdsOutputSettings::default_max_batch_size(),
+        }
+    }
+}
+
+impl OtlpUdsOutputSettings {
+    const fn default_num_tasks() -> usize {
+        1
+    }
+
+    const fn default_max_batch_size() -> usize {
+        512
+    }
+}

--- a/foundations/src/telemetry/telemetry_context.rs
+++ b/foundations/src/telemetry/telemetry_context.rs
@@ -21,6 +21,15 @@ feature_use!(cfg(feature = "tracing"), {
     });
 });
 
+feature_use!(cfg(feature = "user-tracing"), {
+    use super::tracing::UserSpanScope;
+    use super::tracing::internal::current_user_span;
+
+    feature_use!(cfg(feature = "testing"), {
+        use super::tracing::testing::{UserTestTracerScope, current_user_test_tracer};
+    });
+});
+
 #[cfg(feature = "testing")]
 use super::testing::TestTelemetryContext;
 
@@ -98,8 +107,14 @@ pub struct TelemetryContext {
     #[cfg(feature = "tracing")]
     pub(super) span: Option<SharedSpan>,
 
+    #[cfg(feature = "user-tracing")]
+    pub(super) user_span: Option<SharedSpan>,
+
     #[cfg(all(feature = "tracing", feature = "testing"))]
     pub(super) test_tracer: Option<Tracer>,
+
+    #[cfg(all(feature = "user-tracing", feature = "testing"))]
+    pub(super) user_test_tracer: Option<Tracer>,
 }
 
 impl TelemetryContext {
@@ -112,8 +127,14 @@ impl TelemetryContext {
             #[cfg(feature = "tracing")]
             span: current_span(),
 
+            #[cfg(feature = "user-tracing")]
+            user_span: current_user_span(),
+
             #[cfg(all(feature = "tracing", feature = "testing"))]
             test_tracer: current_test_tracer(),
+
+            #[cfg(all(feature = "user-tracing", feature = "testing"))]
+            user_test_tracer: current_user_test_tracer(),
         }
     }
 
@@ -172,8 +193,18 @@ impl TelemetryContext {
             #[cfg(feature = "tracing")]
             _span_scope: self.span.as_ref().cloned().map(SpanScope::new),
 
+            #[cfg(feature = "user-tracing")]
+            _user_span_scope: self.user_span.as_ref().cloned().map(UserSpanScope::new),
+
             #[cfg(all(feature = "tracing", feature = "testing"))]
             _test_tracer_scope: self.test_tracer.as_ref().cloned().map(TestTracerScope::new),
+
+            #[cfg(all(feature = "user-tracing", feature = "testing"))]
+            _user_test_tracer_scope: self
+                .user_test_tracer
+                .as_ref()
+                .cloned()
+                .map(UserTestTracerScope::new),
         }
     }
 
@@ -330,6 +361,9 @@ impl TelemetryContext {
     /// Creates a new telemetry context, that includes a forked trace, creating a
     /// linked child trace.
     ///
+    /// Only the internal trace is forked, not the user trace: user spans created in
+    /// the forked context stay in the current user trace.
+    ///
     /// If the current trace is sampled, the new child trace also will be sampled.
     /// If the current trace isn't sampled, no new child trace is created.
     ///
@@ -383,8 +417,14 @@ impl TelemetryContext {
 
             span: Some(fork_trace(fork_name)),
 
+            #[cfg(feature = "user-tracing")]
+            user_span: self.user_span.clone(),
+
             #[cfg(feature = "testing")]
             test_tracer: self.test_tracer.clone(),
+
+            #[cfg(all(feature = "user-tracing", feature = "testing"))]
+            user_test_tracer: self.user_test_tracer.clone(),
         }
     }
 }
@@ -458,8 +498,14 @@ impl TelemetryContext {
             #[cfg(feature = "tracing")]
             span: self.span.clone(),
 
+            #[cfg(feature = "user-tracing")]
+            user_span: self.user_span.clone(),
+
             #[cfg(all(feature = "tracing", feature = "testing"))]
             test_tracer: self.test_tracer.clone(),
+
+            #[cfg(all(feature = "user-tracing", feature = "testing"))]
+            user_test_tracer: self.user_test_tracer.clone(),
         }
     }
 }

--- a/foundations/src/telemetry/testing.rs
+++ b/foundations/src/telemetry/testing.rs
@@ -42,6 +42,9 @@ pub struct TestTelemetryContext {
     #[cfg(feature = "tracing")]
     traces_sink: parking_lot::Mutex<TestTracesSink>,
 
+    #[cfg(feature = "user-tracing")]
+    user_traces_sink: parking_lot::Mutex<TestTracesSink>,
+
     #[cfg(feature = "logging")]
     log_records: TestLogRecords,
 }
@@ -62,6 +65,9 @@ impl TestTelemetryContext {
         #[cfg(feature = "tracing")]
         let (tracer, traces_sink) = create_test_tracer(&Default::default());
 
+        #[cfg(feature = "user-tracing")]
+        let (user_tracer, user_traces_sink) = create_test_tracer(&Default::default());
+
         TestTelemetryContext {
             inner: TelemetryContext {
                 #[cfg(feature = "logging")]
@@ -70,12 +76,21 @@ impl TestTelemetryContext {
                 #[cfg(feature = "tracing")]
                 span: None,
 
+                #[cfg(feature = "user-tracing")]
+                user_span: None,
+
                 #[cfg(feature = "tracing")]
                 test_tracer: Some(tracer),
+
+                #[cfg(feature = "user-tracing")]
+                user_test_tracer: Some(user_tracer),
             },
 
             #[cfg(feature = "tracing")]
             traces_sink: parking_lot::Mutex::new(traces_sink),
+
+            #[cfg(feature = "user-tracing")]
+            user_traces_sink: parking_lot::Mutex::new(user_traces_sink),
 
             #[cfg(feature = "logging")]
             log_records,
@@ -137,6 +152,12 @@ impl TestTelemetryContext {
     #[cfg(feature = "tracing")]
     pub fn traces(&self, options: TestTraceOptions) -> Vec<TestTrace> {
         self.traces_sink.lock().traces(options)
+    }
+
+    /// Returns all the user-tracing traces produced in the test context.
+    #[cfg(feature = "user-tracing")]
+    pub fn user_traces(&self, options: TestTraceOptions) -> Vec<TestTrace> {
+        self.user_traces_sink.lock().traces(options)
     }
 }
 

--- a/foundations/src/telemetry/tracing/channel.rs
+++ b/foundations/src/telemetry/tracing/channel.rs
@@ -56,6 +56,11 @@ pub(super) enum PipelineType {
     /// metrics. Prometheus treats this the same as an absent label.
     #[serde(rename = "")]
     System,
+
+    /// User tracing pipeline.
+    #[cfg(feature = "user-tracing")]
+    #[serde(rename = "user")]
+    User,
 }
 
 /// An instrumented, multi-consumer span receiver layered on top of

--- a/foundations/src/telemetry/tracing/init.rs
+++ b/foundations/src/telemetry/tracing/init.rs
@@ -14,6 +14,13 @@ use std::sync::{LazyLock, OnceLock};
 #[cfg(feature = "telemetry-otlp-grpc")]
 use super::output_otlp_grpc;
 
+#[cfg(feature = "user-tracing")]
+use super::output_otlp_uds;
+#[cfg(feature = "user-tracing")]
+use crate::telemetry::settings::{UserTracesOutput, UserTracingSettings};
+#[cfg(feature = "user-tracing")]
+use cf_rustracing::sampler::AllSampler;
+
 #[cfg(feature = "testing")]
 use std::borrow::Cow;
 
@@ -21,7 +28,26 @@ use std::borrow::Cow;
 // ensure initialization. Make sure nobody else invalidates our cache lines.
 static HARNESS: CachePadded<OnceLock<TracingHarness>> = CachePadded::new(OnceLock::new());
 
+#[cfg(feature = "user-tracing")]
+static USER_HARNESS: CachePadded<OnceLock<TracingHarness>> = CachePadded::new(OnceLock::new());
+
 static NOOP_HARNESS: CachePadded<LazyLock<TracingHarness>> =
+    CachePadded::new(LazyLock::new(|| {
+        let (noop_tracer, _) = Tracer::new(NullSampler.boxed());
+
+        TracingHarness {
+            tracer: noop_tracer,
+            span_scope_stack: Default::default(),
+
+            #[cfg(feature = "testing")]
+            test_tracer_scope_stack: Default::default(),
+
+            active_roots: Default::default(),
+        }
+    }));
+
+#[cfg(feature = "user-tracing")]
+static USER_NOOP_HARNESS: CachePadded<LazyLock<TracingHarness>> =
     CachePadded::new(LazyLock::new(|| {
         let (noop_tracer, _) = Tracer::new(NullSampler.boxed());
 
@@ -50,6 +76,12 @@ pub(crate) struct TracingHarness {
 impl TracingHarness {
     pub(crate) fn get() -> &'static Self {
         HARNESS.get().unwrap_or_else(|| &**NOOP_HARNESS)
+    }
+
+    /// User-tracing harness, or the user no-op harness when the user pipeline isn't initialized.
+    #[cfg(feature = "user-tracing")]
+    pub(crate) fn get_user() -> &'static Self {
+        USER_HARNESS.get().unwrap_or_else(|| &**USER_NOOP_HARNESS)
     }
 
     #[cfg(feature = "testing")]
@@ -139,6 +171,62 @@ pub(crate) fn init(
             test_tracer_scope_stack: Default::default(),
 
             active_roots: ActiveRoots::new(settings.liveness_tracking.clone()),
+        }
+    });
+    res
+}
+
+#[cfg(feature = "user-tracing")]
+fn create_tracer_and_span_rx_for_user(
+    settings: &UserTracingSettings,
+) -> BootstrapResult<(Tracer, SharedSpanReceiver)> {
+    // The user pipeline samples everything it receives — the sampling decision
+    // is made upstream at activation time, outside foundations.
+    let sampler = AllSampler.boxed();
+
+    if let Some(cap) = settings.max_queue_size {
+        let (consumer, span_rx) = super::channel::channel(cap, PipelineType::User);
+        Ok((Tracer::with_consumer(sampler, consumer), span_rx))
+    } else {
+        let (consumer, span_rx) = super::channel::unbounded_channel(PipelineType::User);
+        Ok((Tracer::with_consumer(sampler, consumer), span_rx))
+    }
+}
+
+// NOTE: does nothing if user tracing has already been initialized in this process.
+#[cfg(feature = "user-tracing")]
+pub(crate) fn init_user(
+    service_info: &ServiceInfo,
+    settings: &UserTracingSettings,
+) -> BootstrapResult<Option<BoxFuture<'static, BootstrapResult<()>>>> {
+    if !settings.enabled || USER_HARNESS.get().is_some() {
+        return Ok(None);
+    }
+
+    let (tracer, span_rx) = create_tracer_and_span_rx_for_user(settings)?;
+
+    let futs = match &settings.output {
+        UserTracesOutput::OtlpUds(output_settings) => {
+            output_otlp_uds::start(service_info, output_settings, span_rx)?
+        }
+    };
+
+    // Only spawn the futures if we are actually initializing the harness.
+    let mut res = Ok(None);
+    USER_HARNESS.get_or_init(|| {
+        res = Ok(futs.initializer);
+        for f in futs.workers {
+            tokio::spawn(f);
+        }
+
+        TracingHarness {
+            tracer,
+            span_scope_stack: Default::default(),
+
+            #[cfg(feature = "testing")]
+            test_tracer_scope_stack: Default::default(),
+
+            active_roots: Default::default(),
         }
     });
     res

--- a/foundations/src/telemetry/tracing/internal.rs
+++ b/foundations/src/telemetry/tracing/internal.rs
@@ -3,7 +3,11 @@ use super::init::TracingHarness;
 
 use crate::telemetry::tracing::live::LiveReferenceHandle;
 use cf_rustracing::sampler::BoxSampler;
+#[cfg(feature = "user-tracing")]
+use cf_rustracing::span::RoutingMetadata;
 use cf_rustracing::tag::Tag;
+#[cfg(feature = "user-tracing")]
+use cf_rustracing_jaeger::span::TraceId;
 use cf_rustracing_jaeger::span::{Span, SpanContext, SpanContextState};
 use parking_lot::RwLock;
 use rand::RngExt as _;
@@ -60,15 +64,29 @@ pub(crate) struct SharedSpan {
     pub(crate) is_sampled: bool,
 }
 
-impl From<Span> for SharedSpan {
-    fn from(inner: Span) -> Self {
-        let is_sampled = inner.is_sampled();
+/// Wraps a span and registers it with the internal harness's `active_roots` for live tracking.
+pub(crate) fn shared_span(span: Span) -> SharedSpan {
+    let is_sampled = span.is_sampled();
 
-        Self {
-            inner: SharedSpanHandle::new(inner),
-            is_sampled,
-        }
+    SharedSpan {
+        inner: SharedSpanHandle::new(span),
+        is_sampled,
     }
+}
+
+/// Wraps a user span as `Untracked`/`Inactive`, bypassing `active_roots` so user spans never
+/// enter the internal harness's live registry.
+#[cfg(feature = "user-tracing")]
+pub(crate) fn user_shared_span(span: Span) -> SharedSpan {
+    let is_sampled = span.is_sampled();
+
+    let inner = if is_sampled {
+        SharedSpanHandle::Untracked(Arc::new(RwLock::new(span)))
+    } else {
+        SharedSpanHandle::Inactive
+    };
+
+    SharedSpan { inner, is_sampled }
 }
 
 pub fn write_current_span(write_fn: impl FnOnce(&mut Span)) {
@@ -87,11 +105,10 @@ pub fn write_current_span(write_fn: impl FnOnce(&mut Span)) {
 }
 
 pub(crate) fn create_span(name: impl Into<Cow<'static, str>>) -> SharedSpan {
-    match current_span() {
+    shared_span(match current_span() {
         Some(parent) => parent.inner.with_read(|s| s.child(name, |o| o.start())),
         None => start_trace(name, Default::default()),
-    }
-    .into()
+    })
 }
 
 pub(crate) fn current_span() -> Option<SharedSpan> {
@@ -135,6 +152,64 @@ pub(crate) fn start_trace(
     link_new_trace_with_current(&mut current_span, &root_span_name, &mut new_trace_root_span);
 
     new_trace_root_span
+}
+
+#[cfg(feature = "user-tracing")]
+pub(crate) fn current_user_span() -> Option<SharedSpan> {
+    TracingHarness::get_user().span_scope_stack.current()
+}
+
+/// Child of the current user span, or inactive when no user trace is active (never a root).
+#[cfg(feature = "user-tracing")]
+pub(crate) fn create_user_span(name: impl Into<Cow<'static, str>>) -> SharedSpan {
+    match current_user_span() {
+        Some(parent) => user_shared_span(parent.inner.with_read(|s| s.child(name, |o| o.start()))),
+        None => user_shared_span(Span::inactive()),
+    }
+}
+
+#[cfg(feature = "user-tracing")]
+pub fn write_current_user_span(write_fn: impl FnOnce(&mut Span)) {
+    let span = match current_user_span() {
+        Some(span) if span.is_sampled => span,
+        _ => return,
+    };
+
+    let mut span_guard = match &span.inner {
+        SharedSpanHandle::Tracked(handle) => handle.write(),
+        SharedSpanHandle::Untracked(rw_lock) => rw_lock.write(),
+        SharedSpanHandle::Inactive => unreachable!("inactive spans can't be sampled"),
+    };
+
+    write_fn(&mut span_guard);
+}
+
+/// Starts a root user span on the user harness, optionally continuing the inbound W3C trace.
+/// `routing` is set at construction and inherited by child spans.
+#[cfg(feature = "user-tracing")]
+pub(crate) fn start_user_trace(
+    name: impl Into<Cow<'static, str>>,
+    routing: Arc<dyn RoutingMetadata>,
+    inbound: Option<super::TraceparentContext>,
+) -> Span {
+    let tracer = TracingHarness::get_user().tracer();
+    let mut builder = tracer.span(name).routing(routing);
+
+    if let Some(tp) = inbound {
+        let trace_id = TraceId {
+            high: u64::from_be_bytes(tp.trace_id[..8].try_into().unwrap()),
+            low: u64::from_be_bytes(tp.trace_id[8..].try_into().unwrap()),
+        };
+        let state = SpanContextState::new(
+            trace_id,
+            u64::from_be_bytes(tp.parent_id),
+            tp.trace_flags,
+            String::new(),
+        );
+        builder = builder.child_of(&SpanContext::new(state, vec![]));
+    }
+
+    builder.start()
 }
 
 pub(super) fn reporter_error(err: impl Error) {
@@ -182,20 +257,19 @@ fn link_new_trace_with_current(
 pub(crate) fn fork_trace(fork_name: impl Into<Cow<'static, str>>) -> SharedSpan {
     match current_span() {
         Some(span) if span.is_sampled => span,
-        _ => return Span::inactive().into(),
+        _ => return shared_span(Span::inactive()),
     };
 
     let fork_name = fork_name.into();
 
-    start_trace(
+    shared_span(start_trace(
         fork_name,
         StartTraceOptions {
             // NOTE: If the current span is sampled, then forked trace is also forcibly sampled
             override_sampling_ratio: Some(1.0),
             ..Default::default()
         },
-    )
-    .into()
+    ))
 }
 
 fn create_fork_ref_span(fork_name: &str, current_span: &Span) -> Span {

--- a/foundations/src/telemetry/tracing/mod.rs
+++ b/foundations/src/telemetry/tracing/mod.rs
@@ -18,8 +18,16 @@ mod rate_limit;
 #[cfg(feature = "telemetry-otlp-grpc")]
 mod output_otlp_grpc;
 
+#[cfg(feature = "user-tracing")]
+mod output_otlp_uds;
+
+#[cfg(feature = "user-tracing")]
+mod traceparent;
+
 use self::init::TracingHarness;
-use self::internal::{SharedSpan, create_span, current_span, span_trace_id};
+#[cfg(feature = "user-tracing")]
+use self::internal::current_user_span;
+use self::internal::{SharedSpan, create_span, current_span, shared_span, span_trace_id};
 use super::TelemetryContext;
 use super::scope::Scope;
 use std::borrow::Cow;
@@ -30,6 +38,12 @@ pub use self::testing::{TestSpan, TestTrace, TestTraceIterator, TestTraceOptions
 
 pub use cf_rustracing::tag::TagValue;
 pub use cf_rustracing_jaeger::span::{Span, SpanContextState as SerializableTraceState, TraceId};
+
+#[cfg(feature = "user-tracing")]
+pub use self::traceparent::TraceparentContext;
+
+#[cfg(feature = "user-tracing")]
+pub use cf_rustracing::span::RoutingMetadata;
 
 /// Returns active traces as a JSON dump.
 ///
@@ -221,6 +235,64 @@ impl SpanScope {
     }
 }
 
+/// A handle for the scope in which a user-tracing span is active.
+///
+/// Scope ends when the handle is dropped.
+#[cfg(feature = "user-tracing")]
+#[must_use]
+pub struct UserSpanScope {
+    span: SharedSpan,
+    _inner: Scope<SharedSpan>,
+}
+
+#[cfg(feature = "user-tracing")]
+impl UserSpanScope {
+    #[inline]
+    pub(crate) fn new(span: SharedSpan) -> Self {
+        Self {
+            span: span.clone(),
+            _inner: Scope::new(&TracingHarness::get_user().span_scope_stack, span),
+        }
+    }
+
+    /// Converts the user span scope to a [`TelemetryContext`] that can be applied to a future.
+    pub fn into_context(self) -> TelemetryContext {
+        let mut ctx = TelemetryContext::current();
+
+        ctx.user_span = Some(self.span);
+
+        ctx
+    }
+}
+
+/// A span recorded in both the internal and user traces, produced by [`dual_span`].
+///
+/// Scope ends when the handle is dropped. [`into_context`](Self::into_context) carries both the
+/// internal span and, when a user trace was active, the parallel user span.
+#[cfg(feature = "user-tracing")]
+#[must_use]
+pub struct DualSpanScope {
+    inner: SpanScope,
+    user: Option<UserSpanScope>,
+}
+
+#[cfg(feature = "user-tracing")]
+impl DualSpanScope {
+    /// Converts the span scope to a [`TelemetryContext`] that can be applied to a future.
+    ///
+    /// This is effectively a shorthand for calling [`TelemetryContext::current`] with both the
+    /// internal span and the parallel user span being in scope.
+    pub fn into_context(self) -> TelemetryContext {
+        let mut ctx = self.inner.into_context();
+
+        if let Some(user) = self.user {
+            ctx.user_span = Some(user.span);
+        }
+
+        ctx
+    }
+}
+
 /// Options for a new trace.
 #[derive(Default, Debug)]
 pub struct StartTraceOptions {
@@ -366,6 +438,20 @@ pub fn span(name: impl Into<Cow<'static, str>>) -> SpanScope {
     SpanScope::new(create_span(name))
 }
 
+/// Opens an internal span named `name`, plus a parallel user span of the same name (child of the
+/// current user span) when a user trace is active. Both share the returned scope's lifetime.
+#[cfg(feature = "user-tracing")]
+pub fn dual_span(name: impl Into<Cow<'static, str>>) -> DualSpanScope {
+    let name = name.into();
+    let inner = span(name.clone());
+
+    let user = current_user_span()
+        .is_some()
+        .then(|| user_tracing::span(name));
+
+    DualSpanScope { inner, user }
+}
+
 /// Starts a new trace. Ends the current one if it is available and links the new one with it.
 ///
 /// Can also be used to stitch traces with the context received from other services, and can force
@@ -416,7 +502,62 @@ pub fn start_trace(
     root_span_name: impl Into<Cow<'static, str>>,
     options: StartTraceOptions,
 ) -> SpanScope {
-    SpanScope::new(internal::start_trace(root_span_name, options).into())
+    SpanScope::new(shared_span(internal::start_trace(root_span_name, options)))
+}
+
+/// User-tracing entry points and helpers.
+///
+/// The user trace runs in parallel to the internal trace, and everything here operates only on
+/// it. To record a span in both traces at once, use [`dual_span`].
+#[cfg(feature = "user-tracing")]
+pub mod user_tracing {
+    use super::internal::{self, create_user_span, current_user_span, user_shared_span};
+    use super::{RoutingMetadata, TraceparentContext, UserSpanScope};
+    use std::borrow::Cow;
+
+    /// Starts a root user span (per-request activation), optionally continuing the inbound W3C
+    /// trace from `inbound`. `routing` is attached at construction and inherited by child spans.
+    ///
+    /// Without an active root, `span`, `dual_span`, and `add_span_tags!` are no-ops.
+    pub fn start_trace(
+        name: impl Into<Cow<'static, str>>,
+        routing: impl RoutingMetadata + 'static,
+        inbound: Option<TraceparentContext>,
+    ) -> UserSpanScope {
+        UserSpanScope::new(user_shared_span(internal::start_user_trace(
+            name,
+            std::sync::Arc::new(routing),
+            inbound,
+        )))
+    }
+
+    /// Creates a user span as a child of the current user span, or inactive when no user trace is
+    /// active. Never starts a root — roots come only from [`start_trace`].
+    pub fn span(name: impl Into<Cow<'static, str>>) -> UserSpanScope {
+        UserSpanScope::new(create_user_span(name))
+    }
+
+    /// W3C `traceparent` for the current user span, for outbound propagation to the next hop.
+    /// Span-derived (parent-id is the current user span); `None` when no user trace is active.
+    pub fn w3c_traceparent() -> Option<String> {
+        current_user_span()?.inner.with_read(|s| {
+            let state = s.context()?.state();
+
+            Some(format!(
+                "00-{:0>16x}{:0>16x}-{:0>16x}-{:0>2x}",
+                state.trace_id().high,
+                state.trace_id().low,
+                state.span_id(),
+                state.flags()
+            ))
+        })
+    }
+
+    #[doc(inline)]
+    pub use crate::{
+        __add_user_span_log_fields as add_span_log_fields, __add_user_span_tags as add_span_tags,
+        __set_user_span_finish_callback as set_span_finish_callback,
+    };
 }
 
 /// Returns the current span as a raw [rustracing] crate's `Span` that is used by Foundations internally.
@@ -731,6 +872,80 @@ macro_rules! __set_span_finish_callback {
     }};
 }
 
+/// Adds tags to the current user span. No-op when no user trace is active.
+///
+/// Accepts the same arguments as
+/// [`add_span_tags`]; see it for the supported formats
+/// and examples.
+#[cfg(feature = "user-tracing")]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __add_user_span_tags {
+    ( $( $name:expr => $val:expr ),+ ) => {
+        $crate::telemetry::tracing::internal::write_current_user_span(|span| {
+            span.set_tags(|| {
+                vec![ $($crate::reexports_for_macros::cf_rustracing::tag::Tag::new($name, $val)),+ ]
+            });
+        });
+    };
+
+    ( $tags:expr ) => {
+        $crate::telemetry::tracing::internal::write_current_user_span(|span| {
+            span.set_tags(|| {
+                $tags
+                    .into_iter()
+                    .map(|(name, val)| {
+                        $crate::reexports_for_macros::cf_rustracing::tag::Tag::new(name, val)
+                    })
+            });
+        });
+    };
+}
+
+/// Adds log fields to the current user span. No-op when no user trace is active.
+///
+/// Accepts the same arguments as
+/// [`add_span_log_fields`]; see it for the
+/// supported formats and examples.
+#[cfg(feature = "user-tracing")]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __add_user_span_log_fields {
+    ( $( $field:expr => $val:expr ),+ ) => {
+        $crate::telemetry::tracing::internal::write_current_user_span(|span| {
+            span.log(|builder| {
+                $(
+                    builder.field(($field, $val));
+                )+
+            });
+        });
+    };
+}
+
+/// Sets (`$cb`) or clears (`None`) the finish callback on the current user span. No-op when no
+/// user trace is active. Routing is set at construction by
+/// [`start_trace`](crate::telemetry::tracing::user_tracing::start_trace), so this is a general
+/// escape hatch — not used for routing.
+///
+/// Behaves like [`set_span_finish_callback`];
+/// see it for details and examples.
+#[cfg(feature = "user-tracing")]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __set_user_span_finish_callback {
+    ( None ) => {
+        $crate::telemetry::tracing::internal::write_current_user_span(|span| {
+            span.take_finish_callback();
+        })
+    };
+    ( $cb:expr ) => {{
+        let cb = $cb;
+        $crate::telemetry::tracing::internal::write_current_user_span(move |span| {
+            span.set_finish_callback(cb);
+        })
+    }};
+}
+
 /// A convenience macro to construct [`TestTrace`] for test assertions.
 ///
 /// Note that for span timings the macro always generates default
@@ -923,3 +1138,484 @@ pub use {
 #[cfg(feature = "testing")]
 #[doc(inline)]
 pub use __test_trace as test_trace;
+
+#[cfg(all(test, feature = "user-tracing", feature = "testing"))]
+mod user_tracing_tests {
+    use super::{
+        RoutingMetadata, StartTraceOptions, TraceparentContext, dual_span, span, start_trace,
+        test_trace, user_tracing,
+    };
+    use crate::telemetry::TelemetryContext;
+    use crate::telemetry::tracing::{Span, TestTraceOptions};
+    use cf_rustracing::tag::{Tag, TagValue};
+
+    #[derive(Debug)]
+    struct TestRouting {
+        zone_id: u64,
+        account_id: u64,
+    }
+
+    impl RoutingMetadata for TestRouting {
+        fn group_key(&self) -> String {
+            format!("{}|{}", self.zone_id, self.account_id)
+        }
+
+        fn encode(&self) -> String {
+            format!("zone={};account={}", self.zone_id, self.account_id)
+        }
+    }
+
+    fn routing() -> TestRouting {
+        TestRouting {
+            zone_id: 1,
+            account_id: 2,
+        }
+    }
+
+    #[test]
+    fn creation_and_nesting() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        {
+            let _root = user_tracing::start_trace("request", routing(), None);
+            let _child = user_tracing::span("child");
+            let _grandchild = user_tracing::span("grandchild");
+        }
+
+        assert_eq!(
+            ctx.user_traces(Default::default()),
+            vec![test_trace! {
+                "request" => {
+                    "child" => {
+                        "grandchild"
+                    }
+                }
+            }]
+        );
+        // User spans must not leak into the internal pipeline.
+        assert!(ctx.traces(Default::default()).is_empty());
+    }
+
+    #[test]
+    fn tags_and_logs() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        {
+            let _root = user_tracing::start_trace("request", routing(), None);
+            user_tracing::add_span_tags!("cache.status" => "HIT");
+            user_tracing::add_span_log_fields!("event" => "lookup");
+        }
+
+        let opts = TestTraceOptions {
+            include_tags: true,
+            include_logs: true,
+            ..Default::default()
+        };
+        let traces = ctx.user_traces(opts);
+        let root = &traces[0].0;
+
+        assert!(
+            root.tags
+                .contains(&("cache.status".to_string(), TagValue::String("HIT".into())))
+        );
+        assert!(
+            root.logs
+                .contains(&("event".to_string(), "lookup".to_string()))
+        );
+    }
+
+    #[test]
+    fn dual_span_is_parallel() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        {
+            let _root = user_tracing::start_trace("request", routing(), None);
+            let _s = dual_span("op");
+        }
+
+        // Internal pipeline: just the internal span.
+        assert_eq!(ctx.traces(Default::default()), vec![test_trace! { "op" }]);
+        // User pipeline: the parallel user span nested under the user root.
+        assert_eq!(
+            ctx.user_traces(Default::default()),
+            vec![test_trace! { "request" => { "op" } }]
+        );
+    }
+
+    // The parallel user span is named after the span even when the internal trace is dropped by
+    // sampling.
+    #[test]
+    fn dual_span_names_span_when_internal_trace_sampled_out() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        {
+            let _internal_root = start_trace(
+                "internal_root",
+                StartTraceOptions {
+                    override_sampling_ratio: Some(0.0),
+                    ..Default::default()
+                },
+            );
+            let _user_root = user_tracing::start_trace("request", routing(), None);
+
+            let _s = dual_span("op");
+        }
+
+        assert!(ctx.traces(Default::default()).is_empty());
+        assert_eq!(
+            ctx.user_traces(Default::default()),
+            vec![test_trace! { "request" => { "op" } }]
+        );
+    }
+
+    // `dual_span()` carried across an `.await` via its scope's `into_context()`: the parallel user
+    // span survives the boundary and a second `dual_span()` nests under it.
+    #[tokio::test]
+    async fn dual_span_carried_across_await() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        {
+            let _root = user_tracing::start_trace("request", routing(), None);
+
+            dual_span("a")
+                .into_context()
+                .apply(async {
+                    let _c = dual_span("c");
+                })
+                .await;
+        }
+
+        assert_eq!(
+            ctx.user_traces(Default::default()),
+            vec![test_trace! { "request" => { "a" => { "c" } } }]
+        );
+        assert_eq!(
+            ctx.traces(Default::default()),
+            vec![test_trace! { "a" => { "c" } }]
+        );
+    }
+
+    // Same propagation, but `into_context()` is taken on an *internal-only* span (`b`) between two
+    // user spans. The ambient user span (`a`) rides along, so the far-side user span (`c`) nests
+    // under `a` — the user tree skips `b`, which exists only in the internal tree.
+    #[tokio::test]
+    async fn dual_span_carried_via_internal_span() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        {
+            let _root = user_tracing::start_trace("request", routing(), None);
+            let _a = dual_span("a");
+
+            span("b")
+                .into_context()
+                .apply(async {
+                    let _c = dual_span("c");
+                })
+                .await;
+        }
+
+        // User tree: c under a under the root; b is internal-only and absent here.
+        assert_eq!(
+            ctx.user_traces(Default::default()),
+            vec![test_trace! { "request" => { "a" => { "c" } } }]
+        );
+        // Internal tree: a -> b -> c.
+        assert_eq!(
+            ctx.traces(Default::default()),
+            vec![test_trace! { "a" => { "b" => { "c" } } }]
+        );
+    }
+
+    #[test]
+    fn continues_inbound_trace() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        let inbound =
+            TraceparentContext::parse(b"00-11223344556677889900aabbccddeeff-a1b2c3d4e5f60718-01")
+                .unwrap();
+        let _root = user_tracing::start_trace("request", routing(), Some(inbound));
+
+        let out = user_tracing::w3c_traceparent().unwrap();
+        assert!(out.starts_with("00-11223344556677889900aabbccddeeff-"));
+    }
+
+    // Outbound: `w3c_traceparent()` is derived from the *current* user span — a child shares the
+    // root's 128-bit trace id but reports its own span id.
+    #[test]
+    fn outbound_traceparent_is_span_derived() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        let _root = user_tracing::start_trace("request", routing(), None);
+        let root_tp = user_tracing::w3c_traceparent().expect("root traceparent");
+
+        let _child = user_tracing::span("child");
+        let child_tp = user_tracing::w3c_traceparent().expect("child traceparent");
+
+        // Same version + trace id ("00-" + 32 hex = 35 chars); different span id.
+        assert_eq!(&root_tp[..35], &child_tp[..35]);
+        assert_ne!(root_tp, child_tp);
+    }
+
+    #[test]
+    fn no_op_without_activation() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        {
+            // No `user_tracing::start_trace`, so user tracing isn't active for this scope.
+            let _child = user_tracing::span("child");
+            user_tracing::add_span_tags!("k" => "v");
+        }
+
+        assert!(ctx.user_traces(Default::default()).is_empty());
+    }
+
+    #[test]
+    fn finish_callback_runs() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        {
+            let _root = user_tracing::start_trace("request", routing(), None);
+            user_tracing::set_span_finish_callback!(|span: &mut Span| {
+                span.set_tag(|| Tag::new("finished", true));
+            });
+        }
+
+        let opts = TestTraceOptions {
+            include_tags: true,
+            ..Default::default()
+        };
+        let traces = ctx.user_traces(opts);
+        assert!(traces[0].0.tags.iter().any(|(k, _)| k == "finished"));
+    }
+
+    #[tokio::test]
+    async fn propagates_across_await() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        {
+            let root_ctx = user_tracing::start_trace("request", routing(), None).into_context();
+            root_ctx
+                .apply(async {
+                    let _child = user_tracing::span("child");
+                })
+                .await;
+        }
+
+        assert_eq!(
+            ctx.user_traces(Default::default()),
+            vec![test_trace! { "request" => { "child" } }]
+        );
+    }
+
+    // The user span rides along on the ambient `TelemetryContext` even when propagation goes
+    // through an *internal* span's `into_context()` — no explicit user-span threading needed.
+    #[tokio::test]
+    async fn user_span_carried_by_internal_context() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        {
+            let _root = user_tracing::start_trace("request", routing(), None);
+
+            // Propagate via an internal span's context; never touch the user scope.
+            span("internal")
+                .into_context()
+                .apply(async {
+                    let _user_child = user_tracing::span("user_child");
+                })
+                .await;
+        }
+
+        // User pipeline: the user child nested under the user root (the user span was carried).
+        assert_eq!(
+            ctx.user_traces(Default::default()),
+            vec![test_trace! { "request" => { "user_child" } }]
+        );
+        // Internal pipeline: just the internal span.
+        assert_eq!(
+            ctx.traces(Default::default()),
+            vec![test_trace! { "internal" }]
+        );
+    }
+
+    // An internal span's `into_context()` carries the *currently active* user span — not just the
+    // root — so a user span created after propagation nests under it. This guards the fact that a
+    // plain `SpanScope` relies on `TelemetryContext::current()` (not a stored field) to carry the
+    // ambient user span.
+    #[tokio::test]
+    async fn internal_context_carries_the_current_user_span() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        {
+            let _root = user_tracing::start_trace("request", routing(), None);
+            let _child = user_tracing::span("child");
+
+            span("internal")
+                .into_context()
+                .apply(async {
+                    let _grandchild = user_tracing::span("grandchild");
+                })
+                .await;
+        }
+
+        assert_eq!(
+            ctx.user_traces(Default::default()),
+            vec![test_trace! { "request" => { "child" => { "grandchild" } } }]
+        );
+    }
+
+    // A real task boundary (`tokio::spawn`): the held context carries the user span into a
+    // separate task, where a child nests under the root.
+    #[tokio::test]
+    async fn user_span_carried_across_spawn() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        {
+            let root_ctx = user_tracing::start_trace("request", routing(), None).into_context();
+            tokio::spawn(root_ctx.apply(async {
+                let _child = user_tracing::span("child");
+            }))
+            .await
+            .unwrap();
+        }
+
+        assert_eq!(
+            ctx.user_traces(Default::default()),
+            vec![test_trace! { "request" => { "child" } }]
+        );
+    }
+
+    // Forking the *internal* trace must preserve the active user span.
+    #[test]
+    fn user_span_survives_forked_trace() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        {
+            let _root = user_tracing::start_trace("request", routing(), None);
+            let _forked = TelemetryContext::current()
+                .with_forked_trace("fork")
+                .scope();
+            let _child = user_tracing::span("child");
+        }
+
+        assert_eq!(
+            ctx.user_traces(Default::default()),
+            vec![test_trace! { "request" => { "child" } }]
+        );
+    }
+
+    // Forking the log must likewise preserve the active user span.
+    #[cfg(feature = "logging")]
+    #[test]
+    fn user_span_survives_forked_log() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        {
+            let _root = user_tracing::start_trace("request", routing(), None);
+            let _forked = TelemetryContext::current().with_forked_log().scope();
+            let _child = user_tracing::span("child");
+        }
+
+        assert_eq!(
+            ctx.user_traces(Default::default()),
+            vec![test_trace! { "request" => { "child" } }]
+        );
+    }
+
+    // Same property via the `#[span_fn]` macro path (a plain internal-traced async fn).
+    #[crate::telemetry::tracing::span_fn("internal_fn", crate_path = "crate")]
+    async fn internal_fn() {
+        let _user_child = user_tracing::span("user_child");
+    }
+
+    #[tokio::test]
+    async fn user_span_carried_by_span_fn() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        {
+            let _root = user_tracing::start_trace("request", routing(), None);
+            internal_fn().await;
+        }
+
+        assert_eq!(
+            ctx.user_traces(Default::default()),
+            vec![test_trace! { "request" => { "user_child" } }]
+        );
+        assert_eq!(
+            ctx.traces(Default::default()),
+            vec![test_trace! { "internal_fn" }]
+        );
+    }
+
+    // `dual_span()` is a no-op for the user pipeline when no user trace is active: the internal
+    // span is still created, but no parallel user span is produced.
+    #[test]
+    fn dual_span_no_op_when_inactive() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        {
+            // No `user_tracing::start_trace` => user tracing not active for this scope.
+            let _s = dual_span("op");
+        }
+
+        assert_eq!(ctx.traces(Default::default()), vec![test_trace! { "op" }]);
+        assert!(ctx.user_traces(Default::default()).is_empty());
+    }
+
+    #[crate::telemetry::tracing::span_fn("user_fn", user = true, crate_path = "crate")]
+    async fn user_fn() {}
+
+    // `#[span_fn(user = true)]` is likewise a no-op for the user pipeline when inactive.
+    #[tokio::test]
+    async fn span_fn_user_no_op_when_inactive() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        user_fn().await;
+
+        assert_eq!(
+            ctx.traces(Default::default()),
+            vec![test_trace! { "user_fn" }]
+        );
+        assert!(ctx.user_traces(Default::default()).is_empty());
+    }
+
+    // `#[span_fn(user = true)]` opens a parallel user span when a user trace is active: the
+    // function appears in both the internal and user pipelines.
+    #[tokio::test]
+    async fn span_fn_user_creates_parallel_span() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        {
+            let _root = user_tracing::start_trace("request", routing(), None);
+            user_fn().await;
+        }
+
+        assert_eq!(
+            ctx.traces(Default::default()),
+            vec![test_trace! { "user_fn" }]
+        );
+        assert_eq!(
+            ctx.user_traces(Default::default()),
+            vec![test_trace! { "request" => { "user_fn" } }]
+        );
+    }
+}

--- a/foundations/src/telemetry/tracing/output_otlp_uds.rs
+++ b/foundations/src/telemetry/tracing/output_otlp_uds.rs
@@ -1,0 +1,591 @@
+//! [OTLP-over-UDS] output for the user tracing pipeline.
+//!
+//! Sends protobuf-encoded OTLP trace data over HTTP/1.1 to a Unix domain
+//! socket served by a local OTLP endpoint.
+
+use super::channel::SharedSpanReceiver;
+use super::init::TraceOutputFutures;
+use super::internal::reporter_error;
+use crate::telemetry::otlp_conversion::tracing::convert_span;
+use crate::telemetry::settings::OtlpUdsOutputSettings;
+use crate::{BootstrapResult, ServiceInfo};
+use anyhow::ensure;
+use cf_rustracing_jaeger::span::FinishedSpan;
+use futures_util::future::FutureExt as _;
+use http_body_util::Full;
+use hyper::body::Bytes;
+use hyper::header::{CONTENT_TYPE, HOST};
+use hyper::{Method, Request, StatusCode};
+use hyper_util::rt::TokioIo;
+use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+use opentelemetry_proto::tonic::trace::v1::ResourceSpans;
+use prost::Message as _;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::net::UnixStream;
+
+const TRACES_PATH: &str = "/v1/traces";
+const CONTENT_TYPE_PROTOBUF: &str = "application/x-protobuf";
+const HOST_HEADER_VALUE: &str = "localhost";
+
+/// A failure exporting a single OTLP request over the Unix domain socket.
+///
+/// This is the concrete error type for the UDS client, mirroring how the
+/// existing exporters surface a concrete library error (`cf_rustracing::Error`,
+/// `tonic::Status`) to [`reporter_error`].
+#[derive(Debug)]
+enum OtlpUdsExportError {
+    Connect(std::io::Error),
+    Handshake(hyper::Error),
+    BuildRequest(http::Error),
+    Send(hyper::Error),
+    Status(StatusCode),
+}
+
+impl std::fmt::Display for OtlpUdsExportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Connect(err) => write!(f, "failed to connect to UDS socket: {err}"),
+            Self::Handshake(err) => write!(f, "HTTP/1 handshake over UDS failed: {err}"),
+            Self::BuildRequest(err) => write!(f, "failed to build OTLP UDS request: {err}"),
+            Self::Send(err) => write!(f, "failed to send OTLP UDS request: {err}"),
+            Self::Status(status) => {
+                write!(f, "OTLP UDS receptor returned non-success status: {status}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for OtlpUdsExportError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Connect(err) => Some(err),
+            Self::Handshake(err) => Some(err),
+            Self::BuildRequest(err) => Some(err),
+            Self::Send(err) => Some(err),
+            Self::Status(_) => None,
+        }
+    }
+}
+
+/// Exports user tracing spans as OTLP over a Unix domain socket.
+#[derive(Debug)]
+pub(super) struct OtlpUdsClient {
+    socket_path: String,
+    routing_header: String,
+}
+
+impl OtlpUdsClient {
+    pub(super) fn new(settings: &OtlpUdsOutputSettings) -> BootstrapResult<Self> {
+        ensure!(
+            !settings.socket_path.is_empty(),
+            "user tracing OTLP UDS `socket_path` must be set"
+        );
+        ensure!(
+            !settings.routing_header_name.is_empty(),
+            "user tracing OTLP UDS `routing_header_name` must be set"
+        );
+
+        Ok(Self {
+            socket_path: settings.socket_path.clone(),
+            routing_header: settings.routing_header_name.clone(),
+        })
+    }
+
+    /// Processes a single drained batch of spans: groups them by routing,
+    /// converts each to OTLP, and POSTs one request per group. Errors are
+    /// reported and do not abort the batch.
+    async fn process_batch(&self, service_info: &ServiceInfo, spans: &mut Vec<FinishedSpan>) {
+        // Group spans by routing so each request carries a single routing value
+        // in its header, encoded once per group.
+        let mut groups: HashMap<String, (String, Vec<ResourceSpans>)> = HashMap::new();
+
+        for span in spans.drain(..) {
+            // Spans without routing aren't user-traced spans we can route, so
+            // drop them. Borrow routing before `convert_span` consumes the span.
+            let Some(routing) = span.routing() else {
+                continue;
+            };
+            let entry = groups
+                .entry(routing.group_key())
+                .or_insert_with(|| (routing.encode(), Vec::new()));
+
+            entry.1.push(convert_span(span, service_info));
+        }
+
+        for (_group_key, (header_value, resource_spans)) in groups {
+            let body = ExportTraceServiceRequest { resource_spans }.encode_to_vec();
+
+            if let Err(err) = self.send(body, header_value).await {
+                reporter_error(err);
+            }
+        }
+    }
+
+    /// POSTs a single OTLP request body to the receptor, tagged with the routing
+    /// header.
+    async fn send(&self, body: Vec<u8>, header_value: String) -> Result<(), OtlpUdsExportError> {
+        let stream = UnixStream::connect(&self.socket_path)
+            .await
+            .map_err(OtlpUdsExportError::Connect)?;
+
+        let (mut send_request, conn) = hyper::client::conn::http1::handshake(TokioIo::new(stream))
+            .await
+            .map_err(OtlpUdsExportError::Handshake)?;
+
+        // Drive the connection in the background; request/response errors are
+        // surfaced via `send_request` below, and the driver completes once the
+        // exchange is done.
+        tokio::spawn(async move {
+            let _ = conn.await;
+        });
+
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri(TRACES_PATH)
+            .header(HOST, HOST_HEADER_VALUE)
+            .header(CONTENT_TYPE, CONTENT_TYPE_PROTOBUF)
+            .header(self.routing_header.as_str(), header_value)
+            .body(Full::new(Bytes::from(body)))
+            .map_err(OtlpUdsExportError::BuildRequest)?;
+
+        let response = send_request
+            .send_request(request)
+            .await
+            .map_err(OtlpUdsExportError::Send)?;
+
+        let status = response.status();
+        if !status.is_success() {
+            return Err(OtlpUdsExportError::Status(status));
+        }
+
+        Ok(())
+    }
+}
+
+pub(super) fn start(
+    service_info: &ServiceInfo,
+    settings: &OtlpUdsOutputSettings,
+    span_rx: SharedSpanReceiver,
+) -> BootstrapResult<TraceOutputFutures> {
+    let client = Arc::new(OtlpUdsClient::new(settings)?);
+    let max_batch_size = settings.max_batch_size;
+
+    let workers = (0..settings.num_tasks)
+        .map(|_| {
+            let client = Arc::clone(&client);
+            let service_info = service_info.clone();
+            let span_rx = span_rx.clone();
+
+            async move { do_export(client, service_info, span_rx, max_batch_size).await }.boxed()
+        })
+        .collect();
+
+    Ok(TraceOutputFutures {
+        initializer: None,
+        workers,
+    })
+}
+
+/// Drains the span channel and hands each batch to the client for export.
+async fn do_export(
+    client: Arc<OtlpUdsClient>,
+    service_info: ServiceInfo,
+    span_rx: SharedSpanReceiver,
+    max_batch_size: usize,
+) {
+    let mut batch = Vec::with_capacity(max_batch_size);
+
+    while span_rx.recv_many(&mut batch, max_batch_size).await > 0 {
+        client.process_batch(&service_info, &mut batch).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cf_rustracing::span::RoutingMetadata;
+    use http_body_util::BodyExt as _;
+    use hyper::Response;
+    use hyper::body::Incoming;
+    use hyper::service::service_fn;
+    use std::convert::Infallible;
+    use std::path::{Path, PathBuf};
+    use tempfile::TempDir;
+    use tokio::net::UnixListener;
+    use tokio::sync::mpsc;
+
+    const TEST_ROUTING_HEADER: &str = "cf-trace-config";
+
+    #[derive(Debug)]
+    struct TestRouting {
+        zone_id: u64,
+        account_id: u64,
+    }
+
+    impl RoutingMetadata for TestRouting {
+        fn group_key(&self) -> String {
+            format!("{}|{}", self.zone_id, self.account_id)
+        }
+
+        fn encode(&self) -> String {
+            serde_json::json!({
+                "zoneId": self.zone_id,
+                "accountId": self.account_id,
+            })
+            .to_string()
+        }
+    }
+
+    struct CapturedRequest {
+        method: String,
+        path: String,
+        host: Option<String>,
+        content_type: Option<String>,
+        trace_config: Option<String>,
+        body: Vec<u8>,
+    }
+
+    /// Binds a UDS "receptor" that captures the first request it receives and
+    /// replies with `status`. The returned `TempDir` must be kept alive for the
+    /// socket file to remain valid.
+    fn spawn_receptor(
+        status: StatusCode,
+    ) -> (PathBuf, TempDir, mpsc::UnboundedReceiver<CapturedRequest>) {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("otlp.sock");
+        let listener = UnixListener::bind(&socket_path).unwrap();
+
+        let (tx, rx) = mpsc::unbounded_channel();
+
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+
+            let service = service_fn(move |req: Request<Incoming>| {
+                let tx = tx.clone();
+
+                async move {
+                    let (parts, body) = req.into_parts();
+                    let headers = &parts.headers;
+                    let get = |name: &str| {
+                        headers
+                            .get(name)
+                            .and_then(|v| v.to_str().ok())
+                            .map(str::to_owned)
+                    };
+
+                    let captured = CapturedRequest {
+                        method: parts.method.to_string(),
+                        path: parts.uri.path().to_string(),
+                        host: get("host"),
+                        content_type: get("content-type"),
+                        trace_config: get(TEST_ROUTING_HEADER),
+                        body: body.collect().await.unwrap().to_bytes().to_vec(),
+                    };
+
+                    tx.send(captured).ok();
+
+                    Ok::<_, Infallible>(
+                        Response::builder()
+                            .status(status)
+                            .body(Full::new(Bytes::new()))
+                            .unwrap(),
+                    )
+                }
+            });
+
+            hyper::server::conn::http1::Builder::new()
+                .serve_connection(TokioIo::new(stream), service)
+                .await
+                .ok();
+        });
+
+        (socket_path, dir, rx)
+    }
+
+    fn settings_for(socket_path: &Path) -> OtlpUdsOutputSettings {
+        OtlpUdsOutputSettings {
+            socket_path: socket_path.to_string_lossy().into_owned(),
+            routing_header_name: TEST_ROUTING_HEADER.to_string(),
+            num_tasks: 1,
+            max_batch_size: 8,
+        }
+    }
+
+    #[tokio::test]
+    async fn new_rejects_empty_socket_path() {
+        let err = OtlpUdsClient::new(&OtlpUdsOutputSettings {
+            socket_path: String::new(),
+            routing_header_name: TEST_ROUTING_HEADER.to_string(),
+            num_tasks: 1,
+            max_batch_size: 8,
+        })
+        .unwrap_err();
+
+        assert!(err.to_string().contains("socket_path"));
+    }
+
+    #[tokio::test]
+    async fn send_posts_otlp_with_headers_and_body() {
+        let (socket_path, _dir, mut rx) = spawn_receptor(StatusCode::OK);
+
+        let client = OtlpUdsClient::new(&settings_for(&socket_path)).unwrap();
+
+        let body = b"hello-otlp".to_vec();
+        let trace_config = r#"{"zone_id":"z1"}"#.to_string();
+
+        client
+            .send(body.clone(), trace_config.clone())
+            .await
+            .unwrap();
+
+        let captured = rx.recv().await.unwrap();
+        assert_eq!(captured.method, "POST");
+        assert_eq!(captured.path, TRACES_PATH);
+        assert_eq!(captured.host.as_deref(), Some(HOST_HEADER_VALUE));
+        assert_eq!(
+            captured.content_type.as_deref(),
+            Some(CONTENT_TYPE_PROTOBUF)
+        );
+        assert_eq!(
+            captured.trace_config.as_deref(),
+            Some(trace_config.as_str())
+        );
+        assert_eq!(captured.body, body);
+    }
+
+    #[tokio::test]
+    async fn send_errors_on_non_success_status() {
+        let (socket_path, _dir, _rx) = spawn_receptor(StatusCode::INTERNAL_SERVER_ERROR);
+
+        let client = OtlpUdsClient::new(&settings_for(&socket_path)).unwrap();
+
+        let err = client
+            .send(b"x".to_vec(), "{}".to_string())
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            OtlpUdsExportError::Status(StatusCode::INTERNAL_SERVER_ERROR)
+        ));
+        assert!(err.to_string().contains("non-success status"));
+    }
+
+    // Drives the full path: a span produced through a tracer (with routing set)
+    // flows through the channel, is converted + encoded by `process_batch`, and
+    // arrives at the receptor with its routing in the `cf-trace-config` header.
+    #[tokio::test]
+    async fn process_batch_sends_converted_spans() {
+        use super::super::channel::{PipelineType, unbounded_channel};
+        use cf_rustracing::Tracer;
+        use cf_rustracing::sampler::AllSampler;
+
+        let (socket_path, _dir, mut rx) = spawn_receptor(StatusCode::OK);
+
+        let (sender, span_rx) = unbounded_channel(PipelineType::User);
+
+        // Produce one finished span with routing, then drop the tracer so the
+        // channel closes and the worker loop terminates after draining.
+        {
+            let tracer = Tracer::with_consumer(AllSampler, sender);
+            let _span = tracer
+                .span("user-root")
+                .routing(Arc::new(TestRouting {
+                    zone_id: 12345,
+                    account_id: 42,
+                }))
+                .start();
+        }
+
+        let service_info = crate::service_info!();
+        let futs = start(&service_info, &settings_for(&socket_path), span_rx).unwrap();
+        for worker in futs.workers {
+            tokio::spawn(worker);
+        }
+
+        let captured = rx.recv().await.unwrap();
+        assert_eq!(captured.method, "POST");
+        assert_eq!(captured.path, TRACES_PATH);
+        assert_eq!(
+            captured.content_type.as_deref(),
+            Some(CONTENT_TYPE_PROTOBUF)
+        );
+        let trace_config: serde_json::Value =
+            serde_json::from_str(captured.trace_config.as_deref().unwrap()).unwrap();
+        assert_eq!(trace_config["zoneId"], 12345);
+        assert_eq!(trace_config["accountId"], 42);
+        // Body is a protobuf-encoded `ExportTraceServiceRequest`.
+        assert!(!captured.body.is_empty());
+    }
+
+    // Full producer path: `init_user` stands up `USER_HARNESS` + the OTLP/UDS exporter, then
+    // `user_tracing::start_trace` + `user_tracing::span` + `user_tracing::add_span_tags!` produce spans that reach the
+    // receptor with routing in the configured routing header. (nextest isolates this in its own
+    // process, so the one-shot `USER_HARNESS` is fine.)
+    #[tokio::test]
+    async fn user_pipeline_exports_with_routing() {
+        use crate::telemetry::settings::{UserTracesOutput, UserTracingSettings};
+        use crate::telemetry::tracing::user_tracing;
+        use opentelemetry_proto::tonic::common::v1::any_value::Value;
+        use prost::Message as _;
+
+        let (socket_path, _dir, mut rx) = spawn_receptor(StatusCode::OK);
+
+        let settings = UserTracingSettings {
+            enabled: true,
+            max_queue_size: None,
+            output: UserTracesOutput::OtlpUds(settings_for(&socket_path)),
+        };
+
+        let service_info = crate::service_info!();
+        crate::telemetry::tracing::init::init_user(&service_info, &settings).unwrap();
+
+        {
+            let _root = user_tracing::start_trace(
+                "request",
+                TestRouting {
+                    zone_id: 12345,
+                    account_id: 42,
+                },
+                None,
+            );
+
+            let _child = user_tracing::span("child");
+            user_tracing::add_span_tags!("cache.status" => "HIT");
+        }
+
+        let captured = rx.recv().await.unwrap();
+        assert_eq!(captured.path, TRACES_PATH);
+
+        let trace_config: serde_json::Value =
+            serde_json::from_str(captured.trace_config.as_deref().unwrap()).unwrap();
+        assert_eq!(trace_config["zoneId"], 12345);
+        assert_eq!(trace_config["accountId"], 42);
+
+        // Decode the OTLP body and verify the producer API actually emitted the expected spans.
+        let req = ExportTraceServiceRequest::decode(captured.body.as_slice()).unwrap();
+        let spans: Vec<_> = req
+            .resource_spans
+            .iter()
+            .flat_map(|rs| &rs.scope_spans)
+            .flat_map(|ss| &ss.spans)
+            .collect();
+
+        let root = spans
+            .iter()
+            .find(|s| s.name == "request")
+            .expect("root span exported");
+        let child = spans
+            .iter()
+            .find(|s| s.name == "child")
+            .expect("child span exported");
+
+        // `user_tracing::add_span_tags!` wrote to the current user span (the child), not the root.
+        let tag = child
+            .attributes
+            .iter()
+            .find(|kv| kv.key == "cache.status")
+            .expect("cache.status tag present on child");
+        assert!(matches!(
+            &tag.value.as_ref().unwrap().value,
+            Some(Value::StringValue(v)) if v == "HIT"
+        ));
+        assert!(!root.attributes.iter().any(|kv| kv.key == "cache.status"));
+
+        // Correct hierarchy: child is a child of root within the same trace.
+        assert_eq!(child.trace_id, root.trace_id);
+        assert_eq!(child.parent_span_id, root.span_id);
+    }
+
+    // Stitching: a root started with an inbound `traceparent` continues that trace on the wire
+    // (same 128-bit trace id, and its parent is the inbound parent span id).
+    #[tokio::test]
+    async fn user_pipeline_continues_inbound_trace() {
+        use crate::telemetry::settings::{UserTracesOutput, UserTracingSettings};
+        use crate::telemetry::tracing::{TraceparentContext, user_tracing};
+        use prost::Message as _;
+
+        let (socket_path, _dir, mut rx) = spawn_receptor(StatusCode::OK);
+
+        let settings = UserTracingSettings {
+            enabled: true,
+            max_queue_size: None,
+            output: UserTracesOutput::OtlpUds(settings_for(&socket_path)),
+        };
+        crate::telemetry::tracing::init::init_user(&crate::service_info!(), &settings).unwrap();
+
+        let inbound =
+            TraceparentContext::parse(b"00-11223344556677889900aabbccddeeff-a1b2c3d4e5f60718-01")
+                .unwrap();
+
+        {
+            let _root = user_tracing::start_trace(
+                "request",
+                TestRouting {
+                    zone_id: 12345,
+                    account_id: 42,
+                },
+                Some(inbound),
+            );
+        }
+
+        let captured = rx.recv().await.unwrap();
+        let req = ExportTraceServiceRequest::decode(captured.body.as_slice()).unwrap();
+        let root = req
+            .resource_spans
+            .iter()
+            .flat_map(|rs| &rs.scope_spans)
+            .flat_map(|ss| &ss.spans)
+            .find(|s| s.name == "request")
+            .expect("root span exported");
+
+        assert_eq!(root.trace_id, inbound.trace_id);
+        assert_eq!(root.parent_span_id, inbound.parent_id);
+    }
+
+    // Routing set on the root is inherited by all descendants, so a grandchild also exports
+    // (the exporter drops spans without routing).
+    #[tokio::test]
+    async fn user_pipeline_inherits_routing_to_descendants() {
+        use crate::telemetry::settings::{UserTracesOutput, UserTracingSettings};
+        use crate::telemetry::tracing::user_tracing;
+        use prost::Message as _;
+
+        let (socket_path, _dir, mut rx) = spawn_receptor(StatusCode::OK);
+
+        let settings = UserTracingSettings {
+            enabled: true,
+            max_queue_size: None,
+            output: UserTracesOutput::OtlpUds(settings_for(&socket_path)),
+        };
+        crate::telemetry::tracing::init::init_user(&crate::service_info!(), &settings).unwrap();
+
+        {
+            let _root = user_tracing::start_trace(
+                "request",
+                TestRouting {
+                    zone_id: 12345,
+                    account_id: 42,
+                },
+                None,
+            );
+            let _child = user_tracing::span("child");
+            let _grandchild = user_tracing::span("grandchild");
+        }
+
+        let captured = rx.recv().await.unwrap();
+        let req = ExportTraceServiceRequest::decode(captured.body.as_slice()).unwrap();
+        let names: Vec<&str> = req
+            .resource_spans
+            .iter()
+            .flat_map(|rs| &rs.scope_spans)
+            .flat_map(|ss| &ss.spans)
+            .map(|s| s.name.as_str())
+            .collect();
+
+        assert!(names.contains(&"request"));
+        assert!(names.contains(&"child"));
+        assert!(names.contains(&"grandchild"));
+    }
+}

--- a/foundations/src/telemetry/tracing/testing.rs
+++ b/foundations/src/telemetry/tracing/testing.rs
@@ -160,6 +160,22 @@ impl TestTracerScope {
     }
 }
 
+#[cfg(feature = "user-tracing")]
+#[must_use]
+pub(crate) struct UserTestTracerScope {
+    _inner: Scope<Tracer>,
+}
+
+#[cfg(feature = "user-tracing")]
+impl UserTestTracerScope {
+    #[inline]
+    pub(crate) fn new(tracer: Tracer) -> Self {
+        Self {
+            _inner: Scope::new(&TracingHarness::get_user().test_tracer_scope_stack, tracer),
+        }
+    }
+}
+
 pub(crate) struct TestTracesSink {
     span_rx: SharedSpanReceiver,
     raw_spans: HashMap<ParentId, Vec<FinishedSpan>>,
@@ -252,6 +268,11 @@ fn span_tags(raw_span: &FinishedSpan) -> Vec<(String, TagValue)> {
 
 pub(crate) fn current_test_tracer() -> Option<Tracer> {
     TracingHarness::get().test_tracer_scope_stack.current()
+}
+
+#[cfg(feature = "user-tracing")]
+pub(crate) fn current_user_test_tracer() -> Option<Tracer> {
+    TracingHarness::get_user().test_tracer_scope_stack.current()
 }
 
 pub(crate) fn create_test_tracer(settings: &TracingSettings) -> (Tracer, TestTracesSink) {

--- a/foundations/src/telemetry/tracing/traceparent.rs
+++ b/foundations/src/telemetry/tracing/traceparent.rs
@@ -1,0 +1,267 @@
+//! W3C Trace Context `traceparent` header parsing.
+//!
+//! Format: `{version}-{trace-id}-{parent-id}-{trace-flags}` (55 bytes, all ASCII).
+//!
+//! Example: `00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01`
+//!
+//! See <https://www.w3.org/TR/trace-context/#traceparent-header>.
+//!
+//! This is the inbound counterpart to the outbound formatter
+//! [`w3c_traceparent`](crate::telemetry::tracing::user_tracing::w3c_traceparent): it parses the
+//! W3C `traceparent` carried in the user-tracing control header so an inbound trace can be
+//! continued by [`start_trace`](crate::telemetry::tracing::user_tracing::start_trace).
+
+/// Parsed components of a valid W3C `traceparent` header value.
+///
+/// Constructed via [`TraceparentContext::parse`]. Round-trippable via
+/// [`TraceparentContext::to_traceparent_string`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TraceparentContext {
+    /// W3C trace-context version. Only `0` (the `00` wire version) is currently accepted.
+    pub version: u8,
+    /// 16-byte (128-bit) trace identifier.
+    pub trace_id: [u8; 16],
+    /// 8-byte (64-bit) parent span identifier.
+    pub parent_id: [u8; 8],
+    /// Trace flags bitfield; bit 0 is the "sampled" flag.
+    pub trace_flags: u8,
+}
+
+impl TraceparentContext {
+    /// Parse a `traceparent` header value.
+    ///
+    /// Returns `None` on any of:
+    /// - Not valid UTF-8
+    /// - Wrong total length or missing/extra dashes
+    /// - Wrong field widths (version=2, trace-id=32, parent-id=16, flags=2)
+    /// - Non-hex characters in any field
+    /// - Unsupported version (only `00` accepted per current W3C spec)
+    /// - All-zero trace-id or parent-id (invalid per spec)
+    pub fn parse(value: &[u8]) -> Option<Self> {
+        let s = std::str::from_utf8(value).ok()?;
+
+        let mut parts = s.splitn(4, '-');
+        let version_str = parts.next()?;
+        let trace_id_str = parts.next()?;
+        let parent_id_str = parts.next()?;
+        let flags_str = parts.next()?;
+
+        // Trailing content (extra dashes) ends up in `flags_str` since `splitn(4)`
+        // packs any remainder into the last segment; the length check below catches it.
+        if version_str.len() != 2
+            || trace_id_str.len() != 32
+            || parent_id_str.len() != 16
+            || flags_str.len() != 2
+        {
+            return None;
+        }
+
+        let version = u8::from_str_radix(version_str, 16).ok()?;
+        // Only version 00 is supported.
+        if version != 0 {
+            return None;
+        }
+
+        let trace_flags = u8::from_str_radix(flags_str, 16).ok()?;
+
+        let mut trace_id = [0u8; 16];
+        hex::decode_to_slice(trace_id_str, &mut trace_id).ok()?;
+
+        let mut parent_id = [0u8; 8];
+        hex::decode_to_slice(parent_id_str, &mut parent_id).ok()?;
+
+        // Per W3C spec, all-zero trace-id and parent-id are invalid.
+        if trace_id == [0u8; 16] || parent_id == [0u8; 8] {
+            return None;
+        }
+
+        Some(Self {
+            version,
+            trace_id,
+            parent_id,
+            trace_flags,
+        })
+    }
+
+    /// Returns true if the sampled bit (bit 0) of `trace_flags` is set,
+    /// indicating the caller decided this trace should be recorded.
+    pub fn is_sampled(&self) -> bool {
+        self.trace_flags & 0x01 != 0
+    }
+
+    /// Re-serialize the parsed context back to a canonical W3C `traceparent` string.
+    pub fn to_traceparent_string(self) -> String {
+        let mut buf = vec![0u8; 55];
+        hex::encode_to_slice([self.version], &mut buf[0..2]).expect("size=2");
+        buf[2] = b'-';
+        hex::encode_to_slice(self.trace_id, &mut buf[3..35]).expect("size=32");
+        buf[35] = b'-';
+        hex::encode_to_slice(self.parent_id, &mut buf[36..52]).expect("size=16");
+        buf[52] = b'-';
+        hex::encode_to_slice([self.trace_flags], &mut buf[53..55]).expect("size=2");
+        String::from_utf8(buf).expect("valid UTF-8")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID: &str = "00-11223344556677889900aabbccddeeff-a1b2c3d4e5f60718-01";
+
+    #[test]
+    fn parse_valid() {
+        let tp = TraceparentContext::parse(VALID.as_bytes()).expect("valid");
+        assert_eq!(tp.version, 0);
+        assert_eq!(
+            tp.trace_id,
+            [
+                0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0x00, 0xaa, 0xbb, 0xcc, 0xdd,
+                0xee, 0xff,
+            ]
+        );
+        assert_eq!(
+            tp.parent_id,
+            [0xa1, 0xb2, 0xc3, 0xd4, 0xe5, 0xf6, 0x07, 0x18]
+        );
+        assert_eq!(tp.trace_flags, 0x01);
+        assert!(tp.is_sampled());
+    }
+
+    #[test]
+    fn roundtrip() {
+        let tp = TraceparentContext::parse(VALID.as_bytes()).expect("valid");
+        assert_eq!(tp.to_traceparent_string(), VALID);
+    }
+
+    #[test]
+    fn uppercase_hex_accepted() {
+        // Uppercase input accepted; output is always lowercase.
+        let uppercase = "00-11223344556677889900AABBCCDDEEFF-A1B2C3D4E5F60718-01";
+        let tp = TraceparentContext::parse(uppercase.as_bytes()).expect("uppercase accepted");
+        assert_eq!(tp.to_traceparent_string(), VALID);
+    }
+
+    #[test]
+    fn sampled_with_extra_flags() {
+        // Bit 0 = sampled; extra bits (e.g. 0x02) are preserved and propagated.
+        let s = "00-11223344556677889900aabbccddeeff-a1b2c3d4e5f60718-03";
+        let tp = TraceparentContext::parse(s.as_bytes()).expect("valid");
+        assert_eq!(tp.trace_flags, 0x03);
+        assert!(tp.is_sampled());
+    }
+
+    #[test]
+    fn unsampled_is_valid() {
+        let s = "00-11223344556677889900aabbccddeeff-a1b2c3d4e5f60718-00";
+        let tp = TraceparentContext::parse(s.as_bytes()).expect("valid");
+        assert_eq!(tp.trace_flags, 0x00);
+        assert!(!tp.is_sampled());
+    }
+
+    #[test]
+    fn empty() {
+        assert!(TraceparentContext::parse(b"").is_none());
+    }
+
+    #[test]
+    fn degenerate() {
+        assert!(TraceparentContext::parse(b"---").is_none());
+        assert!(TraceparentContext::parse(b"00-1-1-00").is_none());
+    }
+
+    #[test]
+    fn wrong_total_length() {
+        // Too short (flags truncated)
+        assert!(
+            TraceparentContext::parse(b"00-11223344556677889900aabbccddeeff-a1b2c3d4e5f60718-0")
+                .is_none()
+        );
+        // Too long (extra char on flags)
+        assert!(
+            TraceparentContext::parse(b"00-11223344556677889900aabbccddeeff-a1b2c3d4e5f60718-012")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn wrong_field_sizes() {
+        // version too short
+        assert!(
+            TraceparentContext::parse(b"0-11223344556677889900aabbccddeeff0-a1b2c3d4e5f60718-01")
+                .is_none()
+        );
+        // trace-id too long
+        assert!(
+            TraceparentContext::parse(b"00-11223344556677889900aabbccddeeff0-1b2c3d4e5f60718-01")
+                .is_none()
+        );
+        // trace-id too short
+        assert!(
+            TraceparentContext::parse(b"00-11223344556677889900aabbccddee-a1b2c3d4e5f6071800-01")
+                .is_none()
+        );
+        // parent-id too long
+        assert!(
+            TraceparentContext::parse(b"00-1223344556677889900aabbccddeeff-a1b2c3d4e5f607180-01")
+                .is_none()
+        );
+        // parent-id too short
+        assert!(
+            TraceparentContext::parse(b"00-112233445566778899900aabbccddeeff-1b2c3d4e5f6071-01")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn empty_fields() {
+        assert!(TraceparentContext::parse(b"00--a1b2c3d4e5f60718-01").is_none());
+        assert!(TraceparentContext::parse(b"00-11223344556677889900aabbccddeeff--01").is_none());
+    }
+
+    #[test]
+    fn bad_hex() {
+        assert!(
+            TraceparentContext::parse(b"0g-11223344556677889900aabbccddeeff-a1b2c3d4e5f60718-01")
+                .is_none()
+        );
+        assert!(
+            TraceparentContext::parse(b"00-x1223344556677889900aabbccddeeff-a1b2c3d4e5f60718-01")
+                .is_none()
+        );
+        assert!(
+            TraceparentContext::parse(b"00-11223344556677889900aabbccddeeff-a1b2c3d4e5f6071x-01")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn unsupported_version() {
+        // Future versions rejected: current spec only defines version 00.
+        assert!(
+            TraceparentContext::parse(b"01-11223344556677889900aabbccddeeff-a1b2c3d4e5f60718-01")
+                .is_none()
+        );
+        assert!(
+            TraceparentContext::parse(b"ff-11223344556677889900aabbccddeeff-a1b2c3d4e5f60718-01")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn all_zero_trace_id_rejected() {
+        let s = "00-00000000000000000000000000000000-a1b2c3d4e5f60718-01";
+        assert!(TraceparentContext::parse(s.as_bytes()).is_none());
+    }
+
+    #[test]
+    fn all_zero_parent_id_rejected() {
+        let s = "00-11223344556677889900aabbccddeeff-0000000000000000-01";
+        assert!(TraceparentContext::parse(s.as_bytes()).is_none());
+    }
+
+    #[test]
+    fn non_utf8() {
+        assert!(TraceparentContext::parse(&[0xff, 0xfe, 0xfd]).is_none());
+    }
+}


### PR DESCRIPTION
## Overview

This adds a **user-facing span pipeline** to `foundations`, parallel to the existing internal tracing pipeline. Application code can emit spans into a separate `USER_HARNESS` that exports **OTLP HTTP over a Unix domain socket** (gRPC unsupported) to an OTLP endpoint, with per-trace **routing metadata** (an application-defined `RoutingMetadata` trait) carried on the wire and W3C `traceparent` continuation in/out.

The design is deliberately a **mirror of internal tracing onto a second harness**: the user API lives in a dedicated `tracing::user_tracing` module whose entry points (`user_tracing::start_trace`, `user_tracing::span`, `user_tracing::add_span_tags!`, …) mirror the top-level internal-tracing functions (`start_trace`, `span`, `add_span_tags!`, …), plus a top-level `dual_span` that records into both pipelines at once. Two hard rules shape the surface:

- **The user and internal pipelines are independent** — separate harnesses, scope stacks, and exporters  
- **Public surface speaks W3C.**

There are two layers to keep separate:

- **init-time:** stand up `USER_HARNESS` \+ the exporter, pointed at the OTLP endpoint's socket.  
- **per-request activation:** `user_tracing::start_trace(...)` opens a root. Without a root, every `user_tracing::span` / `dual_span()` / `#[span_fn(user = true)]` / `user_tracing::add_span_tags!` is a **no-op**.

---

## User guide

### Settings (init-time)

User tracing is configured via one optional block, gated by the `user-tracing` feature and fed to the existing `foundations::telemetry::init`:

```
TelemetrySettings.user_tracing: Option<UserTracingSettings>   // None = off
```

```rust
UserTracingSettings {
    enabled: bool,                       // default: false  (user tracing is opt-in)
    max_queue_size: Option<NonZeroUsize>,// default: 1_000_000; None = unbounded (mirrors internal)
    output: UserTracesOutput,            // only variant today: OtlpUds(..)
}

OtlpUdsOutputSettings {
    socket_path: String,        // ← path to the OTLP endpoint's UDS (required, no default)
                                //   e.g. "/path/to/otlp-receptor.sock"
    routing_header_name: String,// ← header the endpoint reads each span's encoded routing from
                                //   (required, no default) e.g. "cf-trace-config"
    num_tasks: usize,           // default: 1    (concurrent export workers)
    max_batch_size: usize,      // default: 512  (spans drained per export batch)
}
```

The two settings a consumer must choose are **`socket_path`** (the OTLP endpoint's UDS) and **`routing_header_name`** (the header the endpoint reads routing from). Unlike internal tracing, **user tracing is off by default** (`enabled: false`) and must be turned on explicitly; `max_queue_size` mirrors its internal-tracing equivalent; `num_tasks` and `max_batch_size` tune the exporter. All others have defaults and can be configured as needed.

There is deliberately **no sampling configuration** here. Unlike internal tracing, the user pipeline is not sampled inside foundations — the inbound `user_tracing` control header drives the activation (and therefore sampling) decision upstream.

### Instrumentation APIs

Toy example covering the whole surface:

```rust
use foundations::telemetry::tracing::{self, RoutingMetadata, TraceparentContext};

// `RoutingMetadata` is a trait — you define the concrete routing type. `group_key` batches
// spans that share it into one request; `encode` produces the routing header's value.
#[derive(Debug)]
struct MyRouting { zone_id: u64, account_id: u64 }

impl RoutingMetadata for MyRouting {
    fn group_key(&self) -> String { format!("{}|{}", self.zone_id, self.account_id) }
    fn encode(&self) -> String { format!("zone={};account={}", self.zone_id, self.account_id) }
}

// Per request: open the root. `routing` is required and fixed at construction (inherited by all
// descendants); `inbound` continues an upstream W3C trace, or None for a fresh one.
let _root = tracing::user_tracing::start_trace(
    "example_span_name",
    MyRouting { zone_id, account_id },
    inbound,                       // Option<TraceparentContext>
);

// Children — pick whichever fits:
let _child = tracing::user_tracing::span("lookup"); // explicit standalone user child
let _s     = tracing::dual_span("db");              // parallel internal + user child

#[tracing::span_fn("handle_request", user = true)]  // whole-fn dual span (sync or async)
async fn handle_request() { /* ... */ }

// Annotate the current user span (no-op if no user trace is active):
tracing::user_tracing::add_span_tags!("cache.status" => "HIT");

// Across .await / spawn / separate hooks (UserSpanScope is !Send): hold the context.
let ctx = tracing::user_tracing::start_trace("req", routing, None).into_context(); // -> TelemetryContext
ctx.apply(async { let _c = tracing::user_tracing::span("work"); }).await;

// Outbound propagation to the next hop:
let traceparent: Option<String> = tracing::user_tracing::w3c_traceparent();

// Inbound parsing (strict W3C):
let inbound = TraceparentContext::parse(header_bytes); // -> Option<TraceparentContext>
```

Key points for users:

- The **context carries the user span**: `into_context()` / `TelemetryContext::current()` / `#[span_fn]` all propagate it across `.await`, even through an *internal* span's context — no manual threading.  
- **`dual_span()` and `#[span_fn(user = true)]` open a user span in parallel with an internal span** — this matches the guideline to create an internal span for every user span, so a single call feeds both pipelines. `dual_span` names both spans from the same argument, so the user span keeps its name even when the internal trace is sampled out (the two pipelines sample independently).
- **Forking a trace leaves the user trace intact** — `TelemetryContext`'s trace fork only forks the *internal* trace; user spans created in the forked context stay in the current user trace.