### PR TITLE
feat(metrics): add support for metric families and label serialisation

### DIFF
--- a/foundations-metrics-registry/src/proto/mod.rs
+++ b/foundations-metrics-registry/src/proto/mod.rs
@@ -9,7 +9,9 @@
 #[allow(missing_docs, unreachable_pub, clippy::all)]
 mod model;
 
-pub use model::{BucketSpan, Counter, Gauge, Histogram, Metric, MetricFamily, MetricType};
+pub use model::{
+    BucketSpan, Counter, Gauge, Histogram, LabelPair, Metric, MetricFamily, MetricType,
+};
 
 #[cfg(test)]
 mod tests {

--- a/foundations-metrics/Cargo.toml
+++ b/foundations-metrics/Cargo.toml
@@ -11,6 +11,7 @@ foundations-metrics-registry = { workspace = true }
 prometheus-client = "0.25.0"
 serde = { workspace = true, features = ["derive"] }
 ryu = "1.0.23"
+parking_lot = { workspace = true }
 
 [lints]
 workspace = true

--- a/foundations-metrics/Cargo.toml
+++ b/foundations-metrics/Cargo.toml
@@ -9,6 +9,8 @@ license.workspace = true
 [dependencies]
 foundations-metrics-registry = { workspace = true }
 prometheus-client = "0.25.0"
+serde = { workspace = true, features = ["derive"] }
+ryu = "1.0.23"
 
 [lints]
 workspace = true

--- a/foundations-metrics/src/diagnostics.rs
+++ b/foundations-metrics/src/diagnostics.rs
@@ -1,0 +1,61 @@
+//! Reporting of non-fatal diagnostics produced while collecting metrics.
+
+use std::error::Error;
+use std::fmt;
+use std::io::{self, Write};
+use std::sync::OnceLock;
+
+type CollectErrorHook = Box<dyn for<'a> Fn(fmt::Arguments<'a>) + Send + Sync>;
+
+static COLLECT_ERROR_HOOK: OnceLock<CollectErrorHook> = OnceLock::new();
+
+/// Error returned by [`set_collect_error_hook`] when a hook is already installed.
+#[derive(Debug)]
+pub struct CollectErrorHookAlreadySet(());
+
+impl fmt::Display for CollectErrorHookAlreadySet {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a metric collection error hook is already installed")
+    }
+}
+
+impl Error for CollectErrorHookAlreadySet {}
+
+/// Routes non-fatal metric-collection diagnostics through a custom hook.
+///
+/// Collecting metrics never fails: label sets or metric groups that cannot be
+/// encoded are skipped and a non-fatal diagnostic is emitted instead. By default
+/// these diagnostics are written to standard error.
+///
+/// `foundations-metrics` is the low-level layer of the metrics stack and
+/// deliberately depends on no logging framework, keeping logging decoupled from
+/// metrics and avoiding a dependency cycle with higher-level crates. Instead of
+/// calling into a logger directly, it exposes this seam: install a hook to route
+/// collection diagnostics into your logging pipeline (typically at warning
+/// level). The hook applies process-wide and can only be set once.
+///
+/// ```no_run
+/// foundations_metrics::set_collect_error_hook(|args| {
+///     // Forward to your logging framework, e.g. `log`, `tracing`, or `slog`.
+///     eprintln!("{args}");
+/// })
+/// .expect("collect error hook installed once during start-up");
+/// ```
+pub fn set_collect_error_hook(
+    hook: impl for<'a> Fn(fmt::Arguments<'a>) + Send + Sync + 'static,
+) -> Result<(), CollectErrorHookAlreadySet> {
+    COLLECT_ERROR_HOOK
+        .set(Box::new(hook))
+        .map_err(|_| CollectErrorHookAlreadySet(()))
+}
+
+/// Emits a non-fatal collection diagnostic through the installed hook, falling
+/// back to standard error when no hook is set.
+pub(crate) fn report_collect_error(args: fmt::Arguments<'_>) {
+    match COLLECT_ERROR_HOOK.get() {
+        Some(hook) => hook(args),
+        None => {
+            let _ = writeln!(io::stderr().lock(), "{args}");
+        }
+    }
+}

--- a/foundations-metrics/src/labels/error.rs
+++ b/foundations-metrics/src/labels/error.rs
@@ -1,6 +1,8 @@
 use std::error::Error;
 use std::fmt;
 
