### PR TITLE
Release foundations version 5.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "5.7.4"
+version = "5.8.0"
 repository = "https://github.com/cloudflare/foundations"
 edition = "2024"
 authors = ["Cloudflare"]
@@ -41,8 +41,8 @@ check-cfg = [
 [workspace.dependencies]
 anyhow = "1.0.102"
 backtrace = "0.3.76"
-foundations = { version = "5.7.4", path = "./foundations", default-features = false }
-foundations-macros = { version = "=5.7.4", path = "./foundations-macros", default-features = false }
+foundations = { version = "5.8.0", path = "./foundations", default-features = false }
+foundations-macros = { version = "=5.8.0", path = "./foundations-macros", default-features = false }
 bindgen = { version = "0.72.1", default-features = false }
 cc = "1.2.61"
 cf-rustracing = "1.4.0"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,17 @@
 
+5.8.0
+- 2026-06-17 Bump tikv-jemallocator to 0.7.0
+- 2026-07-16 Add user-facing tracing pipeline
+- 2026-07-14 Make log output I/O errors optionally fail-soft
+- 2026-07-10 Split tracing metrics to allow multiple pipelines
+- 2026-07-10 chore(metrics-registry): remove subsystem comment
+- 2026-07-10 refactor(metrics-registry): simplify snapshots with static metric references
+- 2026-07-10 Apply suggestions from code review
+- 2026-07-09 feat(metrics-registry): add core registration API
+- 2026-07-09 fix(cargo): fix fmt & clippy
+- 2026-07-08 feat(metrics-registry): vendor generated Prometheus protobuf model
+- 2026-07-08 feat(metrics-registry): add crate with Prometheus protobuf data model
+
 5.7.4
 - 2026-06-29 Fix potential double panic when logging inside panic hook
 - 2026-06-29 Add regression tests for panic hook logging


### PR DESCRIPTION
### Breaking
- #217: Users who make their own `tikv-jemalloc-sys` or `tikv-jemalloc-ctl` calls will need to update their dependency version to `0.7.0` as well. The upstream jemalloc release brings with it a host of performance and robustness improvements, and direct jemalloc interactions are rare, so we decided a semver violation was warranted in this case.

### Added
- #223: A separate "user tracing" pipeline is available to record traces that are intended for end-user/customer consumption. The traces are batched based on routing metadata to allow an external service to forward them directly to a user's configured destination(s).
- #231: `LoggingSettings::ignore_io_errors` can be enabled to make stdout/stderr/file IO errors non-fatal for foundations' logger. This is disabled by default, preserving the existing behavior of panicking in such situations.

### Changed
- #230: Tracing consumer queue metrics carry a new label `pipeline=""` for the system pipeline. This is backwards compatible, as Prometheus treats an empty label the same as an absent one.