### PR TITLE
feat(metrics): add protobuf and OpenMetrics text encoders and collection

### DIFF
--- a/foundations-metrics-registry/src/encode_metric.rs
+++ b/foundations-metrics-registry/src/encode_metric.rs
@@ -6,5 +6,8 @@ use crate::proto::MetricFamily;
 /// metric or series that fails, so an empty `Vec` is a valid result.
 pub trait EncodeMetric: Send + Sync + 'static {
     /// Encodes this metric into zero or more [`MetricFamily`] messages.
+    ///
+    /// Every returned [`MetricFamily`] must set `name` to a complete, non-empty
+    /// producer-level name.
     fn encode(&self) -> Vec<MetricFamily>;
 }

--- a/foundations-metrics-registry/src/metadata.rs
+++ b/foundations-metrics-registry/src/metadata.rs
@@ -4,7 +4,7 @@
 /// [`register`](crate::register). Build it from [`default`](Self::default) plus
 /// the setters, since downstream crates can't use a struct literal.
 #[non_exhaustive]
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct RegistrationMetadata {
     /// Whether the metric is exported only when optional metrics are requested.
     pub optional: bool,

--- a/foundations-metrics-registry/src/proto/mod.rs
+++ b/foundations-metrics-registry/src/proto/mod.rs
@@ -10,7 +10,8 @@
 mod model;
 
 pub use model::{
-    Bucket, BucketSpan, Counter, Gauge, Histogram, LabelPair, Metric, MetricFamily, MetricType,
+    Bucket, BucketSpan, Counter, Exemplar, Gauge, Histogram, LabelPair, Metric, MetricFamily,
+    MetricType,
 };
 
 #[cfg(test)]

--- a/foundations-metrics-registry/src/proto/mod.rs
+++ b/foundations-metrics-registry/src/proto/mod.rs
@@ -11,7 +11,7 @@ mod model;
 
 pub use model::{
     Bucket, BucketSpan, Counter, Exemplar, Gauge, Histogram, LabelPair, Metric, MetricFamily,
-    MetricType,
+    MetricType, Quantile, Summary,
 };
 
 #[cfg(test)]

--- a/foundations-metrics/Cargo.toml
+++ b/foundations-metrics/Cargo.toml
@@ -15,6 +15,7 @@ prometheus-client = { version = "0.25.0", features = [
 serde = { workspace = true, features = ["derive"] }
 ryu = "1.0.23"
 parking_lot = { workspace = true }
+prost = { workspace = true }
 
 [lints]
 workspace = true

--- a/foundations-metrics/src/collect.rs
+++ b/foundations-metrics/src/collect.rs
@@ -1,0 +1,164 @@
+use foundations_metrics_registry::{iter, proto::LabelPair};
+
+use crate::MetricFamily;
+
+/// Options that control which registered metrics are collected and how the
+/// service name is represented.
+#[derive(Copy, Clone, Debug)]
+pub struct CollectionOptions<'a> {
+    /// Whether metrics registered as optional are included.
+    pub include_optional: bool,
+
+    /// Service name to add to collected metrics, if any.
+    pub service_name: Option<&'a str>,
+
+    /// How `service_name` is represented in collected metrics.
+    pub service_name_format: ServiceNameFormat<'a>,
+}
+
+/// How a service name is represented in collected metrics.
+#[derive(Copy, Clone, Debug)]
+pub enum ServiceNameFormat<'a> {
+    /// Prefix metric family names with the service name.
+    MetricPrefix,
+
+    /// Add the service name to every metric row under the given label name.
+    LabelWithName(&'a str),
+}
+
+/// Collects the currently registered metrics into the canonical protobuf model.
+pub fn collect(options: CollectionOptions) -> Vec<MetricFamily> {
+    let mut collected = Vec::new();
+
+    for registered in iter() {
+        let metadata = registered.metadata();
+
+        if metadata.optional && !options.include_optional {
+            continue;
+        }
+
+        let mut families = registered.metric().encode();
+
+        if let Some(service_name) = options.service_name {
+            match options.service_name_format {
+                ServiceNameFormat::MetricPrefix if !metadata.unprefixed => {
+                    for family in &mut families {
+                        if let Some(name) = &mut family.name {
+                            name.insert(0, '_');
+                            name.insert_str(0, service_name);
+                        }
+                    }
+                }
+                ServiceNameFormat::LabelWithName(label_name) => {
+                    let service_label = LabelPair {
+                        name: Some(label_name.to_owned()),
+                        value: Some(service_name.to_owned()),
+                    };
+
+                    for family in &mut families {
+                        for metric in &mut family.metric {
+                            metric.label.insert(0, service_label.clone());
+                        }
+                    }
+                }
+                ServiceNameFormat::MetricPrefix => {}
+            }
+        }
+
+        collected.extend(families);
+    }
+
+    collected
+}
+
+#[cfg(test)]
+mod tests {
+    use foundations_metrics_registry::proto::{Metric, MetricType};
+
+    use super::*;
+    use crate::{EncodeMetric, RegistrationMetadata, register};
+
+    struct TestMetric(&'static str);
+
+    impl EncodeMetric for TestMetric {
+        fn encode(&self) -> Vec<MetricFamily> {
+            vec![MetricFamily {
+                name: Some(self.0.to_owned()),
+                help: Some("Test metric.".to_owned()),
+                r#type: Some(MetricType::Gauge as i32),
+                metric: vec![Metric::default()],
+                unit: None,
+            }]
+        }
+    }
+
+    fn register_test_metric(name: &'static str, metadata: RegistrationMetadata) {
+        register(
+            Box::new(TestMetric(name)) as Box<dyn EncodeMetric>,
+            metadata,
+        );
+    }
+
+    #[test]
+    fn filters_optional_metrics_and_applies_service_prefix() {
+        register_test_metric("collect_required_metric", RegistrationMetadata::default());
+        register_test_metric(
+            "collect_optional_metric",
+            RegistrationMetadata::default().optional(true),
+        );
+        register_test_metric(
+            "collect_unprefixed_metric",
+            RegistrationMetadata::default().unprefixed(true),
+        );
+
+        let required = collect(CollectionOptions {
+            include_optional: false,
+            service_name: Some("test_service"),
+            service_name_format: ServiceNameFormat::MetricPrefix,
+        });
+        let required_names: Vec<_> = required
+            .iter()
+            .filter_map(|family| family.name.as_deref())
+            .collect();
+
+        assert!(required_names.contains(&"test_service_collect_required_metric"));
+        assert!(!required_names.contains(&"test_service_collect_optional_metric"));
+        assert!(required_names.contains(&"collect_unprefixed_metric"));
+
+        let with_optional = collect(CollectionOptions {
+            include_optional: true,
+            service_name: Some("test_service"),
+            service_name_format: ServiceNameFormat::MetricPrefix,
+        });
+
+        assert!(with_optional.iter().any(|family| {
+            family.name.as_deref() == Some("test_service_collect_optional_metric")
+        }));
+    }
+
+    #[test]
+    fn service_label_is_added_to_prefixed_and_unprefixed_metrics() {
+        register_test_metric("collect_label_metric", RegistrationMetadata::default());
+        register_test_metric(
+            "collect_label_unprefixed_metric",
+            RegistrationMetadata::default().unprefixed(true),
+        );
+
+        let families = collect(CollectionOptions {
+            include_optional: false,
+            service_name: Some("test_service"),
+            service_name_format: ServiceNameFormat::LabelWithName("service"),
+        });
+
+        for name in ["collect_label_metric", "collect_label_unprefixed_metric"] {
+            let family = families
+                .iter()
+                .find(|family| family.name.as_deref() == Some(name))
+                .expect("registered metric should be collected");
+            let label = &family.metric[0].label[0];
+
+            assert_eq!(label.name.as_deref(), Some("service"));
+            assert_eq!(label.value.as_deref(), Some("test_service"));
+        }
+    }
+}

--- a/foundations-metrics/src/encoding/mod.rs
+++ b/foundations-metrics/src/encoding/mod.rs
@@ -13,3 +13,32 @@ pub fn encode_to_protobuf(families: &[MetricFamily]) -> Vec<u8> {
         .flat_map(Message::encode_length_delimited_to_vec)
         .collect()
 }
+#[cfg(test)]
+mod tests {
+    use foundations_metrics_registry::proto::{Gauge, LabelPair, Metric, MetricType};
+
+    use super::*;
+
+    #[test]
+    fn preserves_legacy_info_gauge_representation() {
+        let families = [MetricFamily {
+            name: Some("build_info".to_owned()),
+            help: Some("Build information.".to_owned()),
+            r#type: Some(MetricType::Gauge as i32),
+            metric: vec![Metric {
+                label: vec![LabelPair {
+                    name: Some("version".to_owned()),
+                    value: Some("1.2.3".to_owned()),
+                }],
+                gauge: Some(Gauge { value: Some(1.0) }),
+                ..Default::default()
+            }],
+            unit: None,
+        }];
+
+        let encoded = encode_to_protobuf(&families);
+        let decoded = MetricFamily::decode_length_delimited(encoded.as_slice()).unwrap();
+
+        assert_eq!(decoded, families[0]);
+    }
+}

--- a/foundations-metrics/src/encoding/mod.rs
+++ b/foundations-metrics/src/encoding/mod.rs
@@ -1,0 +1,15 @@
+mod text;
+
+use prost::Message;
+
+use crate::MetricFamily;
+
+pub use text::encode_to_text;
+
+/// Encodes metric families as length-delimited Prometheus protobuf messages.
+pub fn encode_to_protobuf(families: &[MetricFamily]) -> Vec<u8> {
+    families
+        .iter()
+        .flat_map(Message::encode_length_delimited_to_vec)
+        .collect()
+}

--- a/foundations-metrics/src/encoding/mod.rs
+++ b/foundations-metrics/src/encoding/mod.rs
@@ -13,11 +13,78 @@ pub fn encode_to_protobuf(families: &[MetricFamily]) -> Vec<u8> {
         .flat_map(Message::encode_length_delimited_to_vec)
         .collect()
 }
+
 #[cfg(test)]
 mod tests {
-    use foundations_metrics_registry::proto::{Gauge, LabelPair, Metric, MetricType};
+    use foundations_metrics_registry::proto::{
+        Bucket, Gauge, Histogram, LabelPair, Metric, MetricType, Quantile, Summary,
+    };
 
     use super::*;
+
+    #[test]
+    fn preserves_summary_and_gauge_histogram_families() {
+        let families = [
+            MetricFamily {
+                name: Some("empty_summary".to_owned()),
+                help: None,
+                r#type: Some(MetricType::Summary as i32),
+                metric: Vec::new(),
+                unit: None,
+            },
+            MetricFamily {
+                name: Some("request_size".to_owned()),
+                help: Some("Request size.".to_owned()),
+                r#type: Some(MetricType::Summary as i32),
+                metric: vec![Metric {
+                    summary: Some(Summary {
+                        sample_count: Some(2),
+                        sample_sum: Some(6.0),
+                        quantile: vec![Quantile {
+                            quantile: Some(0.5),
+                            value: Some(3.0),
+                        }],
+                        created_timestamp: None,
+                    }),
+                    ..Default::default()
+                }],
+                unit: None,
+            },
+            MetricFamily {
+                name: Some("empty_gauge_histogram".to_owned()),
+                help: None,
+                r#type: Some(MetricType::GaugeHistogram as i32),
+                metric: Vec::new(),
+                unit: None,
+            },
+            MetricFamily {
+                name: Some("queue_item_age".to_owned()),
+                help: Some("Current age distribution of queued items.".to_owned()),
+                r#type: Some(MetricType::GaugeHistogram as i32),
+                metric: vec![Metric {
+                    histogram: Some(Histogram {
+                        sample_count: Some(3),
+                        sample_sum: Some(8.0),
+                        bucket: vec![Bucket {
+                            cumulative_count: Some(1),
+                            upper_bound: Some(1.0),
+                            ..Default::default()
+                        }],
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+                unit: None,
+            },
+        ];
+
+        let expected: Vec<_> = families
+            .iter()
+            .flat_map(Message::encode_length_delimited_to_vec)
+            .collect();
+
+        assert_eq!(encode_to_protobuf(&families), expected);
+    }
 
     #[test]
     fn preserves_legacy_info_gauge_representation() {

--- a/foundations-metrics/src/encoding/text.rs
+++ b/foundations-metrics/src/encoding/text.rs
@@ -1,0 +1,521 @@
+use std::fmt::Write as _;
+
+use foundations_metrics_registry::proto::{
+    Exemplar, Histogram, LabelPair, Metric, MetricFamily, MetricType,
+};
+
+use crate::diagnostics::report_collect_error;
+
+/// Encodes metric families as OpenMetrics text.
+pub fn encode_to_text(families: &[MetricFamily]) -> String {
+    let mut output = String::new();
+
+    for family in families {
+        encode_family(&mut output, family);
+    }
+
+    output.push_str("# EOF\n");
+    output
+}
+
+fn encode_family(output: &mut String, family: &MetricFamily) {
+    let Some(name) = family.name.as_deref().filter(|name| !name.is_empty()) else {
+        report_collect_error(format_args!(
+            "non-fatal error while encoding OpenMetrics text: skipped a metric family without a name"
+        ));
+        return;
+    };
+    let Some(metric_type) = family
+        .r#type
+        .and_then(|value| MetricType::try_from(value).ok())
+    else {
+        report_collect_error(format_args!(
+            "non-fatal error while encoding OpenMetrics text: skipped metric family {name:?} with an unknown type"
+        ));
+        return;
+    };
+
+    if let Some(help) = &family.help {
+        output.push_str("# HELP ");
+        output.push_str(name);
+        output.push(' ');
+        write_escaped(output, help);
+        output.push('\n');
+    }
+
+    output.push_str("# TYPE ");
+    output.push_str(name);
+    output.push(' ');
+    output.push_str(metric_type_name(metric_type));
+    output.push('\n');
+
+    if let Some(unit) = &family.unit {
+        output.push_str("# UNIT ");
+        output.push_str(name);
+        output.push(' ');
+        write_escaped(output, unit);
+        output.push('\n');
+    }
+
+    for metric in &family.metric {
+        encode_metric(output, name, metric_type, metric);
+    }
+}
+
+fn metric_type_name(metric_type: MetricType) -> &'static str {
+    match metric_type {
+        MetricType::Counter => "counter",
+        MetricType::Gauge => "gauge",
+        MetricType::Summary => "summary",
+        MetricType::Untyped => "unknown",
+        MetricType::Histogram => "histogram",
+        MetricType::GaugeHistogram => "gaugehistogram",
+    }
+}
+
+fn encode_metric(output: &mut String, name: &str, metric_type: MetricType, metric: &Metric) {
+    match metric_type {
+        MetricType::Counter => {
+            let Some(counter) = &metric.counter else {
+                report_missing_value(name, "counter");
+                return;
+            };
+            write_sample(
+                output,
+                name,
+                "",
+                metric,
+                None,
+                SampleValue::Float(counter.value.unwrap_or_default()),
+                counter.exemplar.as_ref(),
+            );
+        }
+        MetricType::Gauge => {
+            let Some(gauge) = &metric.gauge else {
+                report_missing_value(name, "gauge");
+                return;
+            };
+            write_plain_sample(
+                output,
+                name,
+                "",
+                metric,
+                SampleValue::Float(gauge.value.unwrap_or_default()),
+            );
+        }
+        MetricType::Summary => {
+            let Some(summary) = &metric.summary else {
+                report_missing_value(name, "summary");
+                return;
+            };
+            for quantile in &summary.quantile {
+                write_sample(
+                    output,
+                    name,
+                    "",
+                    metric,
+                    Some(("quantile", quantile.quantile.unwrap_or_default())),
+                    SampleValue::Float(quantile.value.unwrap_or_default()),
+                    None,
+                );
+            }
+            write_plain_sample(
+                output,
+                name,
+                "_sum",
+                metric,
+                SampleValue::Float(summary.sample_sum.unwrap_or_default()),
+            );
+            write_plain_sample(
+                output,
+                name,
+                "_count",
+                metric,
+                SampleValue::Unsigned(summary.sample_count.unwrap_or_default()),
+            );
+        }
+        MetricType::Untyped => {
+            let Some(untyped) = &metric.untyped else {
+                report_missing_value(name, "untyped value");
+                return;
+            };
+            write_plain_sample(
+                output,
+                name,
+                "",
+                metric,
+                SampleValue::Float(untyped.value.unwrap_or_default()),
+            );
+        }
+        MetricType::Histogram | MetricType::GaugeHistogram => {
+            let Some(histogram) = &metric.histogram else {
+                report_missing_value(name, "histogram");
+                return;
+            };
+            encode_histogram(output, name, metric_type, metric, histogram);
+        }
+    }
+}
+
+fn encode_histogram(
+    output: &mut String,
+    name: &str,
+    metric_type: MetricType,
+    metric: &Metric,
+    histogram: &Histogram,
+) {
+    if histogram.bucket.is_empty() && has_native_buckets(histogram) {
+        report_collect_error(format_args!(
+            "non-fatal error while encoding OpenMetrics text: skipped native histogram row for {name:?}; native histograms require protobuf output"
+        ));
+        return;
+    }
+
+    if histogram
+        .sample_count_float
+        .is_some_and(|count| count > 0.0)
+        || histogram.bucket.iter().any(|bucket| {
+            bucket
+                .cumulative_count_float
+                .is_some_and(|count| count > 0.0)
+        })
+    {
+        report_collect_error(format_args!(
+            "non-fatal error while encoding OpenMetrics text: skipped histogram row for {name:?} with floating-point bucket counts"
+        ));
+        return;
+    }
+
+    let (sum_suffix, count_suffix) = if metric_type == MetricType::GaugeHistogram {
+        ("_gsum", "_gcount")
+    } else {
+        ("_sum", "_count")
+    };
+    let sample_count = histogram.sample_count.unwrap_or_default();
+
+    write_plain_sample(
+        output,
+        name,
+        sum_suffix,
+        metric,
+        SampleValue::Float(histogram.sample_sum.unwrap_or_default()),
+    );
+    write_plain_sample(
+        output,
+        name,
+        count_suffix,
+        metric,
+        SampleValue::Unsigned(sample_count),
+    );
+
+    let mut infinity_bucket_seen = false;
+    for bucket in &histogram.bucket {
+        let upper_bound = bucket.upper_bound.unwrap_or_default();
+        let upper_bound = if upper_bound == f64::MAX {
+            f64::INFINITY
+        } else {
+            upper_bound
+        };
+        infinity_bucket_seen |= upper_bound == f64::INFINITY;
+
+        write_sample(
+            output,
+            name,
+            "_bucket",
+            metric,
+            Some(("le", upper_bound)),
+            SampleValue::Unsigned(bucket.cumulative_count.unwrap_or_default()),
+            bucket.exemplar.as_ref(),
+        );
+    }
+
+    if !infinity_bucket_seen {
+        write_sample(
+            output,
+            name,
+            "_bucket",
+            metric,
+            Some(("le", f64::INFINITY)),
+            SampleValue::Unsigned(sample_count),
+            None,
+        );
+    }
+}
+
+fn has_native_buckets(histogram: &Histogram) -> bool {
+    histogram.schema.is_some()
+        || histogram.zero_threshold.is_some()
+        || histogram.zero_count.is_some()
+        || histogram.zero_count_float.is_some()
+        || !histogram.negative_span.is_empty()
+        || !histogram.negative_delta.is_empty()
+        || !histogram.negative_count.is_empty()
+        || !histogram.positive_span.is_empty()
+        || !histogram.positive_delta.is_empty()
+        || !histogram.positive_count.is_empty()
+}
+
+#[derive(Clone, Copy)]
+enum SampleValue {
+    Float(f64),
+    Unsigned(u64),
+}
+
+fn write_plain_sample(
+    output: &mut String,
+    name: &str,
+    suffix: &str,
+    metric: &Metric,
+    value: SampleValue,
+) {
+    write_sample(output, name, suffix, metric, None, value, None);
+}
+
+fn write_sample(
+    output: &mut String,
+    name: &str,
+    suffix: &str,
+    metric: &Metric,
+    additional_label: Option<(&str, f64)>,
+    value: SampleValue,
+    exemplar: Option<&Exemplar>,
+) {
+    output.push_str(name);
+    output.push_str(suffix);
+    write_labels(output, &metric.label, additional_label);
+    output.push(' ');
+    match value {
+        SampleValue::Float(value) => write_float(output, value),
+        SampleValue::Unsigned(value) => {
+            write!(output, "{value}").expect("writing to a String cannot fail");
+        }
+    }
+
+    if let Some(timestamp_ms) = metric.timestamp_ms {
+        output.push(' ');
+        write_float(output, timestamp_ms as f64 / 1_000.0);
+    }
+
+    if let Some(exemplar) = exemplar.filter(|exemplar| !exemplar.label.is_empty()) {
+        output.push_str(" # ");
+        write_labels(output, &exemplar.label, None);
+        output.push(' ');
+        write_float(output, exemplar.value.unwrap_or_default());
+
+        if let Some(timestamp) = &exemplar.timestamp {
+            output.push(' ');
+            write_float(
+                output,
+                timestamp.seconds as f64 + f64::from(timestamp.nanos) * 1e-9,
+            );
+        }
+    }
+
+    output.push('\n');
+}
+
+fn write_labels(output: &mut String, labels: &[LabelPair], additional_label: Option<(&str, f64)>) {
+    if labels.is_empty() && additional_label.is_none() {
+        return;
+    }
+
+    output.push('{');
+    let mut separator = "";
+    for label in labels {
+        output.push_str(separator);
+        output.push_str(label.name.as_deref().unwrap_or_default());
+        output.push_str("=\"");
+        write_escaped(output, label.value.as_deref().unwrap_or_default());
+        output.push('"');
+        separator = ",";
+    }
+
+    if let Some((name, value)) = additional_label {
+        output.push_str(separator);
+        output.push_str(name);
+        output.push_str("=\"");
+        write_float(output, value);
+        output.push('"');
+    }
+
+    output.push('}');
+}
+
+fn write_float(output: &mut String, value: f64) {
+    if value.is_nan() {
+        output.push_str("NaN");
+    } else if value == f64::INFINITY {
+        output.push_str("+Inf");
+    } else if value == f64::NEG_INFINITY {
+        output.push_str("-Inf");
+    } else {
+        let mut buffer = ryu::Buffer::new();
+        let formatted = buffer.format(value);
+        output.push_str(formatted);
+        if !formatted.contains(['.', 'e', 'E']) {
+            output.push_str(".0");
+        }
+    }
+}
+
+fn write_escaped(output: &mut String, value: &str) {
+    for character in value.chars() {
+        match character {
+            '\\' => output.push_str("\\\\"),
+            '\n' => output.push_str("\\n"),
+            '"' => output.push_str("\\\""),
+            _ => output.push(character),
+        }
+    }
+}
+
+fn report_missing_value(name: &str, expected: &str) {
+    report_collect_error(format_args!(
+        "non-fatal error while encoding OpenMetrics text: skipped row in metric family {name:?}; expected {expected} data"
+    ));
+}
+
+#[cfg(test)]
+mod tests {
+    use foundations_metrics_registry::proto::{
+        Bucket, Counter, Gauge, Histogram, LabelPair, Metric, MetricFamily, MetricType,
+    };
+
+    use super::*;
+
+    #[test]
+    fn encodes_counter_metadata_labels_timestamps_and_exemplars() {
+        let families = [MetricFamily {
+            name: Some("requests".to_owned()),
+            help: Some("A \"quoted\" help\\line\nnext".to_owned()),
+            r#type: Some(MetricType::Counter as i32),
+            metric: vec![Metric {
+                label: vec![LabelPair {
+                    name: Some("kind".to_owned()),
+                    value: Some("a\"b\\c\nd".to_owned()),
+                }],
+                counter: Some(Counter {
+                    value: Some(1.0),
+                    exemplar: Some(Exemplar {
+                        label: vec![LabelPair {
+                            name: Some("trace_id".to_owned()),
+                            value: Some("abc".to_owned()),
+                        }],
+                        value: Some(2.0),
+                        timestamp: None,
+                    }),
+                    created_timestamp: None,
+                }),
+                timestamp_ms: Some(1_500),
+                ..Default::default()
+            }],
+            unit: None,
+        }];
+
+        assert_eq!(
+            encode_to_text(&families),
+            "# HELP requests A \\\"quoted\\\" help\\\\line\\nnext\n\
+# TYPE requests counter\n\
+requests{kind=\"a\\\"b\\\\c\\nd\"} 1.0 1.5 # {trace_id=\"abc\"} 2.0\n\
+# EOF\n"
+        );
+    }
+
+    #[test]
+    fn encodes_classic_histogram_and_maps_terminal_bucket_to_infinity() {
+        let families = [MetricFamily {
+            name: Some("request_duration_seconds".to_owned()),
+            help: Some("Request duration.".to_owned()),
+            r#type: Some(MetricType::Histogram as i32),
+            metric: vec![Metric {
+                label: vec![LabelPair {
+                    name: Some("route".to_owned()),
+                    value: Some("/test".to_owned()),
+                }],
+                histogram: Some(Histogram {
+                    sample_count: Some(3),
+                    sample_sum: Some(4.5),
+                    bucket: vec![
+                        Bucket {
+                            cumulative_count: Some(1),
+                            upper_bound: Some(1.0),
+                            ..Default::default()
+                        },
+                        Bucket {
+                            cumulative_count: Some(3),
+                            upper_bound: Some(f64::MAX),
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }],
+            unit: Some("seconds".to_owned()),
+        }];
+
+        assert_eq!(
+            encode_to_text(&families),
+            "# HELP request_duration_seconds Request duration.\n\
+# TYPE request_duration_seconds histogram\n\
+# UNIT request_duration_seconds seconds\n\
+request_duration_seconds_sum{route=\"/test\"} 4.5\n\
+request_duration_seconds_count{route=\"/test\"} 3\n\
+request_duration_seconds_bucket{route=\"/test\",le=\"1.0\"} 1\n\
+request_duration_seconds_bucket{route=\"/test\",le=\"+Inf\"} 3\n\
+# EOF\n"
+        );
+    }
+
+    #[test]
+    fn appends_an_infinite_histogram_bucket_when_missing() {
+        let families = [MetricFamily {
+            name: Some("values".to_owned()),
+            help: None,
+            r#type: Some(MetricType::Histogram as i32),
+            metric: vec![Metric {
+                histogram: Some(Histogram {
+                    sample_count: Some(2),
+                    sample_sum: Some(3.0),
+                    bucket: vec![Bucket {
+                        cumulative_count: Some(1),
+                        upper_bound: Some(1.0),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }],
+            unit: None,
+        }];
+
+        let output = encode_to_text(&families);
+        assert!(output.contains("values_bucket{le=\"+Inf\"} 2\n"));
+    }
+
+    #[test]
+    fn encodes_gauges_and_special_float_values() {
+        let families = [MetricFamily {
+            name: Some("temperature".to_owned()),
+            help: None,
+            r#type: Some(MetricType::Gauge as i32),
+            metric: [f64::NAN, f64::INFINITY, f64::NEG_INFINITY]
+                .into_iter()
+                .map(|value| Metric {
+                    gauge: Some(Gauge { value: Some(value) }),
+                    ..Default::default()
+                })
+                .collect(),
+            unit: None,
+        }];
+
+        assert_eq!(
+            encode_to_text(&families),
+            "# TYPE temperature gauge\n\
+temperature NaN\n\
+temperature +Inf\n\
+temperature -Inf\n\
+# EOF\n"
+        );
+    }
+}

--- a/foundations-metrics/src/encoding/text.rs
+++ b/foundations-metrics/src/encoding/text.rs
@@ -34,6 +34,14 @@ fn encode_family(output: &mut String, family: &MetricFamily) {
         ));
         return;
     };
+    let metric_type_name = match metric_type {
+        MetricType::Counter => "counter",
+        MetricType::Gauge => "gauge",
+        MetricType::Summary => "summary",
+        MetricType::Untyped => "unknown",
+        MetricType::Histogram => "histogram",
+        MetricType::GaugeHistogram => "gaugehistogram",
+    };
 
     if let Some(help) = &family.help {
         output.push_str("# HELP ");
@@ -46,7 +54,7 @@ fn encode_family(output: &mut String, family: &MetricFamily) {
     output.push_str("# TYPE ");
     output.push_str(name);
     output.push(' ');
-    output.push_str(metric_type_name(metric_type));
+    output.push_str(metric_type_name);
     output.push('\n');
 
     if let Some(unit) = &family.unit {
@@ -59,17 +67,6 @@ fn encode_family(output: &mut String, family: &MetricFamily) {
 
     for metric in &family.metric {
         encode_metric(output, name, metric_type, metric);
-    }
-}
-
-fn metric_type_name(metric_type: MetricType) -> &'static str {
-    match metric_type {
-        MetricType::Counter => "counter",
-        MetricType::Gauge => "gauge",
-        MetricType::Summary => "summary",
-        MetricType::Untyped => "unknown",
-        MetricType::Histogram => "histogram",
-        MetricType::GaugeHistogram => "gaugehistogram",
     }
 }
 
@@ -378,7 +375,8 @@ fn report_missing_value(name: &str, expected: &str) {
 #[cfg(test)]
 mod tests {
     use foundations_metrics_registry::proto::{
-        Bucket, Counter, Gauge, Histogram, LabelPair, Metric, MetricFamily, MetricType,
+        Bucket, Counter, Gauge, Histogram, LabelPair, Metric, MetricFamily, MetricType, Quantile,
+        Summary,
     };
 
     use super::*;
@@ -491,6 +489,63 @@ request_duration_seconds_bucket{route=\"/test\",le=\"+Inf\"} 3\n\
 
         let output = encode_to_text(&families);
         assert!(output.contains("values_bucket{le=\"+Inf\"} 2\n"));
+    }
+
+    #[test]
+    fn encodes_summaries_and_gauge_histograms() {
+        let families = [
+            MetricFamily {
+                name: Some("request_size".to_owned()),
+                help: None,
+                r#type: Some(MetricType::Summary as i32),
+                metric: vec![Metric {
+                    summary: Some(Summary {
+                        sample_count: Some(2),
+                        sample_sum: Some(6.0),
+                        quantile: vec![Quantile {
+                            quantile: Some(0.5),
+                            value: Some(3.0),
+                        }],
+                        created_timestamp: None,
+                    }),
+                    ..Default::default()
+                }],
+                unit: None,
+            },
+            MetricFamily {
+                name: Some("queue_depth".to_owned()),
+                help: None,
+                r#type: Some(MetricType::GaugeHistogram as i32),
+                metric: vec![Metric {
+                    histogram: Some(Histogram {
+                        sample_count: Some(3),
+                        sample_sum: Some(8.0),
+                        bucket: vec![Bucket {
+                            cumulative_count: Some(1),
+                            upper_bound: Some(1.0),
+                            ..Default::default()
+                        }],
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+                unit: None,
+            },
+        ];
+
+        assert_eq!(
+            encode_to_text(&families),
+            "# TYPE request_size summary\n\
+request_size{quantile=\"0.5\"} 3.0\n\
+request_size_sum 6.0\n\
+request_size_count 2\n\
+# TYPE queue_depth gaugehistogram\n\
+queue_depth_gsum 8.0\n\
+queue_depth_gcount 3\n\
+queue_depth_bucket{le=\"1.0\"} 1\n\
+queue_depth_bucket{le=\"+Inf\"} 3\n\
+# EOF\n"
+        );
     }
 
     #[test]

--- a/foundations-metrics/src/encoding/text.rs
+++ b/foundations-metrics/src/encoding/text.rs
@@ -518,4 +518,30 @@ temperature -Inf\n\
 # EOF\n"
         );
     }
+
+    #[test]
+    fn encodes_legacy_info_metric_as_gauge() {
+        let families = [MetricFamily {
+            name: Some("build_info".to_owned()),
+            help: Some("Build information.".to_owned()),
+            r#type: Some(MetricType::Gauge as i32),
+            metric: vec![Metric {
+                label: vec![LabelPair {
+                    name: Some("version".to_owned()),
+                    value: Some("1.2.3".to_owned()),
+                }],
+                gauge: Some(Gauge { value: Some(1.0) }),
+                ..Default::default()
+            }],
+            unit: None,
+        }];
+
+        assert_eq!(
+            encode_to_text(&families),
+            "# HELP build_info Build information.\n\
+# TYPE build_info gauge\n\
+build_info{version=\"1.2.3\"} 1.0\n\
+# EOF\n"
+        );
+    }
 }

--- a/foundations-metrics/src/encoding/text.rs
+++ b/foundations-metrics/src/encoding/text.rs
@@ -43,7 +43,9 @@ fn encode_family(output: &mut String, family: &MetricFamily) {
         MetricType::GaugeHistogram => "gaugehistogram",
     };
 
-    if let Some(help) = &family.help {
+    // An empty help string carries no information, so the line is omitted rather
+    // than written with a blank value.
+    if let Some(help) = family.help.as_deref().filter(|help| !help.is_empty()) {
         output.push_str("# HELP ");
         output.push_str(name);
         output.push(' ');
@@ -380,6 +382,30 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn omits_the_help_line_when_there_is_no_help_text() {
+        let families = [MetricFamily {
+            name: Some("requests".to_owned()),
+            help: Some(String::new()),
+            r#type: Some(MetricType::Counter as i32),
+            metric: vec![Metric {
+                counter: Some(Counter {
+                    value: Some(1.0),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }],
+            unit: None,
+        }];
+
+        assert_eq!(
+            encode_to_text(&families),
+            "# TYPE requests counter\n\
+requests 1.0\n\
+# EOF\n"
+        );
+    }
 
     #[test]
     fn encodes_counter_metadata_labels_timestamps_and_exemplars() {

--- a/foundations-metrics/src/lib.rs
+++ b/foundations-metrics/src/lib.rs
@@ -8,6 +8,7 @@
 
 mod collect;
 mod diagnostics;
+mod encoding;
 mod labels;
 pub mod metrics;
 mod registered;
@@ -15,6 +16,7 @@ mod value;
 
 pub use collect::{CollectionOptions, ServiceNameFormat, collect};
 pub use diagnostics::{CollectErrorHookAlreadySet, set_collect_error_hook};
+pub use encoding::{encode_to_protobuf, encode_to_text};
 pub use foundations_metrics_registry::{
     EncodeMetric, IntoMetrics, MetricFamily, RegistrationMetadata, register,
 };

--- a/foundations-metrics/src/lib.rs
+++ b/foundations-metrics/src/lib.rs
@@ -6,12 +6,14 @@
 //! shared process-global registry and the stable wire format.
 #![warn(missing_docs)]
 
+mod collect;
 mod diagnostics;
 mod labels;
 pub mod metrics;
 mod registered;
 mod value;
 
+pub use collect::{CollectionOptions, ServiceNameFormat, collect};
 pub use diagnostics::{CollectErrorHookAlreadySet, set_collect_error_hook};
 pub use foundations_metrics_registry::{
     EncodeMetric, IntoMetrics, MetricFamily, RegistrationMetadata, register,


### PR DESCRIPTION
## Overview

This PR completes the path from registered metrics to Prometheus-compatible wire output:

1. Collect registered metrics into the canonical protobuf `MetricFamily` model.
2. Encode those families as length-delimited Prometheus protobuf or OpenMetrics text.

The public API now exposes `collect`, `CollectionOptions`, `ServiceNameFormat`, `encode_to_protobuf`, and `encode_to_text`.

## Collection

`collect` iterates over the global registry and encodes each registered metric into one or more `MetricFamily` values.

`CollectionOptions` controls whether optional metrics are included and how a service name is represented:

- `MetricPrefix` prefixes metric family names, except metrics registered as unprefixed.
- `LabelWithName` adds the service name as a label to every row.

The resulting `Vec<MetricFamily>` provides a common boundary between metric implementations and wire encoders.

## Encoding

`encode_to_protobuf` serialises metric families as concatenated, length-delimited Prometheus protobuf messages. This preserves fields that OpenMetrics text cannot fully represent, including native histogram data.

`encode_to_text` supports:

- Counters
- Gauges
- GaugeHistograms
- Summaries
- Untyped metrics
- Classic histograms

Info metrics have no dedicated metric type; they are ordinary gauge families valued 1 that carry their fields as labels. Tests pin this representation in both formats (the family name is unchanged (for example, build_info), the protobuf type is gauge, and text emits `# TYPE build_info gauge`) so that the info-metric layer added in a later PR reproduces the legacy wire output exactly. This PR adds no way to define or report an info metric.

The text encoder emits `# HELP`, `# TYPE`, and `# UNIT` metadata and terminates output with `# EOF`. Empty `# HELP` lines are omitted from output.

Histogram encoding:

- Maps the terminal `f64::MAX` bucket to `+Inf`.
- Adds a terminal `+Inf` bucket when missing.
- Preserves classic histogram bucket exemplars.
- Skips native-only histogram rows.
- Skips histogram rows with positive floating-point counts.

The encoder also handles metric and exemplar timestamps, escapes help text and label values, and emits `NaN`, `+Inf`, and `-Inf` using OpenMetrics syntax.

`Summary` and `GaugeHistogram` families are fully supported. Protobuf passes them through unchanged. In text, summaries emit their `quantile` rows plus `_sum` and `_count`; gauge histograms emit `_bucket` rows plus `_gsum` and `_gcount`.

For text output, families without a non-empty name or recognised type, and rows missing data for their declared type, are skipped and reported through the non-fatal collection error hook.