+// Adapted from prometools' `serde::error::Error`
+// (https://github.com/nox/prometools, licensed MIT OR Apache-2.0).
 /// An error produced while serializing a metric label set.
 #[derive(Debug)]
 pub struct LabelError {

--- a/foundations-metrics/src/labels/error.rs
+++ b/foundations-metrics/src/labels/error.rs
@@ -1,0 +1,33 @@
+use std::error::Error;
+use std::fmt;
+
+/// An error produced while serializing a metric label set.
+#[derive(Debug)]
+pub struct LabelError {
+    message: String,
+}
+
+impl LabelError {
+    pub(crate) fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for LabelError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for LabelError {}
+
+impl serde::ser::Error for LabelError {
+    fn custom<T>(message: T) -> Self
+    where
+        T: fmt::Display,
+    {
+        Self::new(message.to_string())
+    }
+}

--- a/foundations-metrics/src/labels/mod.rs
+++ b/foundations-metrics/src/labels/mod.rs
@@ -14,6 +14,11 @@ use serde::Serialize;
 ///
 /// Label values are stored as raw strings. OpenMetrics escaping is deliberately
 /// deferred until text encoding.
+///
+/// Unit structs and fieldless enum variants serialize to their Rust type or
+/// variant *name* (after any `serde` rename), so renaming the type silently
+/// changes the emitted label value. Use `#[serde(rename = "...")]` to pin a
+/// stable value that is independent of the Rust name.
 pub fn to_label_pairs<S>(labels: &S) -> Result<Vec<LabelPair>, LabelError>
 where
     S: Serialize + ?Sized,

--- a/foundations-metrics/src/labels/mod.rs
+++ b/foundations-metrics/src/labels/mod.rs
@@ -8,6 +8,8 @@ pub use error::LabelError;
 use foundations_metrics_registry::proto::LabelPair;
 use serde::Serialize;
 
+// Adapted from prometools' `serde` label serializer
+// (https://github.com/nox/prometools, licensed MIT OR Apache-2.0).
 /// Serializes a label set into protobuf label pairs.
 ///
 /// Label values are stored as raw strings. OpenMetrics escaping is deliberately

--- a/foundations-metrics/src/labels/mod.rs
+++ b/foundations-metrics/src/labels/mod.rs
@@ -1,0 +1,20 @@
+//! Serialization of metric label sets into the protobuf data model.
+
+mod error;
+mod serializer;
+
+pub use error::LabelError;
+
+use foundations_metrics_registry::proto::LabelPair;
+use serde::Serialize;
+
+/// Serializes a label set into protobuf label pairs.
+///
+/// Label values are stored as raw strings. OpenMetrics escaping is deliberately
+/// deferred until text encoding.
+pub fn to_label_pairs<S>(labels: &S) -> Result<Vec<LabelPair>, LabelError>
+where
+    S: Serialize + ?Sized,
+{
+    labels.serialize(serializer::LabelSetSerializer)
+}

--- a/foundations-metrics/src/labels/serializer.rs
+++ b/foundations-metrics/src/labels/serializer.rs
@@ -6,6 +6,8 @@ use serde::ser::{Impossible, SerializeStruct, Serializer};
 
 use super::LabelError;
 
+// Adapted from prometools' `serde::top::TopSerializer`
+// (https://github.com/nox/prometools, licensed MIT OR Apache-2.0).
 pub(super) struct LabelSetSerializer;
 
 impl Serializer for LabelSetSerializer {
@@ -190,6 +192,8 @@ impl Serializer for LabelSetSerializer {
     }
 }
 
+// Adapted from prometools' `serde::top::StructSerializer`
+// (https://github.com/nox/prometools, licensed MIT OR Apache-2.0).
 pub(super) struct LabelPairSerializer {
     labels: Vec<LabelPair>,
 }
@@ -215,6 +219,8 @@ impl SerializeStruct for LabelPairSerializer {
     }
 }
 
+// Adapted from prometools' `serde::value::ValueSerializer`
+// (https://github.com/nox/prometools, licensed MIT OR Apache-2.0).
 struct LabelValueSerializer;
 
 macro_rules! serialize_integer {
@@ -387,6 +393,8 @@ impl Serializer for LabelValueSerializer {
     }
 }
 
+// Adapted from prometools' `serde::top::check_key`
+// (https://github.com/nox/prometools, licensed MIT OR Apache-2.0).
 fn validate_label_name(name: &str) -> Result<(), LabelError> {
     let mut chars = name.chars();
     let valid = chars

--- a/foundations-metrics/src/labels/serializer.rs
+++ b/foundations-metrics/src/labels/serializer.rs
@@ -1,0 +1,499 @@
+use std::fmt;
+
+use foundations_metrics_registry::proto::LabelPair;
+use serde::Serialize;
+use serde::ser::{Impossible, SerializeStruct, Serializer};
+
+use super::LabelError;
+
+pub(super) struct LabelSetSerializer;
+
+impl Serializer for LabelSetSerializer {
+    type Ok = Vec<LabelPair>;
+    type Error = LabelError;
+    type SerializeSeq = Impossible<Self::Ok, Self::Error>;
+    type SerializeTuple = Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleStruct = Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleVariant = Impossible<Self::Ok, Self::Error>;
+    type SerializeMap = Impossible<Self::Ok, Self::Error>;
+    type SerializeStruct = LabelPairSerializer;
+    type SerializeStructVariant = Impossible<Self::Ok, Self::Error>;
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Vec::new())
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Ok(Vec::new())
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Vec::new())
+    }
+
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Ok(LabelPairSerializer {
+            labels: Vec::with_capacity(len),
+        })
+    }
+
+    fn serialize_bool(self, _value: bool) -> Result<Self::Ok, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_i8(self, _value: i8) -> Result<Self::Ok, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_i16(self, _value: i16) -> Result<Self::Ok, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_i32(self, _value: i32) -> Result<Self::Ok, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_i64(self, _value: i64) -> Result<Self::Ok, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_i128(self, _value: i128) -> Result<Self::Ok, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_u8(self, _value: u8) -> Result<Self::Ok, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_u16(self, _value: u16) -> Result<Self::Ok, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_u32(self, _value: u32) -> Result<Self::Ok, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_u64(self, _value: u64) -> Result<Self::Ok, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_u128(self, _value: u128) -> Result<Self::Ok, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_f32(self, _value: f32) -> Result<Self::Ok, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_f64(self, _value: f64) -> Result<Self::Ok, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_char(self, _value: char) -> Result<Self::Ok, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_str(self, _value: &str) -> Result<Self::Ok, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_bytes(self, _value: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(invalid_label_set())
+    }
+
+    fn is_human_readable(&self) -> bool {
+        true
+    }
+}
+
+pub(super) struct LabelPairSerializer {
+    labels: Vec<LabelPair>,
+}
+
+impl SerializeStruct for LabelPairSerializer {
+    type Ok = Vec<LabelPair>;
+    type Error = LabelError;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        validate_label_name(key)?;
+        self.labels.push(LabelPair {
+            name: Some(key.to_owned()),
+            value: Some(value.serialize(LabelValueSerializer)?),
+        });
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(self.labels)
+    }
+}
+
+struct LabelValueSerializer;
+
+macro_rules! serialize_integer {
+    ($($method:ident($ty:ty)),+ $(,)?) => {
+        $(
+            fn $method(self, value: $ty) -> Result<Self::Ok, Self::Error> {
+                Ok(value.to_string())
+            }
+        )+
+    };
+}
+
+impl Serializer for LabelValueSerializer {
+    type Ok = String;
+    type Error = LabelError;
+    type SerializeSeq = Impossible<Self::Ok, Self::Error>;
+    type SerializeTuple = Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleStruct = Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleVariant = Impossible<Self::Ok, Self::Error>;
+    type SerializeMap = Impossible<Self::Ok, Self::Error>;
+    type SerializeStruct = Impossible<Self::Ok, Self::Error>;
+    type SerializeStructVariant = Impossible<Self::Ok, Self::Error>;
+
+    fn serialize_bool(self, value: bool) -> Result<Self::Ok, Self::Error> {
+        Ok(value.to_string())
+    }
+
+    serialize_integer!(
+        serialize_i8(i8),
+        serialize_i16(i16),
+        serialize_i32(i32),
+        serialize_i64(i64),
+        serialize_i128(i128),
+        serialize_u8(u8),
+        serialize_u16(u16),
+        serialize_u32(u32),
+        serialize_u64(u64),
+        serialize_u128(u128),
+    );
+
+    fn serialize_f32(self, value: f32) -> Result<Self::Ok, Self::Error> {
+        Ok(ryu::Buffer::new().format(value).to_owned())
+    }
+
+    fn serialize_f64(self, value: f64) -> Result<Self::Ok, Self::Error> {
+        Ok(ryu::Buffer::new().format(value).to_owned())
+    }
+
+    fn serialize_char(self, value: char) -> Result<Self::Ok, Self::Error> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_str(self, value: &str) -> Result<Self::Ok, Self::Error> {
+        Ok(value.to_owned())
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Ok(String::new())
+    }
+
+    fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Ok(name.to_owned())
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Ok(variant.to_owned())
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Ok(String::new())
+    }
+
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        value.serialize(self)
+    }
+
+    fn collect_str<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: fmt::Display + ?Sized,
+    {
+        Ok(value.to_string())
+    }
+
+    fn serialize_bytes(self, _value: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Err(invalid_label_value("byte array"))
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        Err(invalid_label_value("newtype variant"))
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(invalid_label_value("sequence"))
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(invalid_label_value("tuple"))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(invalid_label_value("tuple struct"))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(invalid_label_value("tuple variant"))
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(invalid_label_value("map"))
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(invalid_label_value("struct"))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(invalid_label_value("struct variant"))
+    }
+
+    fn is_human_readable(&self) -> bool {
+        true
+    }
+}
+
+fn validate_label_name(name: &str) -> Result<(), LabelError> {
+    let mut chars = name.chars();
+    let valid = chars
+        .next()
+        .is_some_and(|character| character.is_ascii_alphabetic() || matches!(character, '_' | ':'))
+        && chars
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | ':'));
+
+    valid.then_some(()).ok_or_else(|| {
+        LabelError::new(format!(
+            "invalid metric label name {name:?}: expected [a-zA-Z_:][a-zA-Z0-9_:]*"
+        ))
+    })
+}
+
+fn invalid_label_set() -> LabelError {
+    LabelError::new("metric labels must serialize as a struct or unit")
+}
+
+fn invalid_label_value(kind: &str) -> LabelError {
+    LabelError::new(format!("unsupported {kind} metric label value"))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Serialize;
+
+    use crate::to_label_pairs;
+
+    #[derive(Serialize)]
+    #[serde(rename_all = "lowercase")]
+    enum Method {
+        Get,
+    }
+
+    #[derive(Serialize)]
+    struct Labels<'a> {
+        method: Method,
+        status: u16,
+        sampled: bool,
+        ratio: f64,
+        missing: Option<&'a str>,
+        raw: &'a str,
+    }
+
+    #[test]
+    fn serializes_supported_values_without_text_escaping() {
+        let pairs = to_label_pairs(&Labels {
+            method: Method::Get,
+            status: 200,
+            sampled: true,
+            ratio: 1.0,
+            missing: None,
+            raw: "quote=\" slash=\\ newline=\n",
+        })
+        .unwrap();
+
+        let values: Vec<_> = pairs
+            .iter()
+            .map(|pair| {
+                (
+                    pair.name.as_deref().unwrap(),
+                    pair.value.as_deref().unwrap(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            values,
+            [
+                ("method", "get"),
+                ("status", "200"),
+                ("sampled", "true"),
+                ("ratio", "1.0"),
+                ("missing", ""),
+                ("raw", "quote=\" slash=\\ newline=\n"),
+            ]
+        );
+    }
+
+    #[test]
+    fn unit_is_an_empty_label_set() {
+        assert!(to_label_pairs(&()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn rejects_invalid_label_names() {
+        #[derive(Serialize)]
+        struct Invalid {
+            #[serde(rename = "not-valid")]
+            value: &'static str,
+        }
+
+        assert!(to_label_pairs(&Invalid { value: "x" }).is_err());
+    }
+
+    #[test]
+    fn rejects_compound_label_values() {
+        #[derive(Serialize)]
+        struct Invalid {
+            values: Vec<u8>,
+        }
+
+        assert!(
+            to_label_pairs(&Invalid {
+                values: vec![1, 2, 3],
+            })
+            .is_err()
+        );
+    }
+}

--- a/foundations-metrics/src/lib.rs
+++ b/foundations-metrics/src/lib.rs
@@ -7,7 +7,7 @@
 #![warn(missing_docs)]
 
 mod diagnostics;
-pub mod labels;
+mod labels;
 pub mod metrics;
 mod registered;
 mod value;

--- a/foundations-metrics/src/lib.rs
+++ b/foundations-metrics/src/lib.rs
@@ -6,6 +6,7 @@
 //! shared process-global registry and the stable wire format.
 #![warn(missing_docs)]
 
+pub mod labels;
 pub mod metrics;
 mod registered;
 mod value;
@@ -13,5 +14,8 @@ mod value;
 pub use foundations_metrics_registry::{
     EncodeMetric, IntoMetrics, MetricFamily, RegistrationMetadata, register,
 };
-pub use metrics::{Counter, CounterAtomic, Gauge, GaugeAtomic, GaugeGuard, RangeGauge};
+pub use labels::{LabelError, to_label_pairs};
+pub use metrics::{
+    Counter, CounterAtomic, Family, Gauge, GaugeAtomic, GaugeGuard, MetricConstructor, RangeGauge,
+};
 pub use registered::NamedMetric;

--- a/foundations-metrics/src/lib.rs
+++ b/foundations-metrics/src/lib.rs
@@ -6,11 +6,13 @@
 //! shared process-global registry and the stable wire format.
 #![warn(missing_docs)]
 
+mod diagnostics;
 pub mod labels;
 pub mod metrics;
 mod registered;
 mod value;
 
+pub use diagnostics::{CollectErrorHookAlreadySet, set_collect_error_hook};
 pub use foundations_metrics_registry::{
     EncodeMetric, IntoMetrics, MetricFamily, RegistrationMetadata, register,
 };

--- a/foundations-metrics/src/lib.rs
+++ b/foundations-metrics/src/lib.rs
@@ -18,6 +18,7 @@ pub use foundations_metrics_registry::{
 };
 pub use labels::{LabelError, to_label_pairs};
 pub use metrics::{
-    Counter, CounterAtomic, Family, Gauge, GaugeAtomic, GaugeGuard, MetricConstructor, RangeGauge,
+    Counter, CounterAtomic, Family, FamilyMetricGuard, Gauge, GaugeAtomic, GaugeGuard,
+    MetricConstructor, RangeGauge,
 };
 pub use registered::NamedMetric;

--- a/foundations-metrics/src/metrics/family.rs
+++ b/foundations-metrics/src/metrics/family.rs
@@ -162,6 +162,42 @@ where
         }))
     }
 
+    /// Returns an owned handle to the metric for `label_set`, creating it when
+    /// absent.
+    ///
+    /// The returned handle is a cheap clone that shares storage with the metric
+    /// in the family, so updates through it are reflected in collection. Unlike
+    /// [`get_or_create`](Self::get_or_create), it does not keep the family
+    /// locked, so it is safe to hold and reuse (and avoids that method's
+    /// deadlock hazard).
+    ///
+    /// For a stable label set, prefer resolving the handle once and reusing it
+    /// rather than calling the family on every update.
+    ///
+    /// ```
+    /// use foundations_metrics::{Counter, Family};
+    /// use serde::Serialize;
+    ///
+    /// #[derive(Clone, Eq, Hash, PartialEq, Serialize)]
+    /// struct Labels {
+    ///     method: &'static str,
+    /// }
+    ///
+    /// let requests = Family::<Labels, Counter>::default();
+    ///
+    /// // Resolve the handle once, then reuse it on the hot path.
+    /// let gets = requests.get_or_create_owned(&Labels { method: "GET" });
+    /// gets.inc();
+    /// gets.inc();
+    /// assert_eq!(gets.get(), 2);
+    /// ```
+    pub fn get_or_create_owned(&self, label_set: &S) -> M
+    where
+        M: Clone,
+    {
+        M::clone(&self.get_or_create(label_set))
+    }
+
     /// Removes a label set, returning whether it was present.
     pub fn remove(&self, label_set: &S) -> bool {
         self.metrics.write().remove(label_set).is_some()

--- a/foundations-metrics/src/metrics/family.rs
+++ b/foundations-metrics/src/metrics/family.rs
@@ -206,6 +206,9 @@ where
 {
     fn encode_metric_value(&self) -> Vec<MetricFamily> {
         let metrics = self.metrics.read();
+        // Each label set contributes one row per group, so a freshly created
+        // group will grow to roughly this many rows.
+        let metric_count = metrics.len();
         let mut grouped: Vec<MetricFamily> = Vec::new();
         let mut first_label_error = None;
         let mut label_error_count = 0;
@@ -262,6 +265,9 @@ where
 
                     existing.metric.append(&mut family.metric);
                 } else {
+                    family
+                        .metric
+                        .reserve(metric_count.saturating_sub(family.metric.len()));
                     grouped.push(family);
                 }
             }

--- a/foundations-metrics/src/metrics/family.rs
+++ b/foundations-metrics/src/metrics/family.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::hash::Hash;
+use std::ops::Deref;
 use std::sync::Arc;
 
 use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
@@ -46,6 +47,40 @@ use crate::{MetricFamily, labels::to_label_pairs, value::EncodeMetricValue};
 pub struct Family<S, M, C = fn() -> M> {
     metrics: Arc<RwLock<HashMap<S, M>>>,
     constructor: C,
+}
+
+/// Read-only access to a metric stored in a [`Family`].
+///
+/// The family remains read-locked until this guard is dropped.
+#[must_use = "if unused the family read lock will immediately unlock"]
+pub struct FamilyMetricGuard<'a, M: ?Sized> {
+    guard: MappedRwLockReadGuard<'a, M>,
+}
+
+impl<'a, M: ?Sized> FamilyMetricGuard<'a, M> {
+    fn new(guard: MappedRwLockReadGuard<'a, M>) -> Self {
+        Self { guard }
+    }
+}
+
+impl<M: ?Sized> Deref for FamilyMetricGuard<'_, M> {
+    type Target = M;
+
+    fn deref(&self) -> &Self::Target {
+        &self.guard
+    }
+}
+
+impl<M: fmt::Debug + ?Sized> fmt::Debug for FamilyMetricGuard<'_, M> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, formatter)
+    }
+}
+
+impl<M: fmt::Display + ?Sized> fmt::Display for FamilyMetricGuard<'_, M> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&**self, formatter)
+    }
 }
 
 /// Constructs metrics for a [`Family`].
