### PR TITLE
Release foundations version 5.7.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "5.7.3"
+version = "5.7.4"
 repository = "https://github.com/cloudflare/foundations"
 edition = "2024"
 authors = ["Cloudflare"]
@@ -40,8 +40,8 @@ check-cfg = [
 [workspace.dependencies]
 anyhow = "1.0.102"
 backtrace = "0.3.76"
-foundations = { version = "5.7.3", path = "./foundations", default-features = false }
-foundations-macros = { version = "=5.7.3", path = "./foundations-macros", default-features = false }
+foundations = { version = "5.7.4", path = "./foundations", default-features = false }
+foundations-macros = { version = "=5.7.4", path = "./foundations-macros", default-features = false }
 bindgen = { version = "0.72.1", default-features = false }
 cc = "1.2.61"
 cf-rustracing = "1.3.0"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,12 @@
 
+5.7.4
+- 2026-06-29 Fix potential double panic when logging inside panic hook
+- 2026-06-29 Add regression tests for panic hook logging
+- 2026-06-26 Fix double-panic in panic hook stderr
+- 2026-06-22 Use a dash instead of a dot in bonk model name
+- 2026-06-22 Fix bonk workflow by downgrading opencode
+- 2026-06-19 Setup bonk workflow
+
 5.7.3
 - 2026-06-10 Add cfg(foundations_jemalloc_disable) to opt out of global jemalloc allocator
 - 2026-06-10 Move cfg(foundations_generic_telemetry_wrapper) docs out of lib.rs


### PR DESCRIPTION
### Fixed
- The logging code inside foundations' panic hook could itself panic, especially when the stdout/stderr streams were broken. This is always a double panic, causing a process abort. We now swallow IO errors instead (#224).