### PR TITLE
feat(metrics): Implement exemplar metrics

### DIFF
--- a/foundations-metrics/Cargo.toml
+++ b/foundations-metrics/Cargo.toml
@@ -16,6 +16,7 @@ serde = { workspace = true, features = ["derive"] }
 ryu = "1.0.23"
 parking_lot = { workspace = true }
 prost = { workspace = true }
+prost-types = { workspace = true }
 
 [lints]
 workspace = true

--- a/foundations-metrics/src/collect.rs
+++ b/foundations-metrics/src/collect.rs
@@ -447,6 +447,7 @@ mod tests {
                     exemplars: vec![
                         Exemplar {
                             label: vec![label("bad name", "bad")],
+                            timestamp: Some(Default::default()),
                             ..Default::default()
                         },
                         Exemplar {

--- a/foundations-metrics/src/collect.rs
+++ b/foundations-metrics/src/collect.rs
@@ -450,7 +450,12 @@ mod tests {
                             ..Default::default()
                         },
                         Exemplar {
+                            label: vec![label("trace_id", "missing_timestamp")],
+                            ..Default::default()
+                        },
+                        Exemplar {
                             label: vec![label("trace_id", "good")],
+                            timestamp: Some(Default::default()),
                             ..Default::default()
                         },
                     ],

--- a/foundations-metrics/src/encoding/mod.rs
+++ b/foundations-metrics/src/encoding/mod.rs
@@ -158,6 +158,7 @@ mod tests {
                             exemplars: vec![
                                 Exemplar {
                                     label: vec![label("bad#name", "nonstandard")],
+                                    timestamp: Some(Default::default()),
                                     ..Default::default()
                                 },
                                 Exemplar {

--- a/foundations-metrics/src/encoding/mod.rs
+++ b/foundations-metrics/src/encoding/mod.rs
@@ -161,7 +161,12 @@ mod tests {
                                     ..Default::default()
                                 },
                                 Exemplar {
+                                    label: vec![label("trace_id", "missing_timestamp")],
+                                    ..Default::default()
+                                },
+                                Exemplar {
                                     label: vec![label("trace_id", "good")],
+                                    timestamp: Some(Default::default()),
                                     ..Default::default()
                                 },
                             ],

--- a/foundations-metrics/src/encoding/text.rs
+++ b/foundations-metrics/src/encoding/text.rs
@@ -302,9 +302,13 @@ fn write_sample(
         write_float(output, timestamp_ms as f64 / 1_000.0);
     }
 
-    if let Some(exemplar) = exemplar.filter(|exemplar| !exemplar.label.is_empty()) {
+    if let Some(exemplar) = exemplar {
         output.push_str(" # ");
-        write_labels(output, &exemplar.label, None);
+        if exemplar.label.is_empty() {
+            output.push_str("{}");
+        } else {
+            write_labels(output, &exemplar.label, None);
+        }
         output.push(' ');
         write_float(output, exemplar.value.unwrap_or_default());
 

--- a/foundations-metrics/src/labels/serializer.rs
+++ b/foundations-metrics/src/labels/serializer.rs
@@ -550,7 +550,12 @@ mod tests {
 
     #[test]
     fn serializes_legacy_name_value_sequences() {
-        let pairs = to_label_pairs(&vec![("trace_id", "abc"), ("span_id", "def")]).unwrap();
+        let pairs = to_label_pairs(&vec![
+            ("trace_id", "abc"),
+            ("span_id", "def"),
+            ("trace:id", "ghi"),
+        ])
+        .unwrap();
         let values: Vec<_> = pairs
             .iter()
             .map(|pair| {
@@ -561,8 +566,10 @@ mod tests {
             })
             .collect();
 
-        assert_eq!(values, [("trace_id", "abc"), ("span_id", "def")]);
-        assert!(to_label_pairs(&vec![("trace:id", "bad")]).is_err());
+        assert_eq!(
+            values,
+            [("trace_id", "abc"), ("span_id", "def"), ("trace:id", "ghi"),]
+        );
     }
 
     #[test]

--- a/foundations-metrics/src/labels/serializer.rs
+++ b/foundations-metrics/src/labels/serializer.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use foundations_metrics_registry::proto::LabelPair;
 use serde::Serialize;
-use serde::ser::{Impossible, SerializeStruct, Serializer};
+use serde::ser::{Impossible, SerializeSeq, SerializeStruct, SerializeTuple, Serializer};
 
 use super::LabelError;
 use crate::validation::{NAME_REQUIREMENT, is_valid_name};
@@ -14,8 +14,8 @@ pub(super) struct LabelSetSerializer;
 impl Serializer for LabelSetSerializer {
     type Ok = Vec<LabelPair>;
     type Error = LabelError;
-    type SerializeSeq = Impossible<Self::Ok, Self::Error>;
-    type SerializeTuple = Impossible<Self::Ok, Self::Error>;
+    type SerializeSeq = LabelSequenceSerializer;
+    type SerializeTuple = LabelTupleSerializer;
     type SerializeTupleStruct = Impossible<Self::Ok, Self::Error>;
     type SerializeTupleVariant = Impossible<Self::Ok, Self::Error>;
     type SerializeMap = Impossible<Self::Ok, Self::Error>;
@@ -148,12 +148,21 @@ impl Serializer for LabelSetSerializer {
         Err(invalid_label_set())
     }
 
-    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        Err(invalid_label_set())
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Ok(LabelSequenceSerializer {
+            labels: Vec::with_capacity(len.unwrap_or_default()),
+        })
     }
 
-    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        Err(invalid_label_set())
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        if len != 2 {
+            return Err(LabelError::new("label pairs must contain a name and value"));
+        }
+
+        Ok(LabelTupleSerializer {
+            name: None,
+            value: None,
+        })
     }
 
     fn serialize_tuple_struct(
@@ -190,6 +199,77 @@ impl Serializer for LabelSetSerializer {
 
     fn is_human_readable(&self) -> bool {
         true
+    }
+}
+
+pub(super) struct LabelSequenceSerializer {
+    labels: Vec<LabelPair>,
+}
+
+impl SerializeSeq for LabelSequenceSerializer {
+    type Ok = Vec<LabelPair>;
+    type Error = LabelError;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        let mut labels = value.serialize(LabelSetSerializer)?;
+        if labels.len() != 1 {
+            return Err(LabelError::new(
+                "label sequences must contain name-value pairs",
+            ));
+        }
+        self.labels
+            .push(labels.pop().expect("one label was encoded"));
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(self.labels)
+    }
+}
+
+pub(super) struct LabelTupleSerializer {
+    name: Option<String>,
+    value: Option<String>,
+}
+
+impl SerializeTuple for LabelTupleSerializer {
+    type Ok = Vec<LabelPair>;
+    type Error = LabelError;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        if self.name.is_none() {
+            let name = value.serialize(LabelValueSerializer)?;
+            validate_label_name(&name)?;
+            self.name = Some(name);
+        } else if self.value.is_none() {
+            self.value = Some(value.serialize(LabelValueSerializer)?);
+        } else {
+            return Err(LabelError::new(
+                "label pairs must contain exactly one name and value",
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        let name = self
+            .name
+            .ok_or_else(|| LabelError::new("label pair is missing its name"))?;
+        let value = self
+            .value
+            .ok_or_else(|| LabelError::new("label pair is missing its value"))?;
+
+        Ok(vec![LabelPair {
+            name: Some(name),
+            value: Some(value),
+        }])
     }
 }
 
@@ -466,6 +546,23 @@ mod tests {
                 ("raw", "quote=\" slash=\\ newline=\n"),
             ]
         );
+    }
+
+    #[test]
+    fn serializes_legacy_name_value_sequences() {
+        let pairs = to_label_pairs(&vec![("trace_id", "abc"), ("span_id", "def")]).unwrap();
+        let values: Vec<_> = pairs
+            .iter()
+            .map(|pair| {
+                (
+                    pair.name.as_deref().unwrap(),
+                    pair.value.as_deref().unwrap(),
+                )
+            })
+            .collect();
+
+        assert_eq!(values, [("trace_id", "abc"), ("span_id", "def")]);
+        assert!(to_label_pairs(&vec![("trace:id", "bad")]).is_err());
     }
 
     #[test]

--- a/foundations-metrics/src/lib.rs
+++ b/foundations-metrics/src/lib.rs
@@ -23,8 +23,9 @@ pub use foundations_metrics_registry::{
 };
 pub use labels::{LabelError, to_label_pairs};
 pub use metrics::{
-    Counter, CounterAtomic, Family, FamilyMetricGuard, Gauge, GaugeAtomic, GaugeGuard, Histogram,
-    HistogramBuilder, HistogramSnapshot, HistogramTimer, MetricConstructor, NativeHistogram,
-    NativeHistogramBuilder, RangeGauge, TimeHistogram,
+    Counter, CounterAtomic, CounterWithExemplar, Exemplar, Family, FamilyMetricGuard, Gauge,
+    GaugeAtomic, GaugeGuard, Histogram, HistogramBuilder, HistogramSnapshot, HistogramTimer,
+    HistogramWithExemplars, MetricConstructor, NativeHistogram, NativeHistogramBuilder,
+    NativeHistogramWithExemplars, NativeHistogramWithExemplarsBuilder, RangeGauge, TimeHistogram,
 };
 pub use registered::NamedMetric;

--- a/foundations-metrics/src/lib.rs
+++ b/foundations-metrics/src/lib.rs
@@ -26,6 +26,6 @@ pub use metrics::{
     Counter, CounterAtomic, CounterWithExemplar, Exemplar, Family, FamilyMetricGuard, Gauge,
     GaugeAtomic, GaugeGuard, Histogram, HistogramBuilder, HistogramSnapshot, HistogramTimer,
     HistogramWithExemplars, MetricConstructor, NativeHistogram, NativeHistogramBuilder,
-    NativeHistogramWithExemplars, NativeHistogramWithExemplarsBuilder, RangeGauge, TimeHistogram,
+    NativeHistogramWithExemplars, RangeGauge, TimeHistogram,
 };
 pub use registered::NamedMetric;

--- a/foundations-metrics/src/lib.rs
+++ b/foundations-metrics/src/lib.rs
@@ -23,9 +23,8 @@ pub use foundations_metrics_registry::{
 };
 pub use labels::{LabelError, to_label_pairs};
 pub use metrics::{
-    Counter, CounterAtomic, CounterWithExemplar, Exemplar, Family, FamilyMetricGuard, Gauge,
-    GaugeAtomic, GaugeGuard, Histogram, HistogramBuilder, HistogramSnapshot, HistogramTimer,
-    HistogramWithExemplars, MetricConstructor, NativeHistogram, NativeHistogramBuilder,
-    NativeHistogramWithExemplars, RangeGauge, TimeHistogram,
+    Counter, CounterAtomic, Exemplar, Family, FamilyMetricGuard, Gauge, GaugeAtomic, GaugeGuard,
+    Histogram, HistogramBuilder, HistogramSnapshot, HistogramTimer, MetricConstructor,
+    NativeHistogram, NativeHistogramBuilder, RangeGauge, TimeHistogram, WithExemplar,
 };
 pub use registered::NamedMetric;

--- a/foundations-metrics/src/lib.rs
+++ b/foundations-metrics/src/lib.rs
@@ -23,8 +23,8 @@ pub use foundations_metrics_registry::{
 };
 pub use labels::{LabelError, to_label_pairs};
 pub use metrics::{
-    Counter, CounterAtomic, Exemplar, Family, FamilyMetricGuard, Gauge, GaugeAtomic, GaugeGuard,
-    Histogram, HistogramBuilder, HistogramSnapshot, HistogramTimer, MetricConstructor,
-    NativeHistogram, NativeHistogramBuilder, RangeGauge, TimeHistogram, WithExemplar,
+    Counter, CounterAtomic, Family, FamilyMetricGuard, Gauge, GaugeAtomic, GaugeGuard, Histogram,
+    HistogramBuilder, HistogramSnapshot, HistogramTimer, MetricConstructor, NativeHistogram,
+    NativeHistogramBuilder, RangeGauge, TimeHistogram, WithExemplar,
 };
 pub use registered::NamedMetric;

--- a/foundations-metrics/src/metrics/counter.rs
+++ b/foundations-metrics/src/metrics/counter.rs
@@ -135,7 +135,7 @@ impl<N, A: Default> Default for Counter<N, A> {
 ///
 /// The name/help are left empty here; they are populated at registration and
 /// encode time.
-fn encode_counter(value: f64) -> Vec<MetricFamily> {
+pub(super) fn encode_counter(value: f64) -> Vec<MetricFamily> {
     vec![MetricFamily {
         name: Some(String::new()),
         help: None,

--- a/foundations-metrics/src/metrics/counter.rs
+++ b/foundations-metrics/src/metrics/counter.rs
@@ -3,8 +3,10 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use foundations_metrics_registry::proto::{self, MetricType};
+use serde::Serialize;
 
 use super::IntoF64;
+use super::exemplar::{Exemplar, ExemplarStorage, StoredExemplar, WithExemplar, finish_exemplar};
 
 use crate::{MetricFamily, value::EncodeMetricValue};
 
@@ -158,6 +160,81 @@ where
 {
     fn encode_metric_value(&self) -> Vec<MetricFamily> {
         encode_counter(self.get().into_f64())
+    }
+}
+
+macro_rules! impl_counter_with_exemplar {
+    ($value:ty, $variant:ident) => {
+        impl<S, A> WithExemplar<Counter<$value, A>, S>
+        where
+            A: CounterAtomic<$value>,
+        {
+            /// Returns the current exemplar.
+            pub fn exemplar(&self) -> Option<Exemplar<S, $value>> {
+                match &*self.exemplars.lock() {
+                    ExemplarStorage::Empty | ExemplarStorage::Single(None) => None,
+                    ExemplarStorage::Single(Some(StoredExemplar::$variant(exemplar))) => {
+                        Some(exemplar.clone())
+                    }
+                    ExemplarStorage::Single(Some(_)) => {
+                        unreachable!("counter uses matching exemplar value storage")
+                    }
+                    ExemplarStorage::PerBucket(_) => {
+                        unreachable!("counter uses single exemplar storage")
+                    }
+                }
+            }
+
+            /// Increments the counter by `value`, records the exemplar, and
+            /// returns the previous total.
+            pub fn with_exemplar(&self, label_set: S, value: $value) -> $value {
+                let exemplar = StoredExemplar::$variant(Exemplar::new(label_set, value, None));
+                let mut exemplars = self.exemplars.lock();
+                let previous = self.inner.inc_by(value);
+
+                match &mut *exemplars {
+                    ExemplarStorage::Empty => {
+                        *exemplars = ExemplarStorage::Single(Some(exemplar));
+                    }
+                    ExemplarStorage::Single(stored) => *stored = Some(exemplar),
+                    ExemplarStorage::PerBucket(_) => {
+                        unreachable!("counter uses single exemplar storage")
+                    }
+                }
+
+                previous
+            }
+        }
+    };
+}
+
+impl_counter_with_exemplar!(i64, I64);
+impl_counter_with_exemplar!(u64, U64);
+impl_counter_with_exemplar!(f64, F64);
+
+impl<S, N, A> EncodeMetricValue for WithExemplar<Counter<N, A>, S>
+where
+    S: Serialize + Send + Sync + 'static,
+    N: IntoF64,
+    A: CounterAtomic<N> + Send + Sync + 'static,
+{
+    fn encode_metric_value(&self) -> Vec<MetricFamily> {
+        let exemplars = self.exemplars.lock();
+        let exemplar = match &*exemplars {
+            ExemplarStorage::Empty => None,
+            ExemplarStorage::Single(exemplar) => exemplar.clone(),
+            ExemplarStorage::PerBucket(_) => unreachable!("counter uses single exemplar storage"),
+        };
+        let value = self.inner.get().into_f64();
+        drop(exemplars);
+
+        let mut families = encode_counter(value);
+        let counter = families[0].metric[0]
+            .counter
+            .as_mut()
+            .expect("counter encoder always creates a counter value");
+        counter.exemplar = finish_exemplar(exemplar.as_ref().map(StoredExemplar::encode));
+        families
     }
 }
 

--- a/foundations-metrics/src/metrics/counter.rs
+++ b/foundations-metrics/src/metrics/counter.rs
@@ -169,25 +169,9 @@ macro_rules! impl_counter_with_exemplar {
         where
             A: CounterAtomic<$value>,
         {
-            /// Returns the current exemplar.
-            pub fn exemplar(&self) -> Option<Exemplar<S, $value>> {
-                match &*self.exemplars.lock() {
-                    ExemplarStorage::Empty | ExemplarStorage::Single(None) => None,
-                    ExemplarStorage::Single(Some(StoredExemplar::$variant(exemplar))) => {
-                        Some(exemplar.clone())
-                    }
-                    ExemplarStorage::Single(Some(_)) => {
-                        unreachable!("counter uses matching exemplar value storage")
-                    }
-                    ExemplarStorage::PerBucket(_) => {
-                        unreachable!("counter uses single exemplar storage")
-                    }
-                }
-            }
-
             /// Increments the counter by `value`, records the exemplar, and
             /// returns the previous total.
-            pub fn with_exemplar(&self, label_set: S, value: $value) -> $value {
+            pub fn inc_by_with_exemplar(&self, label_set: S, value: $value) -> $value {
                 let exemplar = StoredExemplar::$variant(Exemplar::new(label_set, value, None));
                 let mut exemplars = self.exemplars.lock();
                 let previous = self.inner.inc_by(value);

--- a/foundations-metrics/src/metrics/exemplar.rs
+++ b/foundations-metrics/src/metrics/exemplar.rs
@@ -1,0 +1,745 @@
+use std::collections::HashMap;
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::time::SystemTime;
+
+use foundations_metrics_registry::proto;
+use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard};
+use prost_types::Timestamp;
+use serde::Serialize;
+
+use super::counter::encode_counter;
+use super::histogram::encode_snapshot;
+use super::{
+    CounterAtomic, Histogram, HistogramBuilder, IntoF64, MetricConstructor, NativeHistogram,
+    NativeHistogramBuilder,
+};
+use crate::diagnostics::report_collect_error;
+use crate::labels::to_label_pairs;
+use crate::validation::EXEMPLAR_SERIALIZATION_ERROR_LABEL;
+use crate::{MetricFamily, value::EncodeMetricValue};
+
+/// Labels and a sampled value associated with a metric observation.
+///
+/// Exemplar values are exposed through [`CounterWithExemplar::get`]. Their fields
+/// remain private; exemplars are created by recording labeled metric updates.
+#[derive(Debug)]
+pub struct Exemplar<S, V> {
+    label_set: Arc<S>,
+    value: V,
+    timestamp: Option<Timestamp>,
+}
+
+impl<S, V> Exemplar<S, V> {
+    /// Returns the exemplar's label set.
+    pub fn label_set(&self) -> &S {
+        &self.label_set
+    }
+
+    /// Returns the sampled increment or observation.
+    pub fn value(&self) -> &V {
+        &self.value
+    }
+}
+
+impl<S, V> Exemplar<S, V> {
+    fn new(label_set: S, value: V, timestamp: Option<Timestamp>) -> Self {
+        Self {
+            label_set: Arc::new(label_set),
+            value,
+            timestamp,
+        }
+    }
+}
+
+impl<S, V: Clone> Clone for Exemplar<S, V> {
+    fn clone(&self) -> Self {
+        Self {
+            label_set: Arc::clone(&self.label_set),
+            value: self.value.clone(),
+            timestamp: self.timestamp,
+        }
+    }
+}
+
+impl<S, V> Exemplar<S, V> {
+    fn encode(&self) -> Result<proto::Exemplar, String>
+    where
+        S: Serialize,
+        V: Clone + IntoF64,
+    {
+        Ok(proto::Exemplar {
+            label: to_label_pairs(self.label_set.as_ref()).map_err(|error| error.to_string())?,
+            value: Some(self.value.clone().into_f64()),
+            timestamp: self.timestamp,
+        })
+    }
+}
+
+fn finish_exemplar(exemplar: Option<Result<proto::Exemplar, String>>) -> Option<proto::Exemplar> {
+    match exemplar {
+        Some(Ok(exemplar)) => Some(exemplar),
+        // Defer reporting to validation, after any enclosing Family lock has
+        // been released.
+        Some(Err(error)) => Some(proto::Exemplar {
+            label: vec![proto::LabelPair {
+                name: Some(EXEMPLAR_SERIALIZATION_ERROR_LABEL.to_owned()),
+                value: Some(error),
+            }],
+            ..Default::default()
+        }),
+        None => None,
+    }
+}
+
+/// A monotonically increasing counter that records an exemplar with an update.
+///
+/// Calling [`inc_by`](Self::inc_by) with a label set replaces the previous
+/// exemplar. Calling it without a label set clears the previous exemplar. The
+/// exemplar value is the increment. [`get`](Self::get) returns the cumulative
+/// counter value and read-only access to the current exemplar. Clones share both
+/// values.
+///
+/// Exemplar labels are serialized with [`serde::Serialize`] during collection.
+#[derive(Debug)]
+pub struct CounterWithExemplar<S, N = u64, A = AtomicU64> {
+    state: Arc<RwLock<CounterWithExemplarState<S, N, A>>>,
+    marker: PhantomData<N>,
+}
+
+#[derive(Debug)]
+struct CounterWithExemplarState<S, N, A> {
+    value: A,
+    exemplar: Option<Exemplar<S, N>>,
+}
+
+impl<S, N, A> CounterWithExemplar<S, N, A>
+where
+    N: Clone,
+    A: CounterAtomic<N>,
+{
+    /// Increments the counter by `value`, returning the previous total.
+    ///
+    /// A provided label set replaces the stored exemplar. `None` clears it.
+    pub fn inc_by(&self, value: N, label_set: Option<S>) -> N {
+        let exemplar = label_set.map(|label_set| Exemplar::new(label_set, value.clone(), None));
+        let mut state = self.state.write();
+        state.exemplar = exemplar;
+        state.value.inc_by(value)
+    }
+
+    /// Returns the cumulative counter value and the current exemplar.
+    ///
+    /// The exemplar guard keeps the counter read-locked until it is dropped.
+    pub fn get(&self) -> (N, MappedRwLockReadGuard<'_, Option<Exemplar<S, N>>>) {
+        let state = self.state.read();
+        let value = state.value.get();
+        let exemplar = RwLockReadGuard::map(state, |state| &state.exemplar);
+        (value, exemplar)
+    }
+
+    /// Returns read-only access to the underlying counter storage.
+    ///
+    /// The returned guard prevents updates until it is dropped.
+    pub fn inner(&self) -> MappedRwLockReadGuard<'_, A> {
+        RwLockReadGuard::map(self.state.read(), |state| &state.value)
+    }
+}
+
+impl<S, N, A> Clone for CounterWithExemplar<S, N, A> {
+    fn clone(&self) -> Self {
+        Self {
+            state: Arc::clone(&self.state),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<S, N, A: Default> Default for CounterWithExemplar<S, N, A> {
+    fn default() -> Self {
+        Self {
+            state: Arc::new(RwLock::new(CounterWithExemplarState {
+                value: A::default(),
+                exemplar: None,
+            })),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<S, N, A> EncodeMetricValue for CounterWithExemplar<S, N, A>
+where
+    S: Serialize + Send + Sync + 'static,
+    N: Clone + IntoF64,
+    A: CounterAtomic<N> + Send + Sync + 'static,
+{
+    fn encode_metric_value(&self) -> Vec<MetricFamily> {
+        let state = self.state.read();
+        let value = state.value.get().into_f64();
+        let exemplar = state.exemplar.clone();
+        drop(state);
+
+        let mut families = encode_counter(value);
+        let counter = families[0].metric[0]
+            .counter
+            .as_mut()
+            .expect("counter encoder always creates a counter value");
+        counter.exemplar = finish_exemplar(exemplar.as_ref().map(Exemplar::encode));
+        families
+    }
+}
+
+/// A classic fixed-bucket histogram that retains one exemplar per bucket.
+///
+/// A labeled observation replaces the exemplar in its bucket. An unlabeled
+/// observation updates the histogram without clearing an existing exemplar.
+/// Clones share histogram and exemplar storage.
+#[derive(Clone, Debug)]
+pub struct HistogramWithExemplars<S> {
+    state: Arc<RwLock<HistogramWithExemplarsState<S>>>,
+}
+
+#[derive(Debug)]
+struct HistogramWithExemplarsState<S> {
+    histogram: Histogram,
+    exemplars: HashMap<usize, Exemplar<S, f64>>,
+}
+
+impl<S> HistogramWithExemplars<S> {
+    /// Creates a histogram with the provided inclusive upper bounds.
+    ///
+    /// Bounds are sorted and a terminal `f64::MAX` bucket is appended.
+    pub fn new(bounds: impl IntoIterator<Item = f64>) -> Self {
+        Self {
+            state: Arc::new(RwLock::new(HistogramWithExemplarsState {
+                histogram: Histogram::new(bounds),
+                exemplars: HashMap::new(),
+            })),
+        }
+    }
+
+    /// Records an observation and optionally associates it with an exemplar.
+    pub fn observe(&self, value: f64, label_set: Option<S>) {
+        let exemplar = label_set.map(|label_set| Exemplar::new(label_set, value, None));
+        let mut state = self.state.write();
+        let bucket = state.histogram.observe_and_bucket(value);
+
+        if let (Some(bucket), Some(exemplar)) = (bucket, exemplar) {
+            state.exemplars.insert(bucket, exemplar);
+        }
+    }
+}
+
+impl<S> EncodeMetricValue for HistogramWithExemplars<S>
+where
+    S: Serialize + Send + Sync + 'static,
+{
+    fn encode_metric_value(&self) -> Vec<MetricFamily> {
+        let state = self.state.read();
+        let snapshot = state.histogram.snapshot();
+        let exemplars: Vec<_> = state
+            .exemplars
+            .iter()
+            .map(|(&index, exemplar)| (index, exemplar.clone()))
+            .collect();
+        drop(state);
+
+        let mut families = encode_snapshot(snapshot);
+        let buckets = &mut families[0].metric[0]
+            .histogram
+            .as_mut()
+            .expect("histogram encoder always creates a histogram value")
+            .bucket;
+
+        for (index, exemplar) in exemplars {
+            if let Some(bucket) = buckets.get_mut(index) {
+                bucket.exemplar = finish_exemplar(Some(exemplar.encode()));
+            }
+        }
+
+        families
+    }
+}
+
+impl<S> MetricConstructor<HistogramWithExemplars<S>> for HistogramBuilder {
+    fn new_metric(&self) -> HistogramWithExemplars<S> {
+        HistogramWithExemplars::new(self.buckets.iter().copied())
+    }
+}
+
+/// Constructs native histograms with exemplar support.
+///
+/// This mirrors [`NativeHistogramBuilder`] without adding another constructor
+/// implementation to that type, which keeps existing constructor inference
+/// unambiguous.
+#[derive(Clone, Copy, Debug)]
+pub struct NativeHistogramWithExemplarsBuilder {
+    inner: NativeHistogramBuilder,
+}
+
+impl NativeHistogramWithExemplarsBuilder {
+    /// Creates a builder with the given bucket growth `factor`.
+    pub fn new(factor: f64) -> Self {
+        Self {
+            inner: NativeHistogramBuilder::new(factor),
+        }
+    }
+
+    /// Sets the zero-bucket threshold.
+    pub fn with_zero_threshold(mut self, zero_threshold: f64) -> Self {
+        self.inner = self.inner.with_zero_threshold(zero_threshold);
+        self
+    }
+
+    /// Sets a best-effort maximum number of populated buckets.
+    pub fn with_max_buckets(mut self, max_buckets: usize) -> Self {
+        self.inner = self.inner.with_max_buckets(max_buckets);
+        self
+    }
+}
+
+/// A native histogram that retains its latest labeled observation as an exemplar.
+///
+/// Native histogram exemplars require timestamps in the Prometheus protobuf
+/// model. The timestamp is captured when the labeled observation is recorded.
+/// Native histograms require protobuf exposition; OpenMetrics text encoding
+/// does not expose their sparse buckets or exemplars.
+#[derive(Clone, Debug)]
+pub struct NativeHistogramWithExemplars<S> {
+    state: Arc<RwLock<NativeHistogramWithExemplarsState<S>>>,
+}
+
+#[derive(Debug)]
+struct NativeHistogramWithExemplarsState<S> {
+    histogram: NativeHistogram,
+    exemplar: Option<Exemplar<S, f64>>,
+}
+
+impl<S> NativeHistogramWithExemplars<S> {
+    /// Creates a native histogram with the given bucket growth `factor`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `factor` is not greater than `1.0`.
+    pub fn new(factor: f64) -> Self {
+        NativeHistogramWithExemplarsBuilder::new(factor).new_metric()
+    }
+
+    /// Records an observation and optionally retains it as the latest exemplar.
+    pub fn observe(&self, value: f64, label_set: Option<S>) {
+        let exemplar = label_set.map(|label_set| Exemplar::new(label_set, value, None));
+        let mut state = self.state.write();
+        state.histogram.observe(value);
+
+        if let Some(mut exemplar) = exemplar {
+            exemplar.timestamp = Some(SystemTime::now().into());
+            state.exemplar = Some(exemplar);
+        }
+    }
+}
+
+impl<S> EncodeMetricValue for NativeHistogramWithExemplars<S>
+where
+    S: Serialize + Send + Sync + 'static,
+{
+    fn encode_metric_value(&self) -> Vec<MetricFamily> {
+        let state = self.state.read();
+        let families = state.histogram.try_encode_metric_value();
+        let exemplar = state.exemplar.clone();
+        drop(state);
+
+        let mut families = match families {
+            Ok(families) => families,
+            Err(error) => {
+                report_collect_error(format_args!(
+                    "non-fatal error while collecting metrics: skipped a native histogram; protobuf encoding failed: {error}"
+                ));
+                return Vec::new();
+            }
+        };
+
+        if let Some(exemplar) = finish_exemplar(exemplar.as_ref().map(Exemplar::encode)) {
+            for histogram in families
+                .iter_mut()
+                .flat_map(|family| &mut family.metric)
+                .filter_map(|metric| metric.histogram.as_mut())
+            {
+                histogram.exemplars.push(exemplar.clone());
+            }
+        }
+
+        families
+    }
+}
+
+impl<S> MetricConstructor<NativeHistogramWithExemplars<S>> for NativeHistogramWithExemplarsBuilder {
+    fn new_metric(&self) -> NativeHistogramWithExemplars<S> {
+        NativeHistogramWithExemplars {
+            state: Arc::new(RwLock::new(NativeHistogramWithExemplarsState {
+                histogram:
+                    <NativeHistogramBuilder as MetricConstructor<NativeHistogram>>::new_metric(
+                        &self.inner,
+                    ),
+                exemplar: None,
+            })),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use foundations_metrics_registry::proto::MetricType;
+    use prost::Message;
+    use serde::Serialize;
+
+    use super::*;
+    use crate::{
+        CollectionOptions, EncodeMetric, Family, NamedMetric, RegistrationMetadata,
+        ServiceNameFormat, collect, encode_to_protobuf, encode_to_text, register,
+    };
+
+    #[derive(Clone, Debug, Serialize)]
+    struct TraceLabels {
+        trace_id: &'static str,
+    }
+
+    fn trace_id(exemplar: &proto::Exemplar) -> Option<&str> {
+        exemplar
+            .label
+            .iter()
+            .find(|label| label.name.as_deref() == Some("trace_id"))
+            .and_then(|label| label.value.as_deref())
+    }
+
+    #[test]
+    fn counter_replaces_and_clears_exemplars_and_clones_share_storage() {
+        let counter = CounterWithExemplar::<TraceLabels>::default();
+        let clone = counter.clone();
+
+        assert_eq!(
+            counter.inc_by(2, Some(TraceLabels { trace_id: "first" })),
+            0
+        );
+        assert_eq!(clone.inc_by(3, Some(TraceLabels { trace_id: "latest" })), 2);
+
+        let families = counter.encode_metric_value();
+        let encoded = families[0].metric[0].counter.as_ref().unwrap();
+        let exemplar = encoded.exemplar.as_ref().unwrap();
+        assert_eq!(encoded.value, Some(5.0));
+        assert_eq!(exemplar.value, Some(3.0));
+        assert_eq!(trace_id(exemplar), Some("latest"));
+        assert!(exemplar.timestamp.is_none());
+
+        let (value, exemplar) = counter.get();
+        assert_eq!(value, 5);
+        assert!(exemplar.is_some());
+        drop(exemplar);
+        assert_eq!(
+            counter.inner().load(std::sync::atomic::Ordering::Relaxed),
+            5
+        );
+
+        assert_eq!(counter.inc_by(1, None), 5);
+        assert_eq!(counter.get().0, 6);
+        assert!(
+            counter.encode_metric_value()[0].metric[0]
+                .counter
+                .as_ref()
+                .unwrap()
+                .exemplar
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn classic_histogram_retains_latest_exemplar_per_bucket() {
+        let histogram = HistogramWithExemplars::new([1.0, 2.0]);
+        histogram.observe(0.5, Some(TraceLabels { trace_id: "first" }));
+        histogram.observe(
+            0.75,
+            Some(TraceLabels {
+                trace_id: "replacement",
+            }),
+        );
+        histogram.observe(0.8, None);
+        histogram.observe(
+            1.5,
+            Some(TraceLabels {
+                trace_id: "second_bucket",
+            }),
+        );
+
+        let families = histogram.encode_metric_value();
+        let encoded = families[0].metric[0].histogram.as_ref().unwrap();
+        assert_eq!(encoded.sample_count, Some(4));
+        assert_eq!(encoded.sample_sum, Some(3.55));
+        assert_eq!(
+            encoded
+                .bucket
+                .iter()
+                .map(|bucket| bucket.cumulative_count)
+                .collect::<Vec<_>>(),
+            [Some(3), Some(4), Some(4)]
+        );
+        assert_eq!(
+            trace_id(encoded.bucket[0].exemplar.as_ref().unwrap()),
+            Some("replacement")
+        );
+        assert_eq!(
+            encoded.bucket[0].exemplar.as_ref().unwrap().value,
+            Some(0.75)
+        );
+        assert_eq!(
+            trace_id(encoded.bucket[1].exemplar.as_ref().unwrap()),
+            Some("second_bucket")
+        );
+        assert!(encoded.bucket[2].exemplar.is_none());
+    }
+
+    #[test]
+    fn native_histogram_retains_latest_timestamped_exemplar() {
+        let histogram = NativeHistogramWithExemplars::new(1.1);
+        let clone = histogram.clone();
+        histogram.observe(0.5, Some(TraceLabels { trace_id: "first" }));
+        clone.observe(2.0, None);
+        clone.observe(3.0, Some(TraceLabels { trace_id: "latest" }));
+
+        let families = histogram.encode_metric_value();
+        let encoded = families[0].metric[0].histogram.as_ref().unwrap();
+        assert_eq!(encoded.sample_count, Some(3));
+        assert_eq!(encoded.sample_sum, Some(5.5));
+        assert!(!encoded.positive_span.is_empty());
+        assert_eq!(encoded.exemplars.len(), 1);
+        assert_eq!(encoded.exemplars[0].value, Some(3.0));
+        assert_eq!(trace_id(&encoded.exemplars[0]), Some("latest"));
+        assert!(encoded.exemplars[0].timestamp.is_some());
+    }
+
+    #[test]
+    fn exemplar_label_failure_drops_only_the_exemplar() {
+        let counter = CounterWithExemplar::<&'static str>::default();
+        counter.inc_by(2, Some("not a label set"));
+
+        let families = NamedMetric::new("serialization_failure", "", counter).encode();
+        let sentinel = &families[0].metric[0]
+            .counter
+            .as_ref()
+            .unwrap()
+            .exemplar
+            .as_ref()
+            .unwrap()
+            .label[0];
+        assert_eq!(
+            sentinel.name.as_deref(),
+            Some(EXEMPLAR_SERIALIZATION_ERROR_LABEL)
+        );
+        assert_eq!(
+            sentinel.value.as_deref(),
+            Some("metric labels must serialize as a struct or unit")
+        );
+
+        let payload = encode_to_protobuf(&families);
+        let encoded = MetricFamily::decode_length_delimited(payload.as_slice()).unwrap();
+        let encoded = encoded.metric[0].counter.as_ref().unwrap();
+        assert_eq!(encoded.value, Some(2.0));
+        assert!(encoded.exemplar.is_none());
+    }
+
+    #[test]
+    fn empty_exemplar_label_sets_are_retained_in_text() {
+        let counter = CounterWithExemplar::<()>::default();
+        counter.inc_by(2, Some(()));
+
+        let families = NamedMetric::new("empty_exemplar", "", counter).encode();
+        assert!(encode_to_text(&families).contains("empty_exemplar 2.0 # {} 2.0\n"));
+    }
+
+    #[test]
+    fn accepts_legacy_sequence_label_sets() {
+        let counter = CounterWithExemplar::<Vec<(&'static str, &'static str)>>::default();
+        counter.inc_by(1, Some(vec![("trace_id", "legacy")]));
+
+        let families = counter.encode_metric_value();
+        let exemplar = families[0].metric[0]
+            .counter
+            .as_ref()
+            .unwrap()
+            .exemplar
+            .as_ref()
+            .unwrap();
+        assert_eq!(trace_id(exemplar), Some("legacy"));
+    }
+
+    #[test]
+    fn updates_do_not_require_serializable_label_sets() {
+        struct OpaqueLabels;
+
+        let counter = CounterWithExemplar::<OpaqueLabels>::default();
+        counter.inc_by(1, Some(OpaqueLabels));
+        assert_eq!(counter.get().0, 1);
+
+        let classic = HistogramWithExemplars::new([1.0]);
+        classic.observe(0.5, Some(OpaqueLabels));
+
+        let native = NativeHistogramWithExemplars::new(1.1);
+        native.observe(0.5, Some(OpaqueLabels));
+    }
+
+    #[test]
+    fn families_keep_series_and_exemplar_labels_separate() {
+        #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+        struct SeriesLabels {
+            method: &'static str,
+        }
+
+        let family = Family::<SeriesLabels, CounterWithExemplar<TraceLabels>>::default();
+        family
+            .get_or_create(&SeriesLabels { method: "GET" })
+            .inc_by(1, Some(TraceLabels { trace_id: "abc" }));
+
+        let families = family.encode_metric_value();
+        let metric = &families[0].metric[0];
+        assert!(metric.label.iter().any(|label| {
+            label.name.as_deref() == Some("method") && label.value.as_deref() == Some("GET")
+        }));
+        assert_eq!(
+            trace_id(metric.counter.as_ref().unwrap().exemplar.as_ref().unwrap()),
+            Some("abc")
+        );
+    }
+
+    #[test]
+    fn histogram_builders_construct_exemplar_metrics() {
+        let classic: HistogramWithExemplars<TraceLabels> = HistogramBuilder {
+            buckets: &[0.5, 1.0],
+        }
+        .new_metric();
+        classic.observe(
+            0.75,
+            Some(TraceLabels {
+                trace_id: "classic",
+            }),
+        );
+        assert!(
+            classic.encode_metric_value()[0].metric[0]
+                .histogram
+                .as_ref()
+                .unwrap()
+                .bucket[1]
+                .exemplar
+                .is_some()
+        );
+
+        let native: NativeHistogramWithExemplars<TraceLabels> =
+            NativeHistogramWithExemplarsBuilder::new(1.1)
+                .with_max_buckets(160)
+                .new_metric();
+        native.observe(0.75, Some(TraceLabels { trace_id: "native" }));
+        assert_eq!(
+            native.encode_metric_value()[0].metric[0]
+                .histogram
+                .as_ref()
+                .unwrap()
+                .exemplars
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn registered_exemplar_counter_is_collected_and_encoded() {
+        let counter = CounterWithExemplar::<TraceLabels>::default();
+        counter.inc_by(
+            4,
+            Some(TraceLabels {
+                trace_id: "registered",
+            }),
+        );
+        register(
+            Box::new(NamedMetric::new(
+                "registered_counter_with_exemplar",
+                "A registered exemplar counter.",
+                counter,
+            )) as Box<dyn EncodeMetric>,
+            RegistrationMetadata::default(),
+        );
+
+        let families = collect(CollectionOptions {
+            include_optional: false,
+            service_name: None,
+            service_name_format: ServiceNameFormat::MetricPrefix,
+        });
+        let family = families
+            .iter()
+            .find(|family| family.name.as_deref() == Some("registered_counter_with_exemplar"))
+            .expect("registered exemplar counter is collected");
+        assert_eq!(family.r#type, Some(MetricType::Counter as i32));
+        assert_eq!(
+            trace_id(
+                family.metric[0]
+                    .counter
+                    .as_ref()
+                    .unwrap()
+                    .exemplar
+                    .as_ref()
+                    .unwrap()
+            ),
+            Some("registered")
+        );
+
+        let text = encode_to_text(std::slice::from_ref(family));
+        assert!(
+            text.contains("registered_counter_with_exemplar 4.0 # {trace_id=\"registered\"} 4.0\n")
+        );
+    }
+
+    #[test]
+    fn registered_native_exemplar_family_round_trips_through_protobuf() {
+        #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+        struct SeriesLabels {
+            method: &'static str,
+        }
+
+        let family = Family::<
+            SeriesLabels,
+            NativeHistogramWithExemplars<TraceLabels>,
+            NativeHistogramWithExemplarsBuilder,
+        >::new_with_constructor(NativeHistogramWithExemplarsBuilder::new(1.1));
+        family
+            .get_or_create(&SeriesLabels { method: "GET" })
+            .observe(0.25, Some(TraceLabels { trace_id: "native" }));
+        register(
+            Box::new(NamedMetric::new(
+                "registered_native_histogram_with_exemplars",
+                "A registered native histogram with exemplars.",
+                family,
+            )) as Box<dyn EncodeMetric>,
+            RegistrationMetadata::default(),
+        );
+
+        let families = collect(CollectionOptions {
+            include_optional: false,
+            service_name: None,
+            service_name_format: ServiceNameFormat::MetricPrefix,
+        });
+        let family = families
+            .iter()
+            .find(|family| {
+                family.name.as_deref() == Some("registered_native_histogram_with_exemplars")
+            })
+            .expect("registered native histogram family is collected");
+        let payload = encode_to_protobuf(std::slice::from_ref(family));
+        let mut bytes = payload.as_slice();
+        let decoded = MetricFamily::decode_length_delimited(&mut bytes).unwrap();
+        let metric = &decoded.metric[0];
+        assert!(metric.label.iter().any(|label| {
+            label.name.as_deref() == Some("method") && label.value.as_deref() == Some("GET")
+        }));
+        let exemplars = &metric.histogram.as_ref().unwrap().exemplars;
+        assert_eq!(exemplars.len(), 1);
+        assert_eq!(trace_id(&exemplars[0]), Some("native"));
+        assert!(exemplars[0].timestamp.is_some());
+        assert!(bytes.is_empty());
+    }
+}

--- a/foundations-metrics/src/metrics/exemplar.rs
+++ b/foundations-metrics/src/metrics/exemplar.rs
@@ -689,9 +689,9 @@ mod tests {
         );
 
         let text = encode_to_text(std::slice::from_ref(family));
-        assert!(
-            text.contains("registered_counter_with_exemplar 4.0 # {trace_id=\"registered\"} 4.0\n")
-        );
+        assert!(text.contains(
+            "registered_counter_with_exemplar 4.0 # {\"trace_id\"=\"registered\"} 4.0\n"
+        ));
     }
 
     #[test]

--- a/foundations-metrics/src/metrics/exemplar.rs
+++ b/foundations-metrics/src/metrics/exemplar.rs
@@ -13,26 +13,11 @@ use crate::labels::to_label_pairs;
 use crate::validation::EXEMPLAR_SERIALIZATION_ERROR_LABEL;
 
 /// Labels and a sampled value associated with a metric observation.
-///
-/// Their fields remain private; exemplars are created by recording labeled
-/// metric updates.
 #[derive(Debug)]
-pub struct Exemplar<S, V> {
+pub(super) struct Exemplar<S, V> {
     label_set: Arc<S>,
     value: V,
     pub(super) timestamp: Option<Timestamp>,
-}
-
-impl<S, V> Exemplar<S, V> {
-    /// Returns the exemplar's label set.
-    pub fn label_set(&self) -> &S {
-        &self.label_set
-    }
-
-    /// Returns the sampled increment or observation.
-    pub fn value(&self) -> &V {
-        &self.value
-    }
 }
 
 impl<S, V> Exemplar<S, V> {
@@ -103,9 +88,25 @@ pub(super) fn finish_exemplar(
 /// requests.inc();
 ///
 /// // Labeled: the exemplar and the increment are applied together.
-/// requests.with_exemplar(TraceLabels { trace_id: "abc" }, 4);
+/// requests.inc_by_with_exemplar(TraceLabels { trace_id: "abc" }, 4);
 ///
 /// assert_eq!(requests.get(), 5);
+/// ```
+///
+/// A histogram exemplar can link an unusual observation to a trace:
+///
+/// ```
+/// use foundations_metrics::{Histogram, WithExemplar};
+/// # #[derive(serde::Serialize)]
+/// # struct TraceLabels { trace_id: &'static str }
+///
+/// let request_latency = WithExemplar::<Histogram, TraceLabels>::new(
+///     Histogram::new([0.1, 0.5, 1.0]),
+/// );
+///
+/// request_latency.observe(0.05);
+/// // Attach the trace ID of a slow request to the matching latency bucket.
+/// request_latency.observe_with_exemplar(TraceLabels { trace_id: "abc123" }, 0.8);
 /// ```
 ///
 /// Cloning a supported metric shares both its inner metric and exemplar storage.
@@ -292,31 +293,36 @@ mod tests {
     #[test]
     fn reads_and_updates_interleave_without_deadlock() {
         let counter = WithExemplar::<Counter, TraceLabels>::new(Counter::default());
-        counter.with_exemplar(TraceLabels { trace_id: "a" }, 1);
+        counter.inc_by_with_exemplar(TraceLabels { trace_id: "a" }, 1);
 
         let value = counter.get();
         assert_eq!(value, 1);
         counter.inc();
         assert_eq!(counter.get(), 2);
         let _inner = counter.inner();
-        counter.with_exemplar(TraceLabels { trace_id: "b" }, 1);
+        counter.inc_by_with_exemplar(TraceLabels { trace_id: "b" }, 1);
         assert_eq!(counter.get(), 3);
     }
 
     #[test]
-    fn reading_an_exemplar_does_not_block_inner_metric_updates() {
+    fn unlabeled_updates_do_not_take_the_exemplar_lock() {
         use std::sync::Arc as StdArc;
+        use std::sync::mpsc;
+        use std::time::Duration;
+
         let counter = StdArc::new(WithExemplar::<Counter, TraceLabels>::default());
-        let exemplar = counter.exemplar();
+        let exemplars = counter.exemplars.lock();
 
         let writer = StdArc::clone(&counter);
+        let (updated_tx, updated_rx) = mpsc::channel();
         let handle = std::thread::spawn(move || {
-            writer.inc();
-            writer.get()
+            updated_tx.send(writer.inc()).unwrap();
         });
-        let _second = counter.inner();
-        assert!(exemplar.is_none());
-        assert_eq!(handle.join().unwrap(), 1);
+
+        assert_eq!(updated_rx.recv_timeout(Duration::from_secs(1)).unwrap(), 0);
+        drop(exemplars);
+        handle.join().unwrap();
+        assert_eq!(counter.get(), 1);
     }
 
     #[test]
@@ -325,11 +331,11 @@ mod tests {
         let clone = counter.clone();
 
         assert_eq!(
-            counter.with_exemplar(TraceLabels { trace_id: "first" }, 2),
+            counter.inc_by_with_exemplar(TraceLabels { trace_id: "first" }, 2),
             0
         );
         assert_eq!(
-            clone.with_exemplar(TraceLabels { trace_id: "latest" }, 3),
+            clone.inc_by_with_exemplar(TraceLabels { trace_id: "latest" }, 3),
             2
         );
 
@@ -341,11 +347,7 @@ mod tests {
         assert_eq!(trace_id(exemplar), Some("latest"));
         assert!(exemplar.timestamp.is_none());
 
-        // No guard is handed out, so reads and updates freely interleave. Under
-        // the previous `get() -> (N, MappedRwLockReadGuard<'_, _>)` API these
-        // three lines deadlocked.
         assert_eq!(counter.get(), 5);
-        assert!(counter.exemplar().is_some());
         assert_eq!(
             counter.inner().load(std::sync::atomic::Ordering::Relaxed),
             5
@@ -355,7 +357,14 @@ mod tests {
         // exemplar in place.
         assert_eq!(counter.inc(), 5);
         assert_eq!(counter.get(), 6);
-        assert!(counter.exemplar().is_some());
+        assert!(
+            counter.encode_metric_value()[0].metric[0]
+                .counter
+                .as_ref()
+                .unwrap()
+                .exemplar
+                .is_some()
+        );
 
         counter.clear_exemplars();
         assert!(
@@ -371,17 +380,30 @@ mod tests {
     #[test]
     fn counter_exemplars_preserve_their_value_type() {
         let unsigned = WithExemplar::<Counter, TraceLabels>::default();
-        unsigned.with_exemplar(
+        unsigned.inc_by_with_exemplar(
             TraceLabels {
                 trace_id: "unsigned",
             },
             u64::MAX,
         );
-        assert_eq!(unsigned.exemplar().unwrap().value(), &u64::MAX);
+        let unsigned_exemplars = unsigned.exemplars.lock();
+        let ExemplarStorage::Single(Some(StoredExemplar::U64(unsigned_exemplar))) =
+            &*unsigned_exemplars
+        else {
+            panic!("expected an unsigned counter exemplar");
+        };
+        assert_eq!(unsigned_exemplar.value, u64::MAX);
+        assert_eq!(unsigned_exemplar.label_set.trace_id, "unsigned");
+        drop(unsigned_exemplars);
 
         let float = WithExemplar::<Counter<f64>, TraceLabels>::default();
-        float.with_exemplar(TraceLabels { trace_id: "float" }, 1.5);
-        assert_eq!(float.exemplar().unwrap().value(), &1.5);
+        float.inc_by_with_exemplar(TraceLabels { trace_id: "float" }, 1.5);
+        let float_exemplars = float.exemplars.lock();
+        let ExemplarStorage::Single(Some(StoredExemplar::F64(float_exemplar))) = &*float_exemplars
+        else {
+            panic!("expected a floating-point counter exemplar");
+        };
+        assert_eq!(float_exemplar.value, 1.5);
     }
 
     #[test]
@@ -393,7 +415,7 @@ mod tests {
             Counter<u64, BlockingCounterAtomic>,
             TraceLabels,
         >::default());
-        counter.with_exemplar(TraceLabels { trace_id: "old" }, 1);
+        counter.inc_by_with_exemplar(TraceLabels { trace_id: "old" }, 1);
         counter
             .inner()
             .block_get
@@ -412,7 +434,7 @@ mod tests {
         let updater = Arc::clone(&counter);
         let (updated_tx, updated_rx) = mpsc::channel();
         let updater = std::thread::spawn(move || {
-            let previous = updater.with_exemplar(TraceLabels { trace_id: "new" }, 1);
+            let previous = updater.inc_by_with_exemplar(TraceLabels { trace_id: "new" }, 1);
             updated_tx.send(previous).unwrap();
         });
 
@@ -442,15 +464,15 @@ mod tests {
     #[test]
     fn classic_histogram_retains_latest_exemplar_per_bucket() {
         let histogram = WithExemplar::new(Histogram::new([1.0, 2.0]));
-        histogram.with_exemplar(TraceLabels { trace_id: "first" }, 0.5);
-        histogram.with_exemplar(
+        histogram.observe_with_exemplar(TraceLabels { trace_id: "first" }, 0.5);
+        histogram.observe_with_exemplar(
             TraceLabels {
                 trace_id: "replacement",
             },
             0.75,
         );
         histogram.observe(0.8);
-        histogram.with_exemplar(
+        histogram.observe_with_exemplar(
             TraceLabels {
                 trace_id: "second_bucket",
             },
@@ -488,9 +510,9 @@ mod tests {
     fn native_histogram_retains_latest_timestamped_exemplar() {
         let histogram = WithExemplar::new(NativeHistogram::new(1.1));
         let clone = histogram.clone();
-        histogram.with_exemplar(TraceLabels { trace_id: "first" }, 0.5);
+        histogram.observe_with_exemplar(TraceLabels { trace_id: "first" }, 0.5);
         clone.observe(2.0);
-        clone.with_exemplar(TraceLabels { trace_id: "latest" }, 3.0);
+        clone.observe_with_exemplar(TraceLabels { trace_id: "latest" }, 3.0);
 
         let families = histogram.encode_metric_value();
         let encoded = families[0].metric[0].histogram.as_ref().unwrap();
@@ -506,7 +528,7 @@ mod tests {
     #[test]
     fn exemplar_label_failure_drops_only_the_exemplar() {
         let counter = WithExemplar::<Counter, &'static str>::default();
-        counter.with_exemplar("not a label set", 2);
+        counter.inc_by_with_exemplar("not a label set", 2);
 
         let families = NamedMetric::new("serialization_failure", "", counter).encode();
         let sentinel = &families[0].metric[0]
@@ -536,7 +558,7 @@ mod tests {
     #[test]
     fn empty_exemplar_label_sets_are_retained_in_text() {
         let counter = WithExemplar::<Counter, ()>::default();
-        counter.with_exemplar((), 2);
+        counter.inc_by_with_exemplar((), 2);
 
         let families = NamedMetric::new("empty_exemplar", "", counter).encode();
         assert!(encode_to_text(&families).contains("empty_exemplar 2.0 # {} 2.0\n"));
@@ -545,7 +567,7 @@ mod tests {
     #[test]
     fn accepts_legacy_sequence_label_sets() {
         let counter = WithExemplar::<Counter, Vec<(&'static str, &'static str)>>::default();
-        counter.with_exemplar(vec![("trace_id", "legacy")], 1);
+        counter.inc_by_with_exemplar(vec![("trace_id", "legacy")], 1);
 
         let families = counter.encode_metric_value();
         let exemplar = families[0].metric[0]
@@ -563,14 +585,14 @@ mod tests {
         struct OpaqueLabels;
 
         let counter = WithExemplar::<Counter, OpaqueLabels>::default();
-        counter.with_exemplar(OpaqueLabels, 1);
+        counter.inc_by_with_exemplar(OpaqueLabels, 1);
         assert_eq!(counter.get(), 1);
 
         let classic = WithExemplar::<Histogram, OpaqueLabels>::new(Histogram::new([1.0]));
-        classic.with_exemplar(OpaqueLabels, 0.5);
+        classic.observe_with_exemplar(OpaqueLabels, 0.5);
 
         let native = WithExemplar::<NativeHistogram, OpaqueLabels>::new(NativeHistogram::new(1.1));
-        native.with_exemplar(OpaqueLabels, 0.5);
+        native.observe_with_exemplar(OpaqueLabels, 0.5);
     }
 
     #[test]
@@ -583,7 +605,7 @@ mod tests {
         let family = Family::<SeriesLabels, WithExemplar<Counter, TraceLabels>>::default();
         family
             .get_or_create(&SeriesLabels { method: "GET" })
-            .with_exemplar(TraceLabels { trace_id: "abc" }, 1);
+            .inc_by_with_exemplar(TraceLabels { trace_id: "abc" }, 1);
 
         let families = family.encode_metric_value();
         let metric = &families[0].metric[0];
@@ -602,7 +624,7 @@ mod tests {
             buckets: &[0.5, 1.0],
         }
         .new_metric();
-        classic.with_exemplar(
+        classic.observe_with_exemplar(
             TraceLabels {
                 trace_id: "classic",
             },
@@ -621,7 +643,7 @@ mod tests {
         let native: WithExemplar<NativeHistogram, TraceLabels> = NativeHistogramBuilder::new(1.1)
             .with_max_buckets(160)
             .new_metric();
-        native.with_exemplar(TraceLabels { trace_id: "native" }, 0.75);
+        native.observe_with_exemplar(TraceLabels { trace_id: "native" }, 0.75);
         assert_eq!(
             native.encode_metric_value()[0].metric[0]
                 .histogram
@@ -636,7 +658,7 @@ mod tests {
     #[test]
     fn registered_exemplar_counter_is_collected_and_encoded() {
         let counter = WithExemplar::<Counter, TraceLabels>::default();
-        counter.with_exemplar(
+        counter.inc_by_with_exemplar(
             TraceLabels {
                 trace_id: "registered",
             },
@@ -694,7 +716,7 @@ mod tests {
         >::new_with_constructor(NativeHistogramBuilder::new(1.1));
         family
             .get_or_create(&SeriesLabels { method: "GET" })
-            .with_exemplar(TraceLabels { trace_id: "native" }, 0.25);
+            .observe_with_exemplar(TraceLabels { trace_id: "native" }, 0.25);
         register(
             Box::new(NamedMetric::new(
                 "registered_native_histogram_with_exemplars",

--- a/foundations-metrics/src/metrics/exemplar.rs
+++ b/foundations-metrics/src/metrics/exemplar.rs
@@ -1,34 +1,26 @@
 use std::collections::HashMap;
-use std::marker::PhantomData;
+use std::fmt;
+use std::ops::Deref;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
-use std::time::SystemTime;
 
 use foundations_metrics_registry::proto;
-use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard};
+use parking_lot::Mutex;
 use prost_types::Timestamp;
 use serde::Serialize;
 
-use super::counter::encode_counter;
-use super::histogram::encode_snapshot;
-use super::{
-    CounterAtomic, Histogram, HistogramBuilder, IntoF64, MetricConstructor, NativeHistogram,
-    NativeHistogramBuilder,
-};
-use crate::diagnostics::report_collect_error;
+use super::IntoF64;
 use crate::labels::to_label_pairs;
 use crate::validation::EXEMPLAR_SERIALIZATION_ERROR_LABEL;
-use crate::{MetricFamily, value::EncodeMetricValue};
 
 /// Labels and a sampled value associated with a metric observation.
 ///
-/// Exemplar values are exposed through [`CounterWithExemplar::get`]. Their fields
-/// remain private; exemplars are created by recording labeled metric updates.
+/// Their fields remain private; exemplars are created by recording labeled
+/// metric updates.
 #[derive(Debug)]
 pub struct Exemplar<S, V> {
     label_set: Arc<S>,
     value: V,
-    timestamp: Option<Timestamp>,
+    pub(super) timestamp: Option<Timestamp>,
 }
 
 impl<S, V> Exemplar<S, V> {
@@ -44,7 +36,7 @@ impl<S, V> Exemplar<S, V> {
 }
 
 impl<S, V> Exemplar<S, V> {
-    fn new(label_set: S, value: V, timestamp: Option<Timestamp>) -> Self {
+    pub(super) fn new(label_set: S, value: V, timestamp: Option<Timestamp>) -> Self {
         Self {
             label_set: Arc::new(label_set),
             value,
@@ -64,7 +56,7 @@ impl<S, V: Clone> Clone for Exemplar<S, V> {
 }
 
 impl<S, V> Exemplar<S, V> {
-    fn encode(&self) -> Result<proto::Exemplar, String>
+    pub(super) fn encode(&self) -> Result<proto::Exemplar, String>
     where
         S: Serialize,
         V: Clone + IntoF64,
@@ -77,7 +69,9 @@ impl<S, V> Exemplar<S, V> {
     }
 }
 
-fn finish_exemplar(exemplar: Option<Result<proto::Exemplar, String>>) -> Option<proto::Exemplar> {
+pub(super) fn finish_exemplar(
+    exemplar: Option<Result<proto::Exemplar, String>>,
+) -> Option<proto::Exemplar> {
     match exemplar {
         Some(Ok(exemplar)) => Some(exemplar),
         // Defer reporting to validation, after any enclosing Family lock has
@@ -93,263 +87,142 @@ fn finish_exemplar(exemplar: Option<Result<proto::Exemplar, String>>) -> Option<
     }
 }
 
-/// A monotonically increasing counter that records an exemplar with an update.
+/// A metric paired with exemplar storage.
 ///
-/// Calling [`inc_by`](Self::inc_by) with a label set replaces the previous
-/// exemplar. Calling it without a label set clears the previous exemplar. The
-/// exemplar value is the increment. [`get`](Self::get) returns the cumulative
-/// counter value and read-only access to the current exemplar. Clones share both
-/// values.
+/// The wrapper [`Deref`]s to the inner metric, so unlabeled updates go straight
+/// to it and never touch the exemplar lock:
+///
+/// ```
+/// use foundations_metrics::{Counter, WithExemplar};
+/// # #[derive(serde::Serialize)]
+/// # struct TraceLabels { trace_id: &'static str }
+///
+/// let requests: WithExemplar<Counter, TraceLabels> = WithExemplar::default();
+///
+/// // Unlabeled: identical to `Counter::inc`, and leaves any exemplar in place.
+/// requests.inc();
+///
+/// // Labeled: the exemplar and the increment are applied together.
+/// requests.with_exemplar(TraceLabels { trace_id: "abc" }, 4);
+///
+/// assert_eq!(requests.get(), 5);
+/// ```
+///
+/// Cloning a supported metric shares both its inner metric and exemplar storage.
 ///
 /// Exemplar labels are serialized with [`serde::Serialize`] during collection.
-#[derive(Debug)]
-pub struct CounterWithExemplar<S, N = u64, A = AtomicU64> {
-    state: Arc<RwLock<CounterWithExemplarState<S, N, A>>>,
-    marker: PhantomData<N>,
+pub struct WithExemplar<T, S> {
+    pub(super) inner: T,
+    pub(super) exemplars: Arc<Mutex<ExemplarStorage<S>>>,
 }
 
 #[derive(Debug)]
-struct CounterWithExemplarState<S, N, A> {
-    value: A,
-    exemplar: Option<Exemplar<S, N>>,
+pub(super) enum ExemplarStorage<S> {
+    Empty,
+    Single(Option<StoredExemplar<S>>),
+    PerBucket(HashMap<usize, Exemplar<S, f64>>),
 }
 
-impl<S, N, A> CounterWithExemplar<S, N, A>
+#[derive(Debug)]
+pub(super) enum StoredExemplar<S> {
+    I64(Exemplar<S, i64>),
+    U64(Exemplar<S, u64>),
+    F64(Exemplar<S, f64>),
+}
+
+impl<S> Clone for StoredExemplar<S> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::I64(exemplar) => Self::I64(exemplar.clone()),
+            Self::U64(exemplar) => Self::U64(exemplar.clone()),
+            Self::F64(exemplar) => Self::F64(exemplar.clone()),
+        }
+    }
+}
+
+impl<S> StoredExemplar<S> {
+    pub(super) fn encode(&self) -> Result<proto::Exemplar, String>
+    where
+        S: Serialize,
+    {
+        match self {
+            Self::I64(exemplar) => exemplar.encode(),
+            Self::U64(exemplar) => exemplar.encode(),
+            Self::F64(exemplar) => exemplar.encode(),
+        }
+    }
+}
+
+impl<S> ExemplarStorage<S> {
+    fn clear(&mut self) {
+        match self {
+            Self::Empty => {}
+            Self::Single(exemplar) => *exemplar = None,
+            Self::PerBucket(exemplars) => exemplars.clear(),
+        }
+    }
+}
+
+impl<T, S> WithExemplar<T, S> {
+    /// Wraps `metric` in exemplar storage.
+    pub fn new(metric: T) -> Self {
+        Self {
+            inner: metric,
+            exemplars: Arc::new(Mutex::new(ExemplarStorage::Empty)),
+        }
+    }
+
+    /// Returns the wrapped metric.
+    pub fn metric(&self) -> &T {
+        &self.inner
+    }
+
+    /// Discards all stored exemplars.
+    pub fn clear_exemplars(&self) {
+        self.exemplars.lock().clear();
+    }
+}
+
+impl<T, S> Deref for WithExemplar<T, S> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T, S> Clone for WithExemplar<T, S>
 where
-    N: Clone,
-    A: CounterAtomic<N>,
+    T: Clone,
 {
-    /// Increments the counter by `value`, returning the previous total.
-    ///
-    /// A provided label set replaces the stored exemplar. `None` clears it.
-    pub fn inc_by(&self, value: N, label_set: Option<S>) -> N {
-        let exemplar = label_set.map(|label_set| Exemplar::new(label_set, value.clone(), None));
-        let mut state = self.state.write();
-        state.exemplar = exemplar;
-        state.value.inc_by(value)
-    }
-
-    /// Returns the cumulative counter value and the current exemplar.
-    ///
-    /// The exemplar guard keeps the counter read-locked until it is dropped.
-    pub fn get(&self) -> (N, MappedRwLockReadGuard<'_, Option<Exemplar<S, N>>>) {
-        let state = self.state.read();
-        let value = state.value.get();
-        let exemplar = RwLockReadGuard::map(state, |state| &state.exemplar);
-        (value, exemplar)
-    }
-
-    /// Returns read-only access to the underlying counter storage.
-    ///
-    /// The returned guard prevents updates until it is dropped.
-    pub fn inner(&self) -> MappedRwLockReadGuard<'_, A> {
-        RwLockReadGuard::map(self.state.read(), |state| &state.value)
-    }
-}
-
-impl<S, N, A> Clone for CounterWithExemplar<S, N, A> {
     fn clone(&self) -> Self {
         Self {
-            state: Arc::clone(&self.state),
-            marker: PhantomData,
+            inner: self.inner.clone(),
+            exemplars: Arc::clone(&self.exemplars),
         }
     }
 }
 
-impl<S, N, A: Default> Default for CounterWithExemplar<S, N, A> {
+impl<T, S> Default for WithExemplar<T, S>
+where
+    T: Default,
+{
     fn default() -> Self {
-        Self {
-            state: Arc::new(RwLock::new(CounterWithExemplarState {
-                value: A::default(),
-                exemplar: None,
-            })),
-            marker: PhantomData,
-        }
+        Self::new(T::default())
     }
 }
 
-impl<S, N, A> EncodeMetricValue for CounterWithExemplar<S, N, A>
+impl<T, S> fmt::Debug for WithExemplar<T, S>
 where
-    S: Serialize + Send + Sync + 'static,
-    N: Clone + IntoF64,
-    A: CounterAtomic<N> + Send + Sync + 'static,
+    T: fmt::Debug,
+    S: fmt::Debug,
 {
-    fn encode_metric_value(&self) -> Vec<MetricFamily> {
-        let state = self.state.read();
-        let value = state.value.get().into_f64();
-        let exemplar = state.exemplar.clone();
-        drop(state);
-
-        let mut families = encode_counter(value);
-        let counter = families[0].metric[0]
-            .counter
-            .as_mut()
-            .expect("counter encoder always creates a counter value");
-        counter.exemplar = finish_exemplar(exemplar.as_ref().map(Exemplar::encode));
-        families
-    }
-}
-
-/// A classic fixed-bucket histogram that retains one exemplar per bucket.
-///
-/// A labeled observation replaces the exemplar in its bucket. An unlabeled
-/// observation updates the histogram without clearing an existing exemplar.
-/// Clones share histogram and exemplar storage.
-#[derive(Clone, Debug)]
-pub struct HistogramWithExemplars<S> {
-    state: Arc<RwLock<HistogramWithExemplarsState<S>>>,
-}
-
-#[derive(Debug)]
-struct HistogramWithExemplarsState<S> {
-    histogram: Histogram,
-    exemplars: HashMap<usize, Exemplar<S, f64>>,
-}
-
-impl<S> HistogramWithExemplars<S> {
-    /// Creates a histogram with the provided inclusive upper bounds.
-    ///
-    /// Bounds are sorted and a terminal `f64::MAX` bucket is appended.
-    pub fn new(bounds: impl IntoIterator<Item = f64>) -> Self {
-        Self {
-            state: Arc::new(RwLock::new(HistogramWithExemplarsState {
-                histogram: Histogram::new(bounds),
-                exemplars: HashMap::new(),
-            })),
-        }
-    }
-
-    /// Records an observation and optionally associates it with an exemplar.
-    pub fn observe(&self, value: f64, label_set: Option<S>) {
-        let exemplar = label_set.map(|label_set| Exemplar::new(label_set, value, None));
-        let mut state = self.state.write();
-        let bucket = state.histogram.observe_and_bucket(value);
-
-        if let (Some(bucket), Some(exemplar)) = (bucket, exemplar) {
-            state.exemplars.insert(bucket, exemplar);
-        }
-    }
-}
-
-impl<S> EncodeMetricValue for HistogramWithExemplars<S>
-where
-    S: Serialize + Send + Sync + 'static,
-{
-    fn encode_metric_value(&self) -> Vec<MetricFamily> {
-        let state = self.state.read();
-        let snapshot = state.histogram.snapshot();
-        let exemplars: Vec<_> = state
-            .exemplars
-            .iter()
-            .map(|(&index, exemplar)| (index, exemplar.clone()))
-            .collect();
-        drop(state);
-
-        let mut families = encode_snapshot(snapshot);
-        let buckets = &mut families[0].metric[0]
-            .histogram
-            .as_mut()
-            .expect("histogram encoder always creates a histogram value")
-            .bucket;
-
-        for (index, exemplar) in exemplars {
-            if let Some(bucket) = buckets.get_mut(index) {
-                bucket.exemplar = finish_exemplar(Some(exemplar.encode()));
-            }
-        }
-
-        families
-    }
-}
-
-impl<S> MetricConstructor<HistogramWithExemplars<S>> for HistogramBuilder {
-    fn new_metric(&self) -> HistogramWithExemplars<S> {
-        HistogramWithExemplars::new(self.buckets.iter().copied())
-    }
-}
-
-/// A native histogram that retains its latest labeled observation as an exemplar.
-///
-/// Native histogram exemplars require timestamps in the Prometheus protobuf
-/// model. The timestamp is captured when the labeled observation is recorded.
-/// Native histograms require protobuf exposition; OpenMetrics text encoding
-/// does not expose their sparse buckets or exemplars.
-#[derive(Clone, Debug)]
-pub struct NativeHistogramWithExemplars<S> {
-    state: Arc<RwLock<NativeHistogramWithExemplarsState<S>>>,
-}
-
-#[derive(Debug)]
-struct NativeHistogramWithExemplarsState<S> {
-    histogram: NativeHistogram,
-    exemplar: Option<Exemplar<S, f64>>,
-}
-
-impl<S> NativeHistogramWithExemplars<S> {
-    /// Creates a native histogram with the given bucket growth `factor`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `factor` is not greater than `1.0`.
-    pub fn new(factor: f64) -> Self {
-        NativeHistogramBuilder::new(factor).new_metric()
-    }
-
-    /// Records an observation and optionally retains it as the latest exemplar.
-    pub fn observe(&self, value: f64, label_set: Option<S>) {
-        let exemplar = label_set.map(|label_set| Exemplar::new(label_set, value, None));
-        let mut state = self.state.write();
-        state.histogram.observe(value);
-
-        if let Some(mut exemplar) = exemplar {
-            exemplar.timestamp = Some(SystemTime::now().into());
-            state.exemplar = Some(exemplar);
-        }
-    }
-}
-
-impl<S> EncodeMetricValue for NativeHistogramWithExemplars<S>
-where
-    S: Serialize + Send + Sync + 'static,
-{
-    fn encode_metric_value(&self) -> Vec<MetricFamily> {
-        let state = self.state.read();
-        let families = state.histogram.try_encode_metric_value();
-        let exemplar = state.exemplar.clone();
-        drop(state);
-
-        let mut families = match families {
-            Ok(families) => families,
-            Err(error) => {
-                report_collect_error(format_args!(
-                    "non-fatal error while collecting metrics: skipped a native histogram; protobuf encoding failed: {error}"
-                ));
-                return Vec::new();
-            }
-        };
-
-        if let Some(exemplar) = finish_exemplar(exemplar.as_ref().map(Exemplar::encode)) {
-            for histogram in families
-                .iter_mut()
-                .flat_map(|family| &mut family.metric)
-                .filter_map(|metric| metric.histogram.as_mut())
-            {
-                histogram.exemplars.push(exemplar.clone());
-            }
-        }
-
-        families
-    }
-}
-
-impl<S> MetricConstructor<NativeHistogramWithExemplars<S>> for NativeHistogramBuilder {
-    fn new_metric(&self) -> NativeHistogramWithExemplars<S> {
-        NativeHistogramWithExemplars {
-            state: Arc::new(RwLock::new(NativeHistogramWithExemplarsState {
-                histogram: NativeHistogramBuilder::new_metric(self),
-                exemplar: None,
-            })),
-        }
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WithExemplar")
+            .field("inner", &self.inner)
+            .field("exemplars", &self.exemplars)
+            .finish()
     }
 }
 
@@ -360,14 +233,52 @@ mod tests {
     use serde::Serialize;
 
     use super::*;
+    use crate::value::EncodeMetricValue;
     use crate::{
-        CollectionOptions, EncodeMetric, Family, NamedMetric, RegistrationMetadata,
-        ServiceNameFormat, collect, encode_to_protobuf, encode_to_text, register,
+        CollectionOptions, Counter, CounterAtomic, EncodeMetric, Family, Histogram,
+        HistogramBuilder, MetricConstructor, MetricFamily, NamedMetric, NativeHistogram,
+        NativeHistogramBuilder, RegistrationMetadata, ServiceNameFormat, collect,
+        encode_to_protobuf, encode_to_text, register,
     };
 
     #[derive(Clone, Debug, Serialize)]
     struct TraceLabels {
         trace_id: &'static str,
+    }
+
+    #[derive(Default)]
+    struct BlockingCounterAtomic {
+        value: std::sync::atomic::AtomicU64,
+        block_get: std::sync::atomic::AtomicBool,
+        entered_get: (std::sync::Mutex<bool>, std::sync::Condvar),
+        release_get: (std::sync::Mutex<bool>, std::sync::Condvar),
+    }
+
+    impl CounterAtomic<u64> for BlockingCounterAtomic {
+        fn inc(&self) -> u64 {
+            self.inc_by(1)
+        }
+
+        fn inc_by(&self, value: u64) -> u64 {
+            self.value
+                .fetch_add(value, std::sync::atomic::Ordering::Relaxed)
+        }
+
+        fn get(&self) -> u64 {
+            if self.block_get.load(std::sync::atomic::Ordering::Relaxed) {
+                let (entered, entered_condvar) = &self.entered_get;
+                *entered.lock().unwrap() = true;
+                entered_condvar.notify_one();
+
+                let (release, release_condvar) = &self.release_get;
+                let mut release = release.lock().unwrap();
+                while !*release {
+                    release = release_condvar.wait(release).unwrap();
+                }
+            }
+
+            self.value.load(std::sync::atomic::Ordering::Relaxed)
+        }
     }
 
     fn trace_id(exemplar: &proto::Exemplar) -> Option<&str> {
@@ -379,15 +290,48 @@ mod tests {
     }
 
     #[test]
-    fn counter_replaces_and_clears_exemplars_and_clones_share_storage() {
-        let counter = CounterWithExemplar::<TraceLabels>::default();
+    fn reads_and_updates_interleave_without_deadlock() {
+        let counter = WithExemplar::<Counter, TraceLabels>::new(Counter::default());
+        counter.with_exemplar(TraceLabels { trace_id: "a" }, 1);
+
+        let value = counter.get();
+        assert_eq!(value, 1);
+        counter.inc();
+        assert_eq!(counter.get(), 2);
+        let _inner = counter.inner();
+        counter.with_exemplar(TraceLabels { trace_id: "b" }, 1);
+        assert_eq!(counter.get(), 3);
+    }
+
+    #[test]
+    fn reading_an_exemplar_does_not_block_inner_metric_updates() {
+        use std::sync::Arc as StdArc;
+        let counter = StdArc::new(WithExemplar::<Counter, TraceLabels>::default());
+        let exemplar = counter.exemplar();
+
+        let writer = StdArc::clone(&counter);
+        let handle = std::thread::spawn(move || {
+            writer.inc();
+            writer.get()
+        });
+        let _second = counter.inner();
+        assert!(exemplar.is_none());
+        assert_eq!(handle.join().unwrap(), 1);
+    }
+
+    #[test]
+    fn counter_replaces_exemplars_and_clones_share_storage() {
+        let counter = WithExemplar::<Counter, TraceLabels>::default();
         let clone = counter.clone();
 
         assert_eq!(
-            counter.inc_by(2, Some(TraceLabels { trace_id: "first" })),
+            counter.with_exemplar(TraceLabels { trace_id: "first" }, 2),
             0
         );
-        assert_eq!(clone.inc_by(3, Some(TraceLabels { trace_id: "latest" })), 2);
+        assert_eq!(
+            clone.with_exemplar(TraceLabels { trace_id: "latest" }, 3),
+            2
+        );
 
         let families = counter.encode_metric_value();
         let encoded = families[0].metric[0].counter.as_ref().unwrap();
@@ -397,17 +341,23 @@ mod tests {
         assert_eq!(trace_id(exemplar), Some("latest"));
         assert!(exemplar.timestamp.is_none());
 
-        let (value, exemplar) = counter.get();
-        assert_eq!(value, 5);
-        assert!(exemplar.is_some());
-        drop(exemplar);
+        // No guard is handed out, so reads and updates freely interleave. Under
+        // the previous `get() -> (N, MappedRwLockReadGuard<'_, _>)` API these
+        // three lines deadlocked.
+        assert_eq!(counter.get(), 5);
+        assert!(counter.exemplar().is_some());
         assert_eq!(
             counter.inner().load(std::sync::atomic::Ordering::Relaxed),
             5
         );
 
-        assert_eq!(counter.inc_by(1, None), 5);
-        assert_eq!(counter.get().0, 6);
+        // Unlabeled increments go straight to the inner counter and leave the
+        // exemplar in place.
+        assert_eq!(counter.inc(), 5);
+        assert_eq!(counter.get(), 6);
+        assert!(counter.exemplar().is_some());
+
+        counter.clear_exemplars();
         assert!(
             counter.encode_metric_value()[0].metric[0]
                 .counter
@@ -419,21 +369,92 @@ mod tests {
     }
 
     #[test]
-    fn classic_histogram_retains_latest_exemplar_per_bucket() {
-        let histogram = HistogramWithExemplars::new([1.0, 2.0]);
-        histogram.observe(0.5, Some(TraceLabels { trace_id: "first" }));
-        histogram.observe(
-            0.75,
-            Some(TraceLabels {
-                trace_id: "replacement",
-            }),
+    fn counter_exemplars_preserve_their_value_type() {
+        let unsigned = WithExemplar::<Counter, TraceLabels>::default();
+        unsigned.with_exemplar(
+            TraceLabels {
+                trace_id: "unsigned",
+            },
+            u64::MAX,
         );
-        histogram.observe(0.8, None);
-        histogram.observe(
-            1.5,
-            Some(TraceLabels {
+        assert_eq!(unsigned.exemplar().unwrap().value(), &u64::MAX);
+
+        let float = WithExemplar::<Counter<f64>, TraceLabels>::default();
+        float.with_exemplar(TraceLabels { trace_id: "float" }, 1.5);
+        assert_eq!(float.exemplar().unwrap().value(), &1.5);
+    }
+
+    #[test]
+    fn collection_keeps_labeled_counter_updates_atomic() {
+        use std::sync::mpsc::{self, RecvTimeoutError};
+        use std::time::Duration;
+
+        let counter = Arc::new(WithExemplar::<
+            Counter<u64, BlockingCounterAtomic>,
+            TraceLabels,
+        >::default());
+        counter.with_exemplar(TraceLabels { trace_id: "old" }, 1);
+        counter
+            .inner()
+            .block_get
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let collector = Arc::clone(&counter);
+        let collector = std::thread::spawn(move || collector.encode_metric_value());
+
+        let (entered, entered_condvar) = &counter.inner().entered_get;
+        let mut entered = entered.lock().unwrap();
+        while !*entered {
+            entered = entered_condvar.wait(entered).unwrap();
+        }
+        drop(entered);
+
+        let updater = Arc::clone(&counter);
+        let (updated_tx, updated_rx) = mpsc::channel();
+        let updater = std::thread::spawn(move || {
+            let previous = updater.with_exemplar(TraceLabels { trace_id: "new" }, 1);
+            updated_tx.send(previous).unwrap();
+        });
+
+        let early_update = updated_rx.recv_timeout(Duration::from_millis(50));
+        let update_blocked = matches!(&early_update, Err(RecvTimeoutError::Timeout));
+
+        let (release, release_condvar) = &counter.inner().release_get;
+        *release.lock().unwrap() = true;
+        release_condvar.notify_one();
+
+        let previous = match early_update {
+            Ok(previous) => previous,
+            Err(RecvTimeoutError::Timeout) => updated_rx.recv().unwrap(),
+            Err(RecvTimeoutError::Disconnected) => panic!("updater disconnected"),
+        };
+        updater.join().unwrap();
+        let families = collector.join().unwrap();
+
+        assert!(update_blocked);
+        assert_eq!(previous, 1);
+        let encoded = families[0].metric[0].counter.as_ref().unwrap();
+        assert_eq!(encoded.value, Some(1.0));
+        assert_eq!(trace_id(encoded.exemplar.as_ref().unwrap()), Some("old"));
+        assert_eq!(counter.get(), 2);
+    }
+
+    #[test]
+    fn classic_histogram_retains_latest_exemplar_per_bucket() {
+        let histogram = WithExemplar::new(Histogram::new([1.0, 2.0]));
+        histogram.with_exemplar(TraceLabels { trace_id: "first" }, 0.5);
+        histogram.with_exemplar(
+            TraceLabels {
+                trace_id: "replacement",
+            },
+            0.75,
+        );
+        histogram.observe(0.8);
+        histogram.with_exemplar(
+            TraceLabels {
                 trace_id: "second_bucket",
-            }),
+            },
+            1.5,
         );
 
         let families = histogram.encode_metric_value();
@@ -465,11 +486,11 @@ mod tests {
 
     #[test]
     fn native_histogram_retains_latest_timestamped_exemplar() {
-        let histogram = NativeHistogramWithExemplars::new(1.1);
+        let histogram = WithExemplar::new(NativeHistogram::new(1.1));
         let clone = histogram.clone();
-        histogram.observe(0.5, Some(TraceLabels { trace_id: "first" }));
-        clone.observe(2.0, None);
-        clone.observe(3.0, Some(TraceLabels { trace_id: "latest" }));
+        histogram.with_exemplar(TraceLabels { trace_id: "first" }, 0.5);
+        clone.observe(2.0);
+        clone.with_exemplar(TraceLabels { trace_id: "latest" }, 3.0);
 
         let families = histogram.encode_metric_value();
         let encoded = families[0].metric[0].histogram.as_ref().unwrap();
@@ -484,8 +505,8 @@ mod tests {
 
     #[test]
     fn exemplar_label_failure_drops_only_the_exemplar() {
-        let counter = CounterWithExemplar::<&'static str>::default();
-        counter.inc_by(2, Some("not a label set"));
+        let counter = WithExemplar::<Counter, &'static str>::default();
+        counter.with_exemplar("not a label set", 2);
 
         let families = NamedMetric::new("serialization_failure", "", counter).encode();
         let sentinel = &families[0].metric[0]
@@ -514,8 +535,8 @@ mod tests {
 
     #[test]
     fn empty_exemplar_label_sets_are_retained_in_text() {
-        let counter = CounterWithExemplar::<()>::default();
-        counter.inc_by(2, Some(()));
+        let counter = WithExemplar::<Counter, ()>::default();
+        counter.with_exemplar((), 2);
 
         let families = NamedMetric::new("empty_exemplar", "", counter).encode();
         assert!(encode_to_text(&families).contains("empty_exemplar 2.0 # {} 2.0\n"));
@@ -523,8 +544,8 @@ mod tests {
 
     #[test]
     fn accepts_legacy_sequence_label_sets() {
-        let counter = CounterWithExemplar::<Vec<(&'static str, &'static str)>>::default();
-        counter.inc_by(1, Some(vec![("trace_id", "legacy")]));
+        let counter = WithExemplar::<Counter, Vec<(&'static str, &'static str)>>::default();
+        counter.with_exemplar(vec![("trace_id", "legacy")], 1);
 
         let families = counter.encode_metric_value();
         let exemplar = families[0].metric[0]
@@ -541,15 +562,15 @@ mod tests {
     fn updates_do_not_require_serializable_label_sets() {
         struct OpaqueLabels;
 
-        let counter = CounterWithExemplar::<OpaqueLabels>::default();
-        counter.inc_by(1, Some(OpaqueLabels));
-        assert_eq!(counter.get().0, 1);
+        let counter = WithExemplar::<Counter, OpaqueLabels>::default();
+        counter.with_exemplar(OpaqueLabels, 1);
+        assert_eq!(counter.get(), 1);
 
-        let classic = HistogramWithExemplars::new([1.0]);
-        classic.observe(0.5, Some(OpaqueLabels));
+        let classic = WithExemplar::<Histogram, OpaqueLabels>::new(Histogram::new([1.0]));
+        classic.with_exemplar(OpaqueLabels, 0.5);
 
-        let native = NativeHistogramWithExemplars::new(1.1);
-        native.observe(0.5, Some(OpaqueLabels));
+        let native = WithExemplar::<NativeHistogram, OpaqueLabels>::new(NativeHistogram::new(1.1));
+        native.with_exemplar(OpaqueLabels, 0.5);
     }
 
     #[test]
@@ -559,10 +580,10 @@ mod tests {
             method: &'static str,
         }
 
-        let family = Family::<SeriesLabels, CounterWithExemplar<TraceLabels>>::default();
+        let family = Family::<SeriesLabels, WithExemplar<Counter, TraceLabels>>::default();
         family
             .get_or_create(&SeriesLabels { method: "GET" })
-            .inc_by(1, Some(TraceLabels { trace_id: "abc" }));
+            .with_exemplar(TraceLabels { trace_id: "abc" }, 1);
 
         let families = family.encode_metric_value();
         let metric = &families[0].metric[0];
@@ -577,15 +598,15 @@ mod tests {
 
     #[test]
     fn histogram_builders_construct_exemplar_metrics() {
-        let classic: HistogramWithExemplars<TraceLabels> = HistogramBuilder {
+        let classic: WithExemplar<Histogram, TraceLabels> = HistogramBuilder {
             buckets: &[0.5, 1.0],
         }
         .new_metric();
-        classic.observe(
-            0.75,
-            Some(TraceLabels {
+        classic.with_exemplar(
+            TraceLabels {
                 trace_id: "classic",
-            }),
+            },
+            0.75,
         );
         assert!(
             classic.encode_metric_value()[0].metric[0]
@@ -597,10 +618,10 @@ mod tests {
                 .is_some()
         );
 
-        let native: NativeHistogramWithExemplars<TraceLabels> = NativeHistogramBuilder::new(1.1)
+        let native: WithExemplar<NativeHistogram, TraceLabels> = NativeHistogramBuilder::new(1.1)
             .with_max_buckets(160)
             .new_metric();
-        native.observe(0.75, Some(TraceLabels { trace_id: "native" }));
+        native.with_exemplar(TraceLabels { trace_id: "native" }, 0.75);
         assert_eq!(
             native.encode_metric_value()[0].metric[0]
                 .histogram
@@ -614,12 +635,12 @@ mod tests {
 
     #[test]
     fn registered_exemplar_counter_is_collected_and_encoded() {
-        let counter = CounterWithExemplar::<TraceLabels>::default();
-        counter.inc_by(
-            4,
-            Some(TraceLabels {
+        let counter = WithExemplar::<Counter, TraceLabels>::default();
+        counter.with_exemplar(
+            TraceLabels {
                 trace_id: "registered",
-            }),
+            },
+            4,
         );
         register(
             Box::new(NamedMetric::new(
@@ -668,12 +689,12 @@ mod tests {
 
         let family = Family::<
             SeriesLabels,
-            NativeHistogramWithExemplars<TraceLabels>,
+            WithExemplar<NativeHistogram, TraceLabels>,
             NativeHistogramBuilder,
         >::new_with_constructor(NativeHistogramBuilder::new(1.1));
         family
             .get_or_create(&SeriesLabels { method: "GET" })
-            .observe(0.25, Some(TraceLabels { trace_id: "native" }));
+            .with_exemplar(TraceLabels { trace_id: "native" }, 0.25);
         register(
             Box::new(NamedMetric::new(
                 "registered_native_histogram_with_exemplars",

--- a/foundations-metrics/src/metrics/exemplar.rs
+++ b/foundations-metrics/src/metrics/exemplar.rs
@@ -268,37 +268,6 @@ impl<S> MetricConstructor<HistogramWithExemplars<S>> for HistogramBuilder {
     }
 }
 
-/// Constructs native histograms with exemplar support.
-///
-/// This mirrors [`NativeHistogramBuilder`] without adding another constructor
-/// implementation to that type, which keeps existing constructor inference
-/// unambiguous.
-#[derive(Clone, Copy, Debug)]
-pub struct NativeHistogramWithExemplarsBuilder {
-    inner: NativeHistogramBuilder,
-}
-
-impl NativeHistogramWithExemplarsBuilder {
-    /// Creates a builder with the given bucket growth `factor`.
-    pub fn new(factor: f64) -> Self {
-        Self {
-            inner: NativeHistogramBuilder::new(factor),
-        }
-    }
-
-    /// Sets the zero-bucket threshold.
-    pub fn with_zero_threshold(mut self, zero_threshold: f64) -> Self {
-        self.inner = self.inner.with_zero_threshold(zero_threshold);
-        self
-    }
-
-    /// Sets a best-effort maximum number of populated buckets.
-    pub fn with_max_buckets(mut self, max_buckets: usize) -> Self {
-        self.inner = self.inner.with_max_buckets(max_buckets);
-        self
-    }
-}
-
 /// A native histogram that retains its latest labeled observation as an exemplar.
 ///
 /// Native histogram exemplars require timestamps in the Prometheus protobuf
@@ -323,7 +292,7 @@ impl<S> NativeHistogramWithExemplars<S> {
     ///
     /// Panics if `factor` is not greater than `1.0`.
     pub fn new(factor: f64) -> Self {
-        NativeHistogramWithExemplarsBuilder::new(factor).new_metric()
+        NativeHistogramBuilder::new(factor).new_metric()
     }
 
     /// Records an observation and optionally retains it as the latest exemplar.
@@ -373,14 +342,11 @@ where
     }
 }
 
-impl<S> MetricConstructor<NativeHistogramWithExemplars<S>> for NativeHistogramWithExemplarsBuilder {
+impl<S> MetricConstructor<NativeHistogramWithExemplars<S>> for NativeHistogramBuilder {
     fn new_metric(&self) -> NativeHistogramWithExemplars<S> {
         NativeHistogramWithExemplars {
             state: Arc::new(RwLock::new(NativeHistogramWithExemplarsState {
-                histogram:
-                    <NativeHistogramBuilder as MetricConstructor<NativeHistogram>>::new_metric(
-                        &self.inner,
-                    ),
+                histogram: NativeHistogramBuilder::new_metric(self),
                 exemplar: None,
             })),
         }
@@ -631,10 +597,9 @@ mod tests {
                 .is_some()
         );
 
-        let native: NativeHistogramWithExemplars<TraceLabels> =
-            NativeHistogramWithExemplarsBuilder::new(1.1)
-                .with_max_buckets(160)
-                .new_metric();
+        let native: NativeHistogramWithExemplars<TraceLabels> = NativeHistogramBuilder::new(1.1)
+            .with_max_buckets(160)
+            .new_metric();
         native.observe(0.75, Some(TraceLabels { trace_id: "native" }));
         assert_eq!(
             native.encode_metric_value()[0].metric[0]
@@ -689,9 +654,9 @@ mod tests {
         );
 
         let text = encode_to_text(std::slice::from_ref(family));
-        assert!(text.contains(
-            "registered_counter_with_exemplar 4.0 # {\"trace_id\"=\"registered\"} 4.0\n"
-        ));
+        assert!(
+            text.contains("registered_counter_with_exemplar 4.0 # {trace_id=\"registered\"} 4.0\n")
+        );
     }
 
     #[test]
@@ -704,8 +669,8 @@ mod tests {
         let family = Family::<
             SeriesLabels,
             NativeHistogramWithExemplars<TraceLabels>,
-            NativeHistogramWithExemplarsBuilder,
-        >::new_with_constructor(NativeHistogramWithExemplarsBuilder::new(1.1));
+            NativeHistogramBuilder,
+        >::new_with_constructor(NativeHistogramBuilder::new(1.1));
         family
             .get_or_create(&SeriesLabels { method: "GET" })
             .observe(0.25, Some(TraceLabels { trace_id: "native" }));

--- a/foundations-metrics/src/metrics/histogram.rs
+++ b/foundations-metrics/src/metrics/histogram.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::iter::once;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -5,10 +6,12 @@ use std::time::{Duration, Instant};
 
 use foundations_metrics_registry::proto::{self, Bucket, MetricType};
 use parking_lot::Mutex;
+use serde::Serialize;
 
 use crate::{MetricFamily, value::EncodeMetricValue};
 
 use super::MetricConstructor;
+use super::exemplar::{Exemplar, ExemplarStorage, WithExemplar, finish_exemplar};
 
 /// A classic fixed-bucket histogram.
 ///
@@ -140,6 +143,65 @@ pub(super) fn encode_snapshot(snapshot: HistogramSnapshot) -> Vec<MetricFamily> 
     }]
 }
 
+impl<S> WithExemplar<Histogram, S> {
+    /// Records `value` and stores the exemplar in the matching bucket.
+    pub fn with_exemplar(&self, label_set: S, value: f64) {
+        let exemplar = Exemplar::new(label_set, value, None);
+        let mut exemplars = self.exemplars.lock();
+        if let Some(bucket) = self.inner.observe_and_bucket(value) {
+            match &mut *exemplars {
+                ExemplarStorage::Empty => {
+                    let mut per_bucket = HashMap::new();
+                    per_bucket.insert(bucket, exemplar);
+                    *exemplars = ExemplarStorage::PerBucket(per_bucket);
+                }
+                ExemplarStorage::PerBucket(exemplars) => {
+                    exemplars.insert(bucket, exemplar);
+                }
+                ExemplarStorage::Single(_) => {
+                    unreachable!("classic histogram uses per-bucket exemplar storage")
+                }
+            }
+        }
+    }
+}
+
+impl<S> EncodeMetricValue for WithExemplar<Histogram, S>
+where
+    S: Serialize + Send + Sync + 'static,
+{
+    fn encode_metric_value(&self) -> Vec<MetricFamily> {
+        let stored_exemplars = self.exemplars.lock();
+        let exemplars: Vec<_> = match &*stored_exemplars {
+            ExemplarStorage::Empty => Vec::new(),
+            ExemplarStorage::PerBucket(exemplars) => exemplars
+                .iter()
+                .map(|(&index, exemplar)| (index, exemplar.clone()))
+                .collect(),
+            ExemplarStorage::Single(_) => {
+                unreachable!("classic histogram uses per-bucket exemplar storage")
+            }
+        };
+        let snapshot = self.inner.snapshot();
+        drop(stored_exemplars);
+
+        let mut families = encode_snapshot(snapshot);
+        let buckets = &mut families[0].metric[0]
+            .histogram
+            .as_mut()
+            .expect("histogram encoder always creates a histogram value")
+            .bucket;
+
+        for (index, exemplar) in exemplars {
+            if let Some(bucket) = buckets.get_mut(index) {
+                bucket.exemplar = finish_exemplar(Some(exemplar.encode()));
+            }
+        }
+
+        families
+    }
+}
+
 /// Constructs classic and time histograms with a fixed set of buckets.
 #[derive(Clone, Debug)]
 pub struct HistogramBuilder {
@@ -150,6 +212,12 @@ pub struct HistogramBuilder {
 impl MetricConstructor<Histogram> for HistogramBuilder {
     fn new_metric(&self) -> Histogram {
         Histogram::new(self.buckets.iter().copied())
+    }
+}
+
+impl<S> MetricConstructor<WithExemplar<Histogram, S>> for HistogramBuilder {
+    fn new_metric(&self) -> WithExemplar<Histogram, S> {
+        WithExemplar::new(MetricConstructor::<Histogram>::new_metric(self))
     }
 }
 

--- a/foundations-metrics/src/metrics/histogram.rs
+++ b/foundations-metrics/src/metrics/histogram.rs
@@ -145,7 +145,7 @@ pub(super) fn encode_snapshot(snapshot: HistogramSnapshot) -> Vec<MetricFamily> 
 
 impl<S> WithExemplar<Histogram, S> {
     /// Records `value` and stores the exemplar in the matching bucket.
-    pub fn with_exemplar(&self, label_set: S, value: f64) {
+    pub fn observe_with_exemplar(&self, label_set: S, value: f64) {
         let exemplar = Exemplar::new(label_set, value, None);
         let mut exemplars = self.exemplars.lock();
         if let Some(bucket) = self.inner.observe_and_bucket(value) {

--- a/foundations-metrics/src/metrics/histogram.rs
+++ b/foundations-metrics/src/metrics/histogram.rs
@@ -66,21 +66,27 @@ impl Histogram {
 
     /// Records an observed value.
     pub fn observe(&self, value: f64) {
+        self.observe_and_bucket(value);
+    }
+
+    pub(super) fn observe_and_bucket(&self, value: f64) -> Option<usize> {
         let mut state = self.state.lock();
         state.sum += value;
         state.count = state.count.wrapping_add(1);
 
-        let bucket = if value.is_nan() {
-            None
-        } else {
-            let index = state
-                .buckets
-                .partition_point(|(upper_bound, _)| *upper_bound < value);
-            state.buckets.get_mut(index)
-        };
+        if value.is_nan() {
+            return None;
+        }
 
-        if let Some((_, count)) = bucket {
+        let index = state
+            .buckets
+            .partition_point(|(upper_bound, _)| *upper_bound < value);
+
+        if let Some((_, count)) = state.buckets.get_mut(index) {
             *count = count.wrapping_add(1);
+            Some(index)
+        } else {
+            None
         }
     }
 
@@ -102,7 +108,7 @@ impl EncodeMetricValue for Histogram {
     }
 }
 
-fn encode_snapshot(snapshot: HistogramSnapshot) -> Vec<MetricFamily> {
+pub(super) fn encode_snapshot(snapshot: HistogramSnapshot) -> Vec<MetricFamily> {
     let mut cumulative_count = 0_u64;
     let buckets = snapshot
         .buckets

--- a/foundations-metrics/src/metrics/mod.rs
+++ b/foundations-metrics/src/metrics/mod.rs
@@ -35,12 +35,17 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 mod counter;
+mod exemplar;
 mod family;
 mod gauge;
 mod histogram;
 mod native_histogram;
 
 pub use counter::{Counter, CounterAtomic};
+pub use exemplar::{
+    CounterWithExemplar, Exemplar, HistogramWithExemplars, NativeHistogramWithExemplars,
+    NativeHistogramWithExemplarsBuilder,
+};
 pub use family::{Family, FamilyMetricGuard, MetricConstructor};
 pub use gauge::{Gauge, GaugeAtomic, GaugeGuard, RangeGauge};
 pub use histogram::{

--- a/foundations-metrics/src/metrics/mod.rs
+++ b/foundations-metrics/src/metrics/mod.rs
@@ -44,7 +44,6 @@ mod native_histogram;
 pub use counter::{Counter, CounterAtomic};
 pub use exemplar::{
     CounterWithExemplar, Exemplar, HistogramWithExemplars, NativeHistogramWithExemplars,
-    NativeHistogramWithExemplarsBuilder,
 };
 pub use family::{Family, FamilyMetricGuard, MetricConstructor};
 pub use gauge::{Gauge, GaugeAtomic, GaugeGuard, RangeGauge};

--- a/foundations-metrics/src/metrics/mod.rs
+++ b/foundations-metrics/src/metrics/mod.rs
@@ -42,9 +42,7 @@ mod histogram;
 mod native_histogram;
 
 pub use counter::{Counter, CounterAtomic};
-pub use exemplar::{
-    CounterWithExemplar, Exemplar, HistogramWithExemplars, NativeHistogramWithExemplars,
-};
+pub use exemplar::{Exemplar, WithExemplar};
 pub use family::{Family, FamilyMetricGuard, MetricConstructor};
 pub use gauge::{Gauge, GaugeAtomic, GaugeGuard, RangeGauge};
 pub use histogram::{

--- a/foundations-metrics/src/metrics/mod.rs
+++ b/foundations-metrics/src/metrics/mod.rs
@@ -42,7 +42,7 @@ mod histogram;
 mod native_histogram;
 
 pub use counter::{Counter, CounterAtomic};
-pub use exemplar::{Exemplar, WithExemplar};
+pub use exemplar::WithExemplar;
 pub use family::{Family, FamilyMetricGuard, MetricConstructor};
 pub use gauge::{Gauge, GaugeAtomic, GaugeGuard, RangeGauge};
 pub use histogram::{

--- a/foundations-metrics/src/metrics/native_histogram.rs
+++ b/foundations-metrics/src/metrics/native_histogram.rs
@@ -56,6 +56,16 @@ impl NativeHistogram {
     pub fn observe(&self, value: f64) {
         self.inner.observe(value);
     }
+
+    pub(super) fn try_encode_metric_value(&self) -> Result<Vec<MetricFamily>, std::fmt::Error> {
+        // Upstream keeps native bucket state private. A cloned histogram shares
+        // storage, so a temporary registry can drive its protobuf encoder.
+        let mut registry = Registry::default();
+        registry.register("native_histogram", "", self.inner.clone());
+
+        prometheus_protobuf::encode(&registry)
+            .map(|families| families.into_iter().map(convert_native_family).collect())
+    }
 }
 
 /// Constructs [`NativeHistogram`]s with a fixed configuration.
@@ -164,13 +174,8 @@ impl MetricConstructor<NativeHistogram> for NativeHistogramBuilder {
 
 impl EncodeMetricValue for NativeHistogram {
     fn encode_metric_value(&self) -> Vec<MetricFamily> {
-        // Upstream keeps native bucket state private. A cloned histogram shares
-        // storage, so a temporary registry can drive its protobuf encoder.
-        let mut registry = Registry::default();
-        registry.register("native_histogram", "", self.inner.clone());
-
-        match prometheus_protobuf::encode(&registry) {
-            Ok(families) => families.into_iter().map(convert_native_family).collect(),
+        match self.try_encode_metric_value() {
+            Ok(families) => families,
             Err(error) => {
                 report_collect_error(format_args!(
                     "non-fatal error while collecting metrics: skipped a native histogram; protobuf encoding failed: {error}"
@@ -325,7 +330,7 @@ mod tests {
 
     #[test]
     fn builder_applies_configuration() {
-        let histogram = NativeHistogramBuilder::new(1.5)
+        let histogram: NativeHistogram = NativeHistogramBuilder::new(1.5)
             .with_zero_threshold(0.001)
             .with_max_buckets(160)
             .new_metric();

--- a/foundations-metrics/src/metrics/native_histogram.rs
+++ b/foundations-metrics/src/metrics/native_histogram.rs
@@ -58,7 +58,7 @@ impl NativeHistogram {
     }
 
     pub(super) fn try_encode_metric_value(&self) -> Result<Vec<MetricFamily>, std::fmt::Error> {
-        // Upstream keeps native bucket state private. A cloned histogram shares
+        // prometheus_client keeps native bucket state private. A cloned histogram shares
         // storage, so a temporary registry can drive its protobuf encoder.
         let mut registry = Registry::default();
         registry.register("native_histogram", "", self.inner.clone());

--- a/foundations-metrics/src/metrics/native_histogram.rs
+++ b/foundations-metrics/src/metrics/native_histogram.rs
@@ -74,7 +74,7 @@ impl NativeHistogram {
 
 impl<S> WithExemplar<NativeHistogram, S> {
     /// Records `value` and retains it as the latest exemplar.
-    pub fn with_exemplar(&self, label_set: S, value: f64) {
+    pub fn observe_with_exemplar(&self, label_set: S, value: f64) {
         let mut exemplar = Exemplar::new(label_set, value, None);
         let mut exemplars = self.exemplars.lock();
         self.inner.observe(value);

--- a/foundations-metrics/src/metrics/native_histogram.rs
+++ b/foundations-metrics/src/metrics/native_histogram.rs
@@ -1,3 +1,5 @@
+use std::time::SystemTime;
+
 use foundations_metrics_registry::proto::{self, Bucket, BucketSpan, LabelPair, MetricType};
 use prometheus_client::encoding::prometheus_protobuf::{
     self, prometheus_data_model as prometheus_proto,
@@ -6,11 +8,13 @@ use prometheus_client::metrics::histogram::{
     Histogram as PrometheusHistogram, NativeHistogramConfig,
 };
 use prometheus_client::registry::Registry;
+use serde::Serialize;
 
 use crate::diagnostics::report_collect_error;
 use crate::{MetricFamily, value::EncodeMetricValue};
 
 use super::MetricConstructor;
+use super::exemplar::{Exemplar, ExemplarStorage, StoredExemplar, WithExemplar, finish_exemplar};
 
 /// A native (exponential-bucket) histogram.
 ///
@@ -65,6 +69,27 @@ impl NativeHistogram {
 
         prometheus_protobuf::encode(&registry)
             .map(|families| families.into_iter().map(convert_native_family).collect())
+    }
+}
+
+impl<S> WithExemplar<NativeHistogram, S> {
+    /// Records `value` and retains it as the latest exemplar.
+    pub fn with_exemplar(&self, label_set: S, value: f64) {
+        let mut exemplar = Exemplar::new(label_set, value, None);
+        let mut exemplars = self.exemplars.lock();
+        self.inner.observe(value);
+        exemplar.timestamp = Some(SystemTime::now().into());
+        let exemplar = StoredExemplar::F64(exemplar);
+
+        match &mut *exemplars {
+            ExemplarStorage::Empty => {
+                *exemplars = ExemplarStorage::Single(Some(exemplar));
+            }
+            ExemplarStorage::Single(stored) => *stored = Some(exemplar),
+            ExemplarStorage::PerBucket(_) => {
+                unreachable!("native histogram uses single exemplar storage")
+            }
+        }
     }
 }
 
@@ -172,6 +197,12 @@ impl MetricConstructor<NativeHistogram> for NativeHistogramBuilder {
     }
 }
 
+impl<S> MetricConstructor<WithExemplar<NativeHistogram, S>> for NativeHistogramBuilder {
+    fn new_metric(&self) -> WithExemplar<NativeHistogram, S> {
+        WithExemplar::new(NativeHistogramBuilder::new_metric(self))
+    }
+}
+
 impl EncodeMetricValue for NativeHistogram {
     fn encode_metric_value(&self) -> Vec<MetricFamily> {
         match self.try_encode_metric_value() {
@@ -183,6 +214,46 @@ impl EncodeMetricValue for NativeHistogram {
                 Vec::new()
             }
         }
+    }
+}
+
+impl<S> EncodeMetricValue for WithExemplar<NativeHistogram, S>
+where
+    S: Serialize + Send + Sync + 'static,
+{
+    fn encode_metric_value(&self) -> Vec<MetricFamily> {
+        let exemplars = self.exemplars.lock();
+        let exemplar = match &*exemplars {
+            ExemplarStorage::Empty => None,
+            ExemplarStorage::Single(exemplar) => exemplar.clone(),
+            ExemplarStorage::PerBucket(_) => {
+                unreachable!("native histogram uses single exemplar storage")
+            }
+        };
+        let families = self.inner.try_encode_metric_value();
+        drop(exemplars);
+
+        let mut families = match families {
+            Ok(families) => families,
+            Err(error) => {
+                report_collect_error(format_args!(
+                    "non-fatal error while collecting metrics: skipped a native histogram; protobuf encoding failed: {error}"
+                ));
+                return Vec::new();
+            }
+        };
+
+        if let Some(exemplar) = finish_exemplar(exemplar.as_ref().map(StoredExemplar::encode)) {
+            for histogram in families
+                .iter_mut()
+                .flat_map(|family| &mut family.metric)
+                .filter_map(|metric| metric.histogram.as_mut())
+            {
+                histogram.exemplars.push(exemplar.clone());
+            }
+        }
+
+        families
     }
 }
 

--- a/foundations-metrics/src/validation.rs
+++ b/foundations-metrics/src/validation.rs
@@ -5,6 +5,8 @@ use foundations_metrics_registry::proto::{Exemplar, LabelPair, Metric, MetricFam
 use crate::diagnostics::report_collect_error;
 
 pub(crate) const NAME_REQUIREMENT: &str = "a non-empty UTF-8 string without NUL bytes";
+pub(crate) const EXEMPLAR_SERIALIZATION_ERROR_LABEL: &str =
+    "\0foundations_metrics_exemplar_serialization_error";
 
 #[derive(Clone, Copy)]
 pub(crate) enum ValidationContext {
@@ -115,6 +117,11 @@ enum LabelIssue<'a> {
     Reserved(&'a str),
 }
 
+enum ExemplarIssue<'a> {
+    Label(LabelIssue<'a>),
+    Serialization(&'a str),
+}
+
 fn find_label_issue<'a>(
     labels: &'a [LabelPair],
     reserved_label: Option<&str>,
@@ -166,12 +173,16 @@ fn exemplars_are_valid(metric: &Metric) -> bool {
                 .bucket
                 .iter()
                 .all(|bucket| bucket.exemplar.as_ref().is_none_or(exemplar_is_valid))
-                && histogram.exemplars.iter().all(exemplar_is_valid)
+                && histogram.exemplars.iter().all(native_exemplar_is_valid)
         })
 }
 
 fn exemplar_is_valid(exemplar: &Exemplar) -> bool {
-    find_label_issue(&exemplar.label, None).is_none()
+    find_exemplar_issue(&exemplar.label).is_none()
+}
+
+fn native_exemplar_is_valid(exemplar: &Exemplar) -> bool {
+    exemplar.timestamp.is_some() && exemplar_is_valid(exemplar)
 }
 
 fn sanitize_exemplars(metric: &mut Metric, family_name: &str, context: ValidationContext) {
@@ -189,8 +200,14 @@ fn sanitize_exemplars(metric: &mut Metric, family_name: &str, context: Validatio
             );
         }
         histogram.exemplars.retain(|exemplar| {
-            if let Some(issue) = find_label_issue(&exemplar.label, None) {
+            if let Some(issue) = find_exemplar_issue(&exemplar.label) {
                 report_exemplar_drop(context, family_name, "native histogram", issue);
+                false
+            } else if exemplar.timestamp.is_none() {
+                report_collect_error(format_args!(
+                    "non-fatal error while {}: dropped native histogram exemplar in metric family {family_name:?} without a required timestamp",
+                    context.action()
+                ));
                 false
             } else {
                 true
@@ -207,7 +224,7 @@ fn sanitize_exemplar_slot(
 ) {
     let Some(issue) = exemplar
         .as_ref()
-        .and_then(|exemplar| find_label_issue(&exemplar.label, None))
+        .and_then(|exemplar| find_exemplar_issue(&exemplar.label))
     else {
         return;
     };
@@ -220,19 +237,36 @@ fn report_exemplar_drop(
     context: ValidationContext,
     family_name: &str,
     kind: &str,
-    issue: LabelIssue<'_>,
+    issue: ExemplarIssue<'_>,
 ) {
     match issue {
-        LabelIssue::Invalid(name) => report_collect_error(format_args!(
+        ExemplarIssue::Label(LabelIssue::Invalid(name)) => report_collect_error(format_args!(
             "non-fatal error while {}: dropped {kind} exemplar in metric family {family_name:?} with invalid label name {name:?}; expected {NAME_REQUIREMENT}",
             context.action()
         )),
-        LabelIssue::Duplicate(name) => report_collect_error(format_args!(
+        ExemplarIssue::Label(LabelIssue::Duplicate(name)) => report_collect_error(format_args!(
             "non-fatal error while {}: dropped {kind} exemplar in metric family {family_name:?} with duplicate label name {name:?}",
             context.action()
         )),
-        LabelIssue::Reserved(_) => unreachable!("exemplar labels have no reserved names"),
+        ExemplarIssue::Serialization(error) => report_collect_error(format_args!(
+            "non-fatal error while {}: dropped {kind} exemplar in metric family {family_name:?}; label serialization failed: {error}",
+            context.action()
+        )),
+        ExemplarIssue::Label(LabelIssue::Reserved(_)) => {
+            unreachable!("exemplar labels have no reserved names")
+        }
     }
+}
+
+fn find_exemplar_issue(labels: &[LabelPair]) -> Option<ExemplarIssue<'_>> {
+    if labels.len() == 1
+        && labels[0].name.as_deref() == Some(EXEMPLAR_SERIALIZATION_ERROR_LABEL)
+        && let Some(error) = labels[0].value.as_deref()
+    {
+        return Some(ExemplarIssue::Serialization(error));
+    }
+
+    find_label_issue(labels, None).map(ExemplarIssue::Label)
 }
 
 #[cfg(test)]
@@ -259,5 +293,18 @@ mod tests {
         for name in ["", "nul\0name"] {
             assert!(!is_valid_name(name));
         }
+    }
+
+    #[test]
+    fn preserves_exemplar_serialization_errors_for_diagnostics() {
+        let labels = [LabelPair {
+            name: Some(EXEMPLAR_SERIALIZATION_ERROR_LABEL.to_owned()),
+            value: Some("root cause".to_owned()),
+        }];
+
+        assert!(matches!(
+            find_exemplar_issue(&labels),
+            Some(ExemplarIssue::Serialization("root cause"))
+        ));
     }
 }


### PR DESCRIPTION
## Overview
Adds first-party exemplar-aware metric types for counters, classic histograms, and native histograms while leaving existing metric types unchanged.

## Public API
- `CounterWithExemplar`
- `HistogramWithExemplars`
- `NativeHistogramWithExemplars`
- Read-only `Exemplar` accessors for labels and sampled values are exposed through `CounterWithExemplar::get`.

These types integrate with `Family`, registration, collection, and the existing protobuf and OpenMetrics encoders.
## Recording Semantics
- Counters retain the exemplar from the latest labeled increment. An unlabelled increment clears it.
- Classic histograms retain the latest labeled observation for each bucket. Unlabelled observations do not clear existing exemplars.
- Native histograms retain the latest labeled observation and capture its timestamp.
- Clones share metric and exemplar storage.
- Family series labels remain separate from exemplar labels.
Recording does not require exemplar labels to implement `Serialize`; serialisation occurs when the metric is encoded.
## Encoding
Counter and classic-histogram exemplars are emitted in both protobuf and OpenMetrics text.
Native-histogram exemplars:
- Include the timestamp required by the Prometheus protobuf model.
- Are preserved in protobuf output.
- Are not emitted in text because native histograms require protobuf exposition.

Empty counter and classic-histogram exemplar label sets remain valid and are emitted in text as {}.

## Labels And Validation
Exemplar labels use the existing label serialiser and support:
- Serialisable structs
- Unit label sets
- Legacy sequences of name-value pairs

Invalid, duplicate, or unserialisable exemplar labels drop only the exemplar. The metric sample remains available, and a non-fatal diagnostic is emitted.

Native-histogram exemplars without the required timestamp are removed with a non-fatal diagnostic; the native histogram itself is still emitted.