@@ -107,11 +142,11 @@ where
     /// The returned guard keeps the family read-locked. Holding it while
     /// accessing another label set in the same family can deadlock if that
     /// second label set needs to be created.
-    pub fn get_or_create(&self, label_set: &S) -> MappedRwLockReadGuard<'_, M> {
+    pub fn get_or_create(&self, label_set: &S) -> FamilyMetricGuard<'_, M> {
         if let Ok(metric) =
             RwLockReadGuard::try_map(self.metrics.read(), |metrics| metrics.get(label_set))
         {
-            return metric;
+            return FamilyMetricGuard::new(metric);
         }
 
         let mut metrics = self.metrics.write();
@@ -120,11 +155,11 @@ where
             .or_insert_with(|| self.constructor.new_metric());
 
         let metrics = RwLockWriteGuard::downgrade(metrics);
-        RwLockReadGuard::map(metrics, |metrics| {
+        FamilyMetricGuard::new(RwLockReadGuard::map(metrics, |metrics| {
             metrics
                 .get(label_set)
                 .expect("metric exists after it was inserted")
-        })
+        }))
     }
 
     /// Removes a label set, returning whether it was present.

--- a/foundations-metrics/src/metrics/family.rs
+++ b/foundations-metrics/src/metrics/family.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::hash::Hash;
-use std::io::{self, Write};
 use std::sync::Arc;
 
 use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use serde::Serialize;
 
+use crate::diagnostics::report_collect_error;
 use crate::{MetricFamily, labels::to_label_pairs, value::EncodeMetricValue};
 
 // Adapted from prometools' `serde::Family`
@@ -219,17 +219,15 @@ where
         drop(metrics);
 
         if let Some(error) = first_label_error {
-            let _ = writeln!(
-                io::stderr().lock(),
+            report_collect_error(format_args!(
                 "non-fatal error while collecting metrics: skipped {label_error_count} label set(s); first serialization error: {error}"
-            );
+            ));
         }
 
         if let Some(name) = first_metadata_error {
-            let _ = writeln!(
-                io::stderr().lock(),
+            report_collect_error(format_args!(
                 "non-fatal error while collecting metrics: skipped {metadata_error_count} metric group(s) with inconsistent metadata; first relative name: {name:?}"
-            );
+            ));
         }
 
         grouped

--- a/foundations-metrics/src/metrics/family.rs
+++ b/foundations-metrics/src/metrics/family.rs
@@ -213,7 +213,7 @@ where
         let mut metadata_error_count = 0;
 
         for (label_set, metric) in metrics.iter() {
-            let labels = match to_label_pairs(label_set) {
+            let mut labels = match to_label_pairs(label_set) {
                 Ok(labels) => labels,
                 Err(error) => {
                     label_error_count += 1;
@@ -222,13 +222,29 @@ where
                 }
             };
 
-            for mut family in metric.encode_metric_value() {
+            let encoded = metric.encode_metric_value();
+            let mut remaining_rows: usize = encoded
+                .iter()
+                .filter(|family| !family.metric.is_empty())
+                .map(|family| family.metric.len())
+                .sum();
+
+            for mut family in encoded {
                 if family.metric.is_empty() {
                     continue;
                 }
 
                 for row in &mut family.metric {
-                    row.label.splice(0..0, labels.iter().cloned());
+                    remaining_rows -= 1;
+
+                    // Prepend so family labels stay before any metric-specific
+                    // labels (e.g. a histogram's `le`). Move into the final
+                    // consumer; clone for the rest.
+                    if remaining_rows == 0 {
+                        row.label.splice(0..0, labels.drain(..));
+                    } else {
+                        row.label.splice(0..0, labels.iter().cloned());
+                    }
                 }
 
                 if let Some(existing) = grouped

--- a/foundations-metrics/src/metrics/family.rs
+++ b/foundations-metrics/src/metrics/family.rs
@@ -9,6 +9,8 @@ use serde::Serialize;
 
 use crate::{MetricFamily, labels::to_label_pairs, value::EncodeMetricValue};
 
+// Adapted from prometools' `serde::Family`
+// (https://github.com/nox/prometools, licensed MIT OR Apache-2.0).
 /// A set of metrics differentiated by their label values.
 ///
 /// Clones share the same metrics. Calling [`Family::get_or_create`] creates a

--- a/foundations-metrics/src/metrics/family.rs
+++ b/foundations-metrics/src/metrics/family.rs
@@ -1,0 +1,466 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::hash::Hash;
+use std::io::{self, Write};
+use std::sync::Arc;
+
+use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use serde::Serialize;
+
+use crate::{MetricFamily, labels::to_label_pairs, value::EncodeMetricValue};
+
+/// A set of metrics differentiated by their label values.
+///
+/// Clones share the same metrics. Calling [`Family::get_or_create`] creates a
+/// metric for a label set on first use and returns the existing metric on later
+/// calls.
+///
+/// # Examples
+///
+/// ```
+/// use foundations_metrics::{Counter, Family};
+/// use serde::Serialize;
+///
+/// #[derive(Clone, Eq, Hash, PartialEq, Serialize)]
+/// struct Labels {
+///     method: &'static str,
+///     status: u16,
+/// }
+///
+/// let requests = Family::<Labels, Counter>::default();
+/// let success = Labels {
+///     method: "GET",
+///     status: 200,
+/// };
+///
+/// requests.get_or_create(&success).inc();
+/// requests.get_or_create(&success).inc_by(2);
+/// assert_eq!(requests.get_or_create(&success).get(), 3);
+///
+/// // Drop any returned guards before removing metrics from the family.
+/// assert!(requests.remove(&success));
+/// assert_eq!(requests.get_or_create(&success).get(), 0);
+/// ```
+pub struct Family<S, M, C = fn() -> M> {
+    metrics: Arc<RwLock<HashMap<S, M>>>,
+    constructor: C,
+}
+
+/// Constructs metrics for a [`Family`].
+///
+/// Custom constructors are useful for metrics that need configuration when
+/// created, such as histograms with a specific set of buckets.
+pub trait MetricConstructor<M> {
+    /// Creates a new metric.
+    fn new_metric(&self) -> M;
+}
+
+impl<M, F> MetricConstructor<M> for F
+where
+    F: Fn() -> M,
+{
+    fn new_metric(&self) -> M {
+        self()
+    }
+}
+
+impl<S, M, C> Family<S, M, C> {
+    /// Creates an empty family that uses `constructor` for new label sets.
+    ///
+    /// ```
+    /// use foundations_metrics::{Counter, Family};
+    ///
+    /// let counters = Family::<&'static str, Counter, _>::new_with_constructor(|| {
+    ///     let counter = Counter::default();
+    ///     counter.inc_by(10);
+    ///     counter
+    /// });
+    ///
+    /// assert_eq!(counters.get_or_create(&"priority").get(), 10);
+    /// ```
+    pub fn new_with_constructor(constructor: C) -> Self {
+        Self {
+            metrics: Arc::new(RwLock::new(HashMap::new())),
+            constructor,
+        }
+    }
+}
+
+impl<S, M> Default for Family<S, M>
+where
+    M: Default,
+{
+    fn default() -> Self {
+        Self::new_with_constructor(M::default)
+    }
+}
+
+impl<S, M, C> Family<S, M, C>
+where
+    S: Clone + Eq + Hash,
+    C: MetricConstructor<M>,
+{
+    /// Returns the metric for `label_set`, creating it when absent.
+    ///
+    /// The returned guard keeps the family read-locked. Holding it while
+    /// accessing another label set in the same family can deadlock if that
+    /// second label set needs to be created.
+    pub fn get_or_create(&self, label_set: &S) -> MappedRwLockReadGuard<'_, M> {
+        if let Ok(metric) =
+            RwLockReadGuard::try_map(self.metrics.read(), |metrics| metrics.get(label_set))
+        {
+            return metric;
+        }
+
+        let mut metrics = self.metrics.write();
+        metrics
+            .entry(label_set.clone())
+            .or_insert_with(|| self.constructor.new_metric());
+
+        let metrics = RwLockWriteGuard::downgrade(metrics);
+        RwLockReadGuard::map(metrics, |metrics| {
+            metrics
+                .get(label_set)
+                .expect("metric exists after it was inserted")
+        })
+    }
+
+    /// Removes a label set, returning whether it was present.
+    pub fn remove(&self, label_set: &S) -> bool {
+        self.metrics.write().remove(label_set).is_some()
+    }
+
+    /// Removes every label set from this family.
+    pub fn clear(&self) {
+        self.metrics.write().clear();
+    }
+}
+
+impl<S, M, C> Clone for Family<S, M, C>
+where
+    C: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            metrics: Arc::clone(&self.metrics),
+            constructor: self.constructor.clone(),
+        }
+    }
+}
+
+impl<S, M, C> fmt::Debug for Family<S, M, C>
+where
+    S: fmt::Debug,
+    M: fmt::Debug,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Family")
+            .field("metrics", &self.metrics)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<S, M, C> EncodeMetricValue for Family<S, M, C>
+where
+    S: Serialize + Send + Sync + 'static,
+    M: EncodeMetricValue,
+    C: Send + Sync + 'static,
+{
+    fn encode_metric_value(&self) -> Vec<MetricFamily> {
+        let metrics = self.metrics.read();
+        let mut grouped: Vec<MetricFamily> = Vec::new();
+        let mut first_label_error = None;
+        let mut label_error_count = 0;
+        let mut first_metadata_error = None;
+        let mut metadata_error_count = 0;
+
+        for (label_set, metric) in metrics.iter() {
+            let labels = match to_label_pairs(label_set) {
+                Ok(labels) => labels,
+                Err(error) => {
+                    label_error_count += 1;
+                    first_label_error.get_or_insert(error);
+                    continue;
+                }
+            };
+
+            for mut family in metric.encode_metric_value() {
+                if family.metric.is_empty() {
+                    continue;
+                }
+
+                for row in &mut family.metric {
+                    row.label.splice(0..0, labels.iter().cloned());
+                }
+
+                if let Some(existing) = grouped
+                    .iter_mut()
+                    .find(|existing| existing.name == family.name)
+                {
+                    if existing.help != family.help
+                        || existing.r#type != family.r#type
+                        || existing.unit != family.unit
+                    {
+                        metadata_error_count += 1;
+                        first_metadata_error.get_or_insert_with(|| family.name.clone());
+                        continue;
+                    }
+
+                    existing.metric.append(&mut family.metric);
+                } else {
+                    grouped.push(family);
+                }
+            }
+        }
+
+        drop(metrics);
+
+        if let Some(error) = first_label_error {
+            let _ = writeln!(
+                io::stderr().lock(),
+                "non-fatal error while collecting metrics: skipped {label_error_count} label set(s); first serialization error: {error}"
+            );
+        }
+
+        if let Some(name) = first_metadata_error {
+            let _ = writeln!(
+                io::stderr().lock(),
+                "non-fatal error while collecting metrics: skipped {metadata_error_count} metric group(s) with inconsistent metadata; first relative name: {name:?}"
+            );
+        }
+
+        grouped
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use foundations_metrics_registry::proto::MetricType;
+    use serde::Serialize;
+
+    use super::*;
+    use crate::{Counter, RangeGauge};
+
+    #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+    struct Labels {
+        method: &'static str,
+        status: u16,
+    }
+
+    #[test]
+    fn creates_reuses_removes_and_clears_metrics() {
+        let family = Family::<Labels, Counter>::default();
+        let get = Labels {
+            method: "GET",
+            status: 200,
+        };
+        let post = Labels {
+            method: "POST",
+            status: 201,
+        };
+
+        family.get_or_create(&get).inc();
+        family.get_or_create(&get).inc_by(2);
+        family.get_or_create(&post).inc_by(4);
+
+        assert_eq!(family.get_or_create(&get).get(), 3);
+        assert_eq!(family.get_or_create(&post).get(), 4);
+        assert!(family.remove(&post));
+        assert!(!family.remove(&post));
+        assert_eq!(family.get_or_create(&post).get(), 0);
+
+        family.clear();
+        assert_eq!(family.get_or_create(&get).get(), 0);
+    }
+
+    #[test]
+    fn clones_share_metrics() {
+        let family = Family::<Labels, Counter>::default();
+        let clone = family.clone();
+        let labels = Labels {
+            method: "GET",
+            status: 200,
+        };
+
+        family.get_or_create(&labels).inc();
+        clone.get_or_create(&labels).inc();
+
+        assert_eq!(family.get_or_create(&labels).get(), 2);
+    }
+
+    #[test]
+    fn custom_constructor_creates_metrics() {
+        let family = Family::<Labels, Counter, _>::new_with_constructor(|| {
+            let counter = Counter::default();
+            counter.inc_by(10);
+            counter
+        });
+        let labels = Labels {
+            method: "GET",
+            status: 200,
+        };
+
+        assert_eq!(family.get_or_create(&labels).get(), 10);
+    }
+
+    #[test]
+    fn encodes_one_row_per_label_set() {
+        let family = Family::<Labels, Counter>::default();
+        family
+            .get_or_create(&Labels {
+                method: "GET",
+                status: 200,
+            })
+            .inc_by(3);
+        family
+            .get_or_create(&Labels {
+                method: "POST",
+                status: 201,
+            })
+            .inc_by(5);
+
+        let families = family.encode_metric_value();
+        assert_eq!(families.len(), 1);
+        assert_eq!(families[0].name.as_deref(), Some(""));
+        assert_eq!(families[0].r#type, Some(MetricType::Counter as i32));
+        assert_eq!(families[0].metric.len(), 2);
+
+        for row in &families[0].metric {
+            let method = row
+                .label
+                .iter()
+                .find(|label| label.name.as_deref() == Some("method"))
+                .and_then(|label| label.value.as_deref())
+                .expect("row has a method label");
+            let value = row
+                .counter
+                .as_ref()
+                .and_then(|counter| counter.value)
+                .expect("row has a counter value");
+
+            match method {
+                "GET" => assert_eq!(value, 3.0),
+                "POST" => assert_eq!(value, 5.0),
+                method => panic!("unexpected method {method}"),
+            }
+        }
+    }
+
+    #[test]
+    fn groups_each_range_gauge_suffix() {
+        let family = Family::<Labels, RangeGauge>::default();
+        let first = Labels {
+            method: "GET",
+            status: 200,
+        };
+        let second = Labels {
+            method: "POST",
+            status: 201,
+        };
+
+        family.get_or_create(&first).inc_by(3);
+        family.get_or_create(&first).dec_by(2);
+        family.get_or_create(&second).inc_by(5);
+
+        let families = family.encode_metric_value();
+        assert_eq!(families.len(), 3);
+
+        for (family, suffix) in families.iter().zip(["", "_min", "_max"]) {
+            assert_eq!(family.name.as_deref(), Some(suffix));
+            assert_eq!(family.r#type, Some(MetricType::Gauge as i32));
+            assert_eq!(family.metric.len(), 2);
+            assert!(family.metric.iter().all(|row| row.label.len() == 2));
+        }
+    }
+
+    #[test]
+    fn skips_only_label_sets_that_fail_to_serialize() {
+        #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+        enum FallibleValue {
+            Valid,
+            Invalid(Vec<u8>),
+        }
+
+        #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+        struct FallibleLabels {
+            value: FallibleValue,
+        }
+
+        let family = Family::<FallibleLabels, Counter>::default();
+        family
+            .get_or_create(&FallibleLabels {
+                value: FallibleValue::Valid,
+            })
+            .inc_by(3);
+        family
+            .get_or_create(&FallibleLabels {
+                value: FallibleValue::Invalid(vec![1, 2, 3]),
+            })
+            .inc_by(5);
+
+        let families = family.encode_metric_value();
+        assert_eq!(families.len(), 1);
+        assert_eq!(families[0].metric.len(), 1);
+        assert_eq!(
+            families[0].metric[0].label[0].value.as_deref(),
+            Some("Valid")
+        );
+        assert_eq!(
+            families[0].metric[0]
+                .counter
+                .as_ref()
+                .and_then(|counter| counter.value),
+            Some(3.0)
+        );
+    }
+
+    #[test]
+    fn skips_metric_groups_with_inconsistent_metadata() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct MetadataMetric {
+            unit: &'static str,
+        }
+
+        impl EncodeMetricValue for MetadataMetric {
+            fn encode_metric_value(&self) -> Vec<MetricFamily> {
+                let counter: Counter = Counter::default();
+                let mut families = counter.encode_metric_value();
+                families[0].unit = Some(self.unit.to_owned());
+                families
+            }
+        }
+
+        let metric_count = Arc::new(AtomicUsize::new(0));
+        let family = Family::<Labels, MetadataMetric, _>::new_with_constructor({
+            let metric_count = Arc::clone(&metric_count);
+            move || MetadataMetric {
+                unit: if metric_count.fetch_add(1, Ordering::Relaxed) == 0 {
+                    "seconds"
+                } else {
+                    "bytes"
+                },
+            }
+        });
+
+        drop(family.get_or_create(&Labels {
+            method: "GET",
+            status: 200,
+        }));
+        drop(family.get_or_create(&Labels {
+            method: "POST",
+            status: 201,
+        }));
+
+        let families = family.encode_metric_value();
+        assert_eq!(families.len(), 1);
+        assert_eq!(families[0].metric.len(), 1);
+    }
+
+    #[test]
+    fn empty_family_encodes_nothing() {
+        let family = Family::<Labels, Counter>::default();
+        assert!(family.encode_metric_value().is_empty());
+    }
+}

--- a/foundations-metrics/src/metrics/mod.rs
+++ b/foundations-metrics/src/metrics/mod.rs
@@ -39,7 +39,7 @@ mod family;
 mod gauge;
 
 pub use counter::{Counter, CounterAtomic};
-pub use family::{Family, MetricConstructor};
+pub use family::{Family, FamilyMetricGuard, MetricConstructor};
 pub use gauge::{Gauge, GaugeAtomic, GaugeGuard, RangeGauge};
 
 fn update_f64(atomic: &AtomicU64, f: impl Fn(f64) -> f64) -> f64 {

--- a/foundations-metrics/src/metrics/mod.rs
+++ b/foundations-metrics/src/metrics/mod.rs
@@ -35,9 +35,11 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 mod counter;
+mod family;
 mod gauge;
 
 pub use counter::{Counter, CounterAtomic};
+pub use family::{Family, MetricConstructor};
 pub use gauge::{Gauge, GaugeAtomic, GaugeGuard, RangeGauge};
 
 fn update_f64(atomic: &AtomicU64, f: impl Fn(f64) -> f64) -> f64 {


### PR DESCRIPTION
## Overview

This PR builds on the already-merged scalar metrics #232  (`Counter`, `Gauge`) to add **labelled metrics**. It introduces a serde-based system for serialising metric label sets into the Prometheus protobuf data model, and adds a `Family` abstraction for grouping metrics by their label values.

## Label serialisation and error handling

* Introduced a new `labels` module with:
  * `to_label_pairs`: serialises any `serde::Serialize` label set into protobuf `LabelPair` values.
  * A serde `Serializer` implementation that flattens a label struct into name/value pairs, **rejecting** unsupported compound types (sequences, maps, nested structs, byte arrays) with clear errors.
  * `LabelError`: a dedicated error type implementing `serde::ser::Error`.
* Preserves the scalar formatting behaviour of the existing metrics backend: `ryu`-based float formatting, serde renames, enum variants, optional values, and `Display` adapters.
* Validates label names against `[a-zA-Z_:][a-zA-Z0-9_:]*`.
* Stores label values as raw strings - OpenMetrics escaping is deliberately deferred to the text encoder, keeping the protobuf model format-independent.
* Added `serde` (with `derive`), `ryu`, and `parking_lot` dependencies to support label serialisation and efficient concurrent metric storage.

## Metrics API enhancements

* Added `Family<S, M, C>`: shared, labelled metric storage with:
  * `get_or_create`, `remove`, and `clear` lifecycle operations; clones share the same underlying metrics.
  * A `MetricConstructor` trait (with a blanket `Fn() -> M` impl) for metrics that need configuration at creation time.
* **Fail-soft collection:** when encoding, invalid label sets and metric groups with inconsistent metadata are skipped (with a diagnostic) rather than failing the entire scrape; multi-series metrics (e.g. `RangeGauge`) are grouped correctly by suffix.
* Re-exported `Family`, `MetricConstructor`, `LabelError`, `to_label_pairs`, and `set_collect_error_hook` from the crate root for downstream use.

## Decoupling logging from metrics

* Collection diagnostics are emitted through an installable hook (`set_collect_error_hook`) rather than a hard-coded logger, defaulting to stderr when none is set.
* **Follow-up (for when `foundations` adopts this crate):** install a collect_error hook that forwards these diagnostics to the telemetry logging pipeline (at warning level), matching the legacy backend's behaviour.

## Protobuf model adjustments

* Re-exported `LabelPair` from the registry `proto` module so downstream code can construct/consume label pairs.

## Attribution

* The label serialiser and `Family` are adapted from [`prometools`](https://github.com/nox/prometools) (`MIT OR Apache-2.0`); per-definition `// Adapted from ...` notes were added, per the discussion with @TheJokr.