### PR TITLE
feat(foundations): use foundations-metrics as the macro backend + expose a foundations-metrics facade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ percent-encoding = "2.3.2"
 quote = "1.0.45"
 regex = "1.12.3"
 reqwest = { version = "0.13.2", default-features = false }
+ryu = "1.0.23"
 socket2 = { version = "0.6.3", features = ["all"] }
 syn = "2.0.117"
 serde = "1.0.228"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,8 @@ anyhow = "1.0.102"
 backtrace = "0.3.76"
 foundations = { version = "5.8.1", path = "./foundations", default-features = false }
 foundations-macros = { version = "=5.8.1", path = "./foundations-macros", default-features = false }
-foundations-metrics-registry = { version = "0.1.0", path = "./foundations-metrics-registry" }
+foundations-metrics-registry = { version = "0.1.0", path = "./foundations-metrics-registry", default-features = false }
+foundations-metrics = { version = "0.1.0", path = "./foundations-metrics", default-features = false }
 bindgen = { version = "0.72.1", default-features = false }
 cc = "1.2.61"
 cf-rustracing = "1.4.0"

--- a/examples/http_server/main.rs
+++ b/examples/http_server/main.rs
@@ -27,6 +27,7 @@ use hyper_util::rt::{TokioExecutor, TokioIo};
 use std::convert::Infallible;
 use std::net::{SocketAddr, TcpListener as StdTcpListener};
 use std::sync::Arc;
+use std::time::Instant;
 use tokio::net::{TcpListener, TcpStream};
 
 #[tokio::main]
@@ -218,6 +219,8 @@ async fn respond(
     req: Request<Incoming>,
     routes: Arc<Map<String, ResponseSettings>>,
 ) -> Result<Response<Full<Bytes>>, Infallible> {
+    let started = Instant::now();
+
     log::add_fields! {
         "request_uri" => req.uri().to_string(),
         "method" => req.method().to_string()
@@ -233,7 +236,7 @@ async fn respond(
         routes.get(req.uri().path())
     };
 
-    Ok(match route {
+    let response = match route {
         Some(route) => {
             log::info!("sending response to the client"; "status_code" => route.status_code);
 
@@ -247,7 +250,12 @@ async fn respond(
             metrics::http_server::requests_failed_total(&endpoint_name, 404).inc();
             Response::builder().status(404).body("".into()).unwrap()
         }
-    })
+    };
+
+    metrics::http_server::request_latency_seconds(&endpoint_name)
+        .observe(started.elapsed().as_secs_f64());
+
+    Ok(response)
 }
 
 #[cfg(target_os = "linux")]

--- a/examples/http_server/metrics.rs
+++ b/examples/http_server/metrics.rs
@@ -1,4 +1,6 @@
-use foundations::telemetry::metrics::{Counter, Gauge, metrics};
+use foundations::telemetry::metrics::{
+    Counter, Gauge, NativeHistogram, NativeHistogramBuilder, metrics,
+};
 use std::sync::Arc;
 
 #[metrics]
@@ -14,4 +16,12 @@ pub(crate) mod http_server {
 
     /// Number of failed requests.
     pub fn requests_failed_total(endpoint_name: &Arc<String>, status_code: u16) -> Counter;
+
+    /// Time spent handling a request, in seconds.
+    #[ctor = NativeHistogramBuilder {
+        bucket_factor: 1.1,
+        zero_threshold: 0.0,
+        max_buckets: 160,
+    }]
+    pub fn request_latency_seconds(endpoint_name: &Arc<String>) -> NativeHistogram;
 }

--- a/foundations-macros/src/metrics/mod.rs
+++ b/foundations-macros/src/metrics/mod.rs
@@ -158,28 +158,9 @@ fn expand_from_parsed(args: MacroArgs, extern_: Mod) -> proc_macro2::TokenStream
         .iter()
         .filter_map(|fn_| label_set_struct(foundations, fn_));
 
-    let registry_init = |var: &str, opt: bool| {
-        let var = Ident::new(var, Span::call_site());
-        let optional = format_ident!("{opt}");
-
-        quote! {
-            let #var = &mut *#foundations::telemetry::metrics::internal::Registries::get_subsystem(
-                stringify!(#mod_name), #optional, #with_service_prefix
-            );
-        }
-    };
-
-    let init_registry = fns
+    let metric_inits = fns
         .iter()
-        .any(|fn_| !fn_.attrs.optional)
-        .then(|| registry_init("registry", false));
-
-    let init_opt_registry = fns
-        .iter()
-        .any(|fn_| fn_.attrs.optional)
-        .then(|| registry_init("opt_registry", true));
-
-    let metric_inits = fns.iter().map(|fn_| metric_init(foundations, fn_));
+        .map(|fn_| metric_init(foundations, &mod_name, &with_service_prefix, fn_));
 
     let metric_fns = fns
         .iter()
@@ -199,9 +180,6 @@ fn expand_from_parsed(args: MacroArgs, extern_: Mod) -> proc_macro2::TokenStream
             #[allow(non_upper_case_globals)]
             static #metrics_struct: ::std::sync::LazyLock<#metrics_struct> =
                 ::std::sync::LazyLock::new(|| {
-                    #init_registry
-                    #init_opt_registry
-
                     #metrics_struct {
                         #(#metric_inits,)*
                     }
@@ -229,7 +207,7 @@ fn metric_field(foundations: &Path, fn_: &ItemFn) -> proc_macro2::TokenStream {
     }) = ctor
     {
         quote! {
-            #foundations::reexports_for_macros::prometools::serde::Family<
+            #foundations::telemetry::metrics::Family<
                 #metric_name,
                 #metric_ty,
                 #ctor_path,
@@ -237,7 +215,7 @@ fn metric_field(foundations: &Path, fn_: &ItemFn) -> proc_macro2::TokenStream {
         }
     } else {
         quote! {
-            #foundations::reexports_for_macros::prometools::serde::Family<
+            #foundations::telemetry::metrics::Family<
                 #metric_name,
                 #metric_ty,
             >
@@ -291,7 +269,12 @@ fn label_set_struct(foundations: &Path, fn_: &ItemFn) -> Option<proc_macro2::Tok
     })
 }
 
-fn metric_init(foundations: &Path, fn_: &ItemFn) -> proc_macro2::TokenStream {
+fn metric_init(
+    foundations: &Path,
+    mod_name: &Ident,
+    with_service_prefix: &Ident,
+    fn_: &ItemFn,
+) -> proc_macro2::TokenStream {
     let ItemFn {
         attrs:
             FnAttrs {
@@ -306,15 +289,7 @@ fn metric_init(foundations: &Path, fn_: &ItemFn) -> proc_macro2::TokenStream {
         ..
     } = fn_;
 
-    let reexports = quote! { #foundations::reexports_for_macros };
-    let registry = Ident::new(
-        if *optional {
-            "opt_registry"
-        } else {
-            "registry"
-        },
-        Span::call_site(),
-    );
+    let optional = format_ident!("{optional}");
 
     // Validate histogram buckets at compile time if this is a HistogramBuilder
     if let Some(ctor) = ctor
@@ -327,10 +302,10 @@ fn metric_init(foundations: &Path, fn_: &ItemFn) -> proc_macro2::TokenStream {
 
     let metric_init = match ctor {
         Some(ctor) if args.is_empty() => quote! {
-            #reexports::prometheus_client::metrics::family::MetricConstructor::new_metric(&(#ctor))
+            #foundations::telemetry::metrics::MetricConstructor::new_metric(&(#ctor))
         },
         Some(ctor) => quote! {
-            #reexports::prometools::serde::Family::new_with_constructor(#ctor)
+            #foundations::telemetry::metrics::Family::new_with_constructor(#ctor)
         },
         None => quote! { ::std::default::Default::default() },
     };
@@ -340,11 +315,18 @@ fn metric_init(foundations: &Path, fn_: &ItemFn) -> proc_macro2::TokenStream {
         #field_name: {
             let metric = #metric_init;
 
-            #reexports::prometheus_client::registry::Registry::register(
-                #registry,
+            #foundations::telemetry::metrics::internal::register_metric(
+                ::std::stringify!(#mod_name),
                 ::std::stringify!(#field_name),
+                ::std::concat!(
+                    ::std::stringify!(#mod_name),
+                    "_",
+                    ::std::stringify!(#field_name),
+                ),
                 str::trim(#doc),
-                #foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
+                ::std::clone::Clone::clone(&metric),
+                #optional,
+                #with_service_prefix,
             );
 
             metric
@@ -386,7 +368,7 @@ fn metric_fn(foundations: &Path, metrics_struct: &Ident, fn_: &ItemFn) -> proc_m
 
         let accessor = quote! {
             ::std::clone::Clone::clone(
-                &#foundations::reexports_for_macros::prometools::serde::Family::get_or_create(
+                &#foundations::telemetry::metrics::Family::get_or_create(
                     &#metrics_struct.#metric_name,
                     &__args,
                 )
@@ -413,7 +395,7 @@ fn metric_fn(foundations: &Path, metrics_struct: &Ident, fn_: &ItemFn) -> proc_m
             #(#cfg)*
             #fn_vis #fn_token #remove_ident(#(#fn_args,)*) #arrow_token bool {
                 #convert_args
-                #foundations::reexports_for_macros::prometools::serde::Family::remove(
+                #foundations::telemetry::metrics::Family::remove(
                     &#metrics_struct.#metric_name,
                     &__args,
                 )
@@ -422,7 +404,7 @@ fn metric_fn(foundations: &Path, metrics_struct: &Ident, fn_: &ItemFn) -> proc_m
             #[doc = #clear_doc]
             #(#cfg)*
             #fn_vis #fn_token #clear_ident() {
-                #foundations::reexports_for_macros::prometools::serde::Family::clear(
+                #foundations::telemetry::metrics::Family::clear(
                     &#metrics_struct.#metric_name,
                 )
             }
@@ -509,17 +491,22 @@ mod tests {
                 #[allow(non_upper_case_globals)]
                 static __oxy_Metrics: ::std::sync::LazyLock<__oxy_Metrics> =
                     ::std::sync::LazyLock::new(|| {
-                        let registry = &mut *tarmac::telemetry::metrics::internal::Registries::get_subsystem(stringify!(oxy), false, true);
-
                         __oxy_Metrics {
                             connections_total: {
                                 let metric = ::std::default::Default::default();
 
-                                tarmac::reexports_for_macros::prometheus_client::registry::Registry::register(
-                                    registry,
+                                tarmac::telemetry::metrics::internal::register_metric(
+                                    ::std::stringify!(oxy),
                                     ::std::stringify!(connections_total),
+                                    ::std::concat!(
+                                        ::std::stringify!(oxy),
+                                        "_",
+                                        ::std::stringify!(connections_total),
+                                    ),
                                     str::trim(" Total number of connections"),
-                                    tarmac::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
+                                    ::std::clone::Clone::clone(&metric),
+                                    false,
+                                    true,
                                 );
 
                                 metric
@@ -566,17 +553,22 @@ mod tests {
                 #[allow(non_upper_case_globals)]
                 static __oxy_Metrics: ::std::sync::LazyLock<__oxy_Metrics> =
                     ::std::sync::LazyLock::new(|| {
-                        let opt_registry = &mut *::foundations::telemetry::metrics::internal::Registries::get_subsystem(stringify!(oxy), true, true);
-
                         __oxy_Metrics {
                             connections_total: {
                                 let metric = ::std::default::Default::default();
 
-                                ::foundations::reexports_for_macros::prometheus_client::registry::Registry::register(
-                                    opt_registry,
+                                ::foundations::telemetry::metrics::internal::register_metric(
+                                    ::std::stringify!(oxy),
                                     ::std::stringify!(connections_total),
+                                    ::std::concat!(
+                                        ::std::stringify!(oxy),
+                                        "_",
+                                        ::std::stringify!(connections_total),
+                                    ),
                                     str::trim(" Total number of connections"),
-                                    ::foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
+                                    ::std::clone::Clone::clone(&metric),
+                                    true,
+                                    true,
                                 );
 
                                 metric
@@ -627,18 +619,22 @@ mod tests {
                 #[allow(non_upper_case_globals)]
                 static __oxy_Metrics: ::std::sync::LazyLock<__oxy_Metrics> =
                     ::std::sync::LazyLock::new(|| {
-                        let registry = &mut *::foundations::telemetry::metrics::internal::Registries::get_subsystem(stringify!(oxy), false, false);
-                        let opt_registry = &mut *::foundations::telemetry::metrics::internal::Registries::get_subsystem(stringify!(oxy), true, false);
-
                         __oxy_Metrics {
                             requests_total: {
                                 let metric = ::std::default::Default::default();
 
-                                ::foundations::reexports_for_macros::prometheus_client::registry::Registry::register(
-                                    registry,
+                                ::foundations::telemetry::metrics::internal::register_metric(
+                                    ::std::stringify!(oxy),
                                     ::std::stringify!(requests_total),
+                                    ::std::concat!(
+                                        ::std::stringify!(oxy),
+                                        "_",
+                                        ::std::stringify!(requests_total),
+                                    ),
                                     str::trim(" Total number of requests"),
-                                    ::foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
+                                    ::std::clone::Clone::clone(&metric),
+                                    false,
+                                    false,
                                 );
 
                                 metric
@@ -646,11 +642,18 @@ mod tests {
                             connections_total: {
                                 let metric = ::std::default::Default::default();
 
-                                ::foundations::reexports_for_macros::prometheus_client::registry::Registry::register(
-                                    opt_registry,
+                                ::foundations::telemetry::metrics::internal::register_metric(
+                                    ::std::stringify!(oxy),
                                     ::std::stringify!(connections_total),
+                                    ::std::concat!(
+                                        ::std::stringify!(oxy),
+                                        "_",
+                                        ::std::stringify!(connections_total),
+                                    ),
                                     str::trim(" Total number of connections"),
-                                    ::foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
+                                    ::std::clone::Clone::clone(&metric),
+                                    true,
+                                    false,
                                 );
 
                                 metric
@@ -704,7 +707,7 @@ mod tests {
                 #[allow(non_camel_case_types)]
                 struct __oxy_Metrics {
                     connections_errors_total:
-                        ::foundations::reexports_for_macros::prometools::serde::Family<
+                        ::foundations::telemetry::metrics::Family<
                             connections_errors_total,
                             Counter,
                         >,
@@ -732,17 +735,22 @@ mod tests {
                 #[allow(non_upper_case_globals)]
                 static __oxy_Metrics: ::std::sync::LazyLock<__oxy_Metrics> =
                     ::std::sync::LazyLock::new(|| {
-                        let registry = &mut *::foundations::telemetry::metrics::internal::Registries::get_subsystem(stringify!(oxy), false, true);
-
                         __oxy_Metrics {
                             connections_errors_total: {
                                 let metric = ::std::default::Default::default();
 
-                                ::foundations::reexports_for_macros::prometheus_client::registry::Registry::register(
-                                    registry,
+                                ::foundations::telemetry::metrics::internal::register_metric(
+                                    ::std::stringify!(oxy),
                                     ::std::stringify!(connections_errors_total),
+                                    ::std::concat!(
+                                        ::std::stringify!(oxy),
+                                        "_",
+                                        ::std::stringify!(connections_errors_total),
+                                    ),
                                     str::trim(" Total number of connection errors"),
-                                    ::foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
+                                    ::std::clone::Clone::clone(&metric),
+                                    false,
+                                    true,
                                 );
 
                                 metric
@@ -765,7 +773,7 @@ mod tests {
                         error: ::std::convert::Into::into(error),
                     };
                     ::std::clone::Clone::clone(
-                        &::foundations::reexports_for_macros::prometools::serde::Family::get_or_create(
+                        &::foundations::telemetry::metrics::Family::get_or_create(
                             &__oxy_Metrics.connections_errors_total,
                             &__args,
                         )
@@ -805,7 +813,7 @@ mod tests {
                 struct __oxy_Metrics {
                     connections_latency: Histogram,
                     requests_per_connection:
-                        ::foundations::reexports_for_macros::prometools::serde::Family<
+                        ::foundations::telemetry::metrics::Family<
                             requests_per_connection,
                             Histogram,
                             HistogramBuilder,
@@ -828,33 +836,45 @@ mod tests {
                 #[allow(non_upper_case_globals)]
                 static __oxy_Metrics: ::std::sync::LazyLock<__oxy_Metrics> =
                     ::std::sync::LazyLock::new(|| {
-                        let registry = &mut *::foundations::telemetry::metrics::internal::Registries::get_subsystem(stringify!(oxy), false, true);
-
                         __oxy_Metrics {
                             connections_latency: {
-                                let metric = ::foundations::reexports_for_macros::prometheus_client::metrics::family::MetricConstructor::new_metric(
+                                let metric = ::foundations::telemetry::metrics::MetricConstructor::new_metric(
                                     &(HistogramBuilder { buckets: &[0.5, 1.] })
                                 );
 
-                                ::foundations::reexports_for_macros::prometheus_client::registry::Registry::register(
-                                    registry,
+                                ::foundations::telemetry::metrics::internal::register_metric(
+                                    ::std::stringify!(oxy),
                                     ::std::stringify!(connections_latency),
+                                    ::std::concat!(
+                                        ::std::stringify!(oxy),
+                                        "_",
+                                        ::std::stringify!(connections_latency),
+                                    ),
                                     str::trim(" Latency of connections"),
-                                    ::foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
+                                    ::std::clone::Clone::clone(&metric),
+                                    false,
+                                    true,
                                 );
 
                                 metric
                             },
                             requests_per_connection: {
-                                let metric = ::foundations::reexports_for_macros::prometools::serde::Family::new_with_constructor(
+                                let metric = ::foundations::telemetry::metrics::Family::new_with_constructor(
                                     HistogramBuilder { buckets: &[2., 3.] }
                                 );
 
-                                ::foundations::reexports_for_macros::prometheus_client::registry::Registry::register(
-                                    registry,
+                                ::foundations::telemetry::metrics::internal::register_metric(
+                                    ::std::stringify!(oxy),
                                     ::std::stringify!(requests_per_connection),
+                                    ::std::concat!(
+                                        ::std::stringify!(oxy),
+                                        "_",
+                                        ::std::stringify!(requests_per_connection),
+                                    ),
                                     str::trim(" Number of requests per connection"),
-                                    ::foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
+                                    ::std::clone::Clone::clone(&metric),
+                                    false,
+                                    true,
                                 );
 
                                 metric
@@ -875,7 +895,7 @@ mod tests {
                 ) -> Histogram {
                     let __args = requests_per_connection { endpoint, };
                     ::std::clone::Clone::clone(
-                        &::foundations::reexports_for_macros::prometools::serde::Family::get_or_create(
+                        &::foundations::telemetry::metrics::Family::get_or_create(
                             &__oxy_Metrics.requests_per_connection,
                             &__args,
                         )
@@ -911,7 +931,7 @@ mod tests {
                 #[allow(non_camel_case_types)]
                 struct __oxy_Metrics {
                     requests_total:
-                        ::foundations::reexports_for_macros::prometools::serde::Family<
+                        ::foundations::telemetry::metrics::Family<
                             requests_total,
                             Counter,
                         >,
@@ -933,17 +953,22 @@ mod tests {
                 #[allow(non_upper_case_globals)]
                 static __oxy_Metrics: ::std::sync::LazyLock<__oxy_Metrics> =
                     ::std::sync::LazyLock::new(|| {
-                        let registry = &mut *::foundations::telemetry::metrics::internal::Registries::get_subsystem(stringify!(oxy), false, true);
-
                         __oxy_Metrics {
                             requests_total: {
                                 let metric = ::std::default::Default::default();
 
-                                ::foundations::reexports_for_macros::prometheus_client::registry::Registry::register(
-                                    registry,
+                                ::foundations::telemetry::metrics::internal::register_metric(
+                                    ::std::stringify!(oxy),
                                     ::std::stringify!(requests_total),
+                                    ::std::concat!(
+                                        ::std::stringify!(oxy),
+                                        "_",
+                                        ::std::stringify!(requests_total),
+                                    ),
                                     str::trim(" Total number of requests"),
-                                    ::foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
+                                    ::std::clone::Clone::clone(&metric),
+                                    false,
+                                    true,
                                 );
 
                                 metric
@@ -956,7 +981,7 @@ mod tests {
                 pub(crate) fn requests_total(status: u16,) -> Counter {
                     let __args = requests_total { status, };
                     ::std::clone::Clone::clone(
-                        &::foundations::reexports_for_macros::prometools::serde::Family::get_or_create(
+                        &::foundations::telemetry::metrics::Family::get_or_create(
                             &__oxy_Metrics.requests_total,
                             &__args,
                         )
@@ -966,7 +991,7 @@ mod tests {
                 #[doc = "Removes one label set from the `requests_total` family."]
                 pub(crate) fn requests_total_remove(status: u16,) -> bool {
                     let __args = requests_total { status, };
-                    ::foundations::reexports_for_macros::prometools::serde::Family::remove(
+                    ::foundations::telemetry::metrics::Family::remove(
                         &__oxy_Metrics.requests_total,
                         &__args,
                     )
@@ -974,7 +999,7 @@ mod tests {
 
                 #[doc = "Removes all label sets from the `requests_total` family."]
                 pub(crate) fn requests_total_clear() {
-                    ::foundations::reexports_for_macros::prometools::serde::Family::clear(
+                    ::foundations::telemetry::metrics::Family::clear(
                         &__oxy_Metrics.requests_total,
                     )
                 }

--- a/foundations-metrics-registry/Cargo.toml
+++ b/foundations-metrics-registry/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "foundations-metrics-registry"
+description = "Process-global metric registry and Prometheus protobuf data model for Foundations."
 version = "0.1.0"
 edition = { workspace = true }
 repository = { workspace = true }

--- a/foundations-metrics-registry/Cargo.toml
+++ b/foundations-metrics-registry/Cargo.toml
@@ -6,6 +6,28 @@ edition = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
+readme = "README.md"
+categories = ["development-tools", "encoding"]
+keywords = ["foundations"]
+# Regenerating the model is a repo-development check whose result depends on the
+# exact `prost-build` in use. Publishing it would hand consumers a test that can
+# fail, and then rewrite its own source, for reasons they cannot act on.
+exclude = ["tests/proto_codegen.rs"]
+
+[package.metadata.release]
+pre-release-hook = [
+    "git-cliff",
+    "-w",
+    "..",
+    "--include-path",
+    "{{crate_name}}/**",
+    "--tag-pattern",
+    "{{crate_name}}-v[0-9]*",
+    "-o",
+    "RELEASE_NOTES.md",
+    "--tag",
+    "{{version}}",
+]
 
 [lints]
 workspace = true

--- a/foundations-metrics-registry/README.md
+++ b/foundations-metrics-registry/README.md
@@ -1,0 +1,28 @@
+# foundations-metrics-registry
+
+The stable core of the `foundations` metrics stack. It holds the process-global metric
+registry and the [`prometheus/client_model`] protobuf types that are the
+canonical wire format for the protobuf `/metrics` endpoint.
+
+The crate is deliberately small and dependency-light. The registry is a
+process-global singleton, so when two `foundations` majors are linked into the
+same binary they have to resolve to the *same* version of this crate to share one
+registry instead of splitting metrics between them. Staying minimal and
+slow-moving is what makes that shared version easy to hold still; the one
+expected source-breaking change is a change to the protobuf data model.
+
+Everything that can evolve more freely — metric types, encoders, label
+serialisation, and service-name handling — lives in the sibling
+[`foundations-metrics`](../foundations-metrics) crate. Reach for this crate
+directly only to consume the registry through `iter`; most code wants `foundations-metrics` instead.
+
+## Documentation
+
+https://docs.rs/foundations-metrics-registry/
+
+## License
+
+BSD-3 licensed. See the [LICENSE](../LICENSE) file for details.
+
+[`prometheus/client_model`]: https://github.com/prometheus/client_model
+[`EncodeMetric`]: https://docs.rs/foundations-metrics-registry/latest/foundations_metrics_registry/trait.EncodeMetric.html

--- a/foundations-metrics-registry/src/encode_metric.rs
+++ b/foundations-metrics-registry/src/encode_metric.rs
@@ -4,6 +4,50 @@ use crate::proto::MetricFamily;
 ///
 /// Encoding is best-effort: implementations skip (and internally report) any
 /// metric or series that fails, so an empty `Vec` is a valid result.
+///
+/// This is the trait the registry stores, so an implementor controls its entire
+/// output: it names its own families and owns any label set it exposes.
+///
+/// `foundations-metrics` also provides an `EncodeMetricValue` trait, whose
+/// implementors encode only a *value* under a relative name. Pairing that with
+/// `NamedMetric` supplies the name, and storing it in a `Family` supplies label
+/// set storage and serialization. Prefer `EncodeMetricValue` unless a metric
+/// needs to control naming or emit several families itself.
+///
+/// # Examples
+///
+/// ```
+/// use foundations_metrics_registry::proto::{Gauge, LabelPair, Metric, MetricType};
+/// use foundations_metrics_registry::{EncodeMetric, MetricFamily, RegistrationMetadata, register};
+///
+/// struct BuildRevision(&'static str);
+///
+/// impl EncodeMetric for BuildRevision {
+///     fn encode(&self) -> Vec<MetricFamily> {
+///         vec![MetricFamily {
+///             // Complete producer-level name: nothing is prepended to it.
+///             name: Some("build_revision".to_owned()),
+///             help: Some("Revision the binary was built from.".to_owned()),
+///             r#type: Some(MetricType::Gauge as i32),
+///             metric: vec![Metric {
+///                 // Labels are this implementation's own responsibility.
+///                 label: vec![LabelPair {
+///                     name: Some("revision".to_owned()),
+///                     value: Some(self.0.to_owned()),
+///                 }],
+///                 gauge: Some(Gauge { value: Some(1.0) }),
+///                 ..Default::default()
+///             }],
+///             unit: None,
+///         }]
+///     }
+/// }
+///
+/// register(
+///     Box::new(BuildRevision("9f2c1ab")) as Box<dyn EncodeMetric>,
+///     RegistrationMetadata::default(),
+/// );
+/// ```
 pub trait EncodeMetric: Send + Sync + 'static {
     /// Encodes this metric into zero or more [`MetricFamily`] messages.
     ///

--- a/foundations-metrics-registry/src/metadata.rs
+++ b/foundations-metrics-registry/src/metadata.rs
@@ -11,6 +11,15 @@ pub struct RegistrationMetadata {
 
     /// Whether to suppress the service-name prefix for this metric.
     pub unprefixed: bool,
+
+    /// Whether to suppress the service-name label for this metric.
+    ///
+    /// Independent of [`unprefixed`](Self::unprefixed): a metric that opts out
+    /// of the service-name prefix is still labelled with the service name under
+    /// [`ServiceNameFormat::LabelWithName`]. Info metrics opt out of both.
+    ///
+    /// [`ServiceNameFormat::LabelWithName`]: https://docs.rs/foundations-metrics
+    pub unlabeled: bool,
 }
 
 impl RegistrationMetadata {
@@ -25,6 +34,13 @@ impl RegistrationMetadata {
     #[must_use]
     pub fn unprefixed(mut self, unprefixed: bool) -> Self {
         self.unprefixed = unprefixed;
+        self
+    }
+
+    /// Sets [`unlabeled`](Self::unlabeled)
+    #[must_use]
+    pub fn unlabeled(mut self, unlabeled: bool) -> Self {
+        self.unlabeled = unlabeled;
         self
     }
 }

--- a/foundations-metrics-registry/src/metadata.rs
+++ b/foundations-metrics-registry/src/metadata.rs
@@ -15,10 +15,8 @@ pub struct RegistrationMetadata {
     /// Whether to suppress the service-name label for this metric.
     ///
     /// Independent of [`unprefixed`](Self::unprefixed): a metric that opts out
-    /// of the service-name prefix is still labelled with the service name under
-    /// [`ServiceNameFormat::LabelWithName`]. Info metrics opt out of both.
-    ///
-    /// [`ServiceNameFormat::LabelWithName`]: https://docs.rs/foundations-metrics
+    /// of the service-name prefix is still labelled with the service name when
+    /// collection represents it as a label. Info metrics opt out of both.
     pub unlabeled: bool,
 }
 

--- a/foundations-metrics/Cargo.toml
+++ b/foundations-metrics/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "foundations-metrics"
 version = "0.1.0"
+readme = "README.md"
 repository.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/foundations-metrics/Cargo.toml
+++ b/foundations-metrics/Cargo.toml
@@ -3,10 +3,27 @@ name = "foundations-metrics"
 description = "Concrete Prometheus metric types and encoders for the Foundations stack."
 version = "0.1.0"
 readme = "README.md"
-repository.workspace = true
-edition.workspace = true
-authors.workspace = true
-license.workspace = true
+repository = { workspace = true }
+edition = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+categories = ["development-tools", "encoding"]
+keywords = ["foundations", "metrics", "prometheus", "openmetrics"]
+
+[package.metadata.release]
+pre-release-hook = [
+    "git-cliff",
+    "-w",
+    "..",
+    "--include-path",
+    "{{crate_name}}/**",
+    "--tag-pattern",
+    "{{crate_name}}-v[0-9]*",
+    "-o",
+    "RELEASE_NOTES.md",
+    "--tag",
+    "{{version}}",
+]
 
 [dependencies]
 foundations-metrics-registry = { workspace = true }
@@ -15,7 +32,7 @@ prometheus-client = { version = "0.25.0", features = [
     "protobuf-protox",
 ] }
 serde = { workspace = true, features = ["derive"] }
-ryu = "1.0.23"
+ryu = { workspace = true }
 parking_lot = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }

--- a/foundations-metrics/Cargo.toml
+++ b/foundations-metrics/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "foundations-metrics"
+description = "Concrete Prometheus metric types and encoders for the Foundations stack."
 version = "0.1.0"
 readme = "README.md"
 repository.workspace = true

--- a/foundations-metrics/README.md
+++ b/foundations-metrics/README.md
@@ -1,0 +1,76 @@
+# foundations-metrics
+
+The evolving layer of the `foundations` metrics stack: the concrete metric types
+and the logic that encodes them into the Prometheus protobuf data model. It sits
+on top of `foundations-metrics-registry`, which owns the process-global registry
+and the stable wire format.
+
+## Migrating from `foundations::telemetry::metrics`
+
+`foundations` re-exports this crate's items through
+`foundations::telemetry::metrics` when its default `foundations-metrics-backend`
+feature is enabled. The substitution is shape-compatible, so existing code keeps
+compiling without changes — which makes the feature a transition aid rather than
+the destination. The facade is slated for removal in the next major release.
+
+To finish the move, depend on this crate directly and import from it:
+
+```toml
+[dependencies]
+foundations-metrics = "0.1"
+```
+
+```rust
+// Before
+use foundations::telemetry::metrics::{Counter, Family, Gauge, InfoMetric, report_info};
+
+// After
+use foundations_metrics::{Counter, Family, Gauge, InfoMetric, report_info};
+```
+
+Two things stay with `foundations` and are not part of this crate:
+
+- `#[metrics]` and `#[info_metric]`, which expand to paths that `foundations`
+  resolves. Keep invoking them through `foundations::telemetry::metrics`.
+- Telemetry setup, including the service name that prefixes or labels collected
+  metrics. This crate takes that name through
+  [`CollectionOptions`](https://docs.rs/foundations-metrics/latest/foundations_metrics/struct.CollectionOptions.html)
+  at collection time instead of discovering it itself.
+
+Mixing the two paths works only with `foundations-metrics-backend` enabled;
+without it, `foundations::telemetry::metrics` names its own legacy types and
+those are distinct from this crate's.
+
+### Deprecated items
+
+Most imports move by renaming the path. These have no drop-in equivalent:
+
+| Deprecated | Replacement |
+| --- | --- |
+| `foundations::telemetry::metrics::add_extra_producer` | [`register`](https://docs.rs/foundations-metrics/latest/foundations_metrics/fn.register.html) |
+| `foundations::telemetry::metrics::ExtraProducer` | [`EncodeMetric`](https://docs.rs/foundations-metrics/latest/foundations_metrics/trait.EncodeMetric.html) or [`EncodeMetricValue`](https://docs.rs/foundations-metrics/latest/foundations_metrics/trait.EncodeMetricValue.html) |
+
+Extra producers append pre-encoded Prometheus *text* to the scrape buffer, which
+bypasses validation and has no protobuf representation — so their output is
+silently absent from a protobuf scrape. Implementing `EncodeMetric` returns
+structured metric families instead, which both encoders can serve. Prefer
+`EncodeMetricValue` paired with `NamedMetric` and `Family` unless a metric needs
+to control its own naming or emit several families.
+
+Enabling the feature also stops draining the `prometheus` crate's global
+registry, which the legacy collector exported alongside its own. Anything
+registered there, including that crate's process collector, needs to be
+re-registered through `register`.
+
+For further guidance, each deprecated item names its own replacement in the
+[`foundations` API docs](https://docs.rs/foundations/), and the traits above are
+documented with examples in the [API docs for this
+crate](https://docs.rs/foundations-metrics/).
+
+## Documentation
+
+https://docs.rs/foundations-metrics/
+
+## License
+
+BSD-3 licensed. See the [LICENSE](../LICENSE) file for details.

--- a/foundations-metrics/README.md
+++ b/foundations-metrics/README.md
@@ -58,9 +58,19 @@ structured metric families instead, which both encoders can serve. Prefer
 to control its own naming or emit several families.
 
 Enabling the feature also stops draining the `prometheus` crate's global
-registry, which the legacy collector exported alongside its own. Anything
-registered there, including that crate's process collector, needs to be
-re-registered through `register`.
+registry, which the legacy collector exported alongside its own. Metrics kept
+only there are no longer scraped. Note that `register` does not accept that
+crate's collectors — [`IntoMetrics`](https://docs.rs/foundations-metrics-registry/latest/foundations_metrics_registry/trait.IntoMetrics.html)
+is sealed over `EncodeMetric` — so they have to be reimplemented against the
+traits above rather than handed over as they are.
+
+On Linux this includes the process collector, which that crate registers on its
+own and which no longer has an equivalent here:
+`process_cpu_seconds_total`, `process_resident_memory_bytes`,
+`process_virtual_memory_bytes`, `process_open_fds`, `process_max_fds`,
+`process_start_time_seconds`, and `process_threads`. Nothing registers these
+after the switch, so alerts and dashboards reading them need either a
+reimplementation or another source such as `node_exporter` or cAdvisor.
 
 For further guidance, each deprecated item names its own replacement in the
 [`foundations` API docs](https://docs.rs/foundations/), and the traits above are

--- a/foundations-metrics/src/collect.rs
+++ b/foundations-metrics/src/collect.rs
@@ -103,25 +103,28 @@ fn apply_service_label(families: &mut [MetricFamily], label_name: &str, service_
     for family in families {
         let family_name = family.name.as_deref().unwrap_or_default();
         family.metric.retain_mut(|metric| {
-            let mut has_same_value = false;
-            for label in &metric.label {
-                if label.name.as_deref() != Some(label_name) {
-                    continue;
-                }
-
-                if label.value.as_deref() != Some(service_name) {
+            // Only the first occurrence decides. A row that
+            // repeats the label is dropped by duplicate-label
+            // validation below with a clearer message, so
+            // scanning past the first match cannot change the
+            // outcome and would only make it order dependent.
+            match metric
+                .label
+                .iter()
+                .find(|label| label.name.as_deref() == Some(label_name))
+            {
+                Some(label) if label.value.as_deref() != Some(service_name) => {
                     report_collect_error(format_args!(
                         "non-fatal error while collecting metrics: skipped row in metric family {family_name:?}; service label {label_name:?} already has a different value"
                     ));
-                    return false;
+                    false
                 }
-                has_same_value = true;
+                Some(_) => true,
+                None => {
+                    metric.label.insert(0, service_label.clone());
+                    true
+                }
             }
-
-            if !has_same_value {
-                metric.label.insert(0, service_label.clone());
-            }
-            true
         });
     }
 }

--- a/foundations-metrics/src/collect.rs
+++ b/foundations-metrics/src/collect.rs
@@ -59,6 +59,7 @@ pub fn collect(options: CollectionOptions) -> Vec<MetricFamily> {
                 service_name,
                 options.service_name_format,
                 metadata.unprefixed,
+                metadata.unlabeled,
             );
         }
 
@@ -75,6 +76,7 @@ fn apply_service_name(
     service_name: &str,
     format: ServiceNameFormat<'_>,
     unprefixed: bool,
+    unlabeled: bool,
 ) {
     match format {
         ServiceNameFormat::MetricPrefix if !unprefixed => {
@@ -85,10 +87,10 @@ fn apply_service_name(
                 }
             }
         }
-        ServiceNameFormat::LabelWithName(label_name) => {
+        ServiceNameFormat::LabelWithName(label_name) if !unlabeled => {
             apply_service_label(families, label_name, service_name);
         }
-        ServiceNameFormat::MetricPrefix => {}
+        ServiceNameFormat::MetricPrefix | ServiceNameFormat::LabelWithName(_) => {}
     }
 }
 

--- a/foundations-metrics/src/collect.rs
+++ b/foundations-metrics/src/collect.rs
@@ -103,11 +103,6 @@ fn apply_service_label(families: &mut [MetricFamily], label_name: &str, service_
     for family in families {
         let family_name = family.name.as_deref().unwrap_or_default();
         family.metric.retain_mut(|metric| {
-            // Only the first occurrence decides. A row that
-            // repeats the label is dropped by duplicate-label
-            // validation below with a clearer message, so
-            // scanning past the first match cannot change the
-            // outcome and would only make it order dependent.
             match metric
                 .label
                 .iter()

--- a/foundations-metrics/src/encoding/mod.rs
+++ b/foundations-metrics/src/encoding/mod.rs
@@ -7,6 +7,10 @@ use crate::validation::{ValidationContext, sanitized_metric_family};
 
 pub use text::{OPENMETRICS_CONTENT_TYPE, encode_to_text};
 
+/// Content type of length-delimited Prometheus protobuf response.
+pub const PROTOBUF_CONTENT_TYPE: &str =
+    "application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited";
+
 /// Encodes metric families as length-delimited Prometheus protobuf messages.
 pub fn encode_to_protobuf(families: &[MetricFamily]) -> Vec<u8> {
     let mut output = Vec::new();

--- a/foundations-metrics/src/encoding/text.rs
+++ b/foundations-metrics/src/encoding/text.rs
@@ -219,6 +219,12 @@ fn encode_histogram(
     let mut infinity_bucket_seen = false;
     for bucket in &histogram.bucket {
         let upper_bound = bucket.upper_bound.unwrap_or_default();
+        // `Histogram` uses `f64::MAX` as its terminal bucket bound, matching
+        // `prometheus_client`, so that the bound stays a finite value the
+        // protobuf data model round-trips unchanged. The text exposition format
+        // has no such constraint and requires the catch-all bucket to be
+        // labelled `le="+Inf"`, so the sentinel is translated on the way out
+        // rather than at its source.
         let upper_bound = if upper_bound == f64::MAX {
             f64::INFINITY
         } else {

--- a/foundations-metrics/src/info.rs
+++ b/foundations-metrics/src/info.rs
@@ -1,0 +1,275 @@
+//! Info metrics: gauges whose value is always `1`, carrying their data in labels.
+
+use std::any::TypeId;
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use foundations_metrics_registry::proto::{Gauge, LabelPair, Metric, MetricType};
+use foundations_metrics_registry::{EncodeMetric, MetricFamily, RegistrationMetadata, register};
+use parking_lot::RwLock;
+use serde::Serialize;
+
+use crate::diagnostics::report_collect_error;
+use crate::labels::to_label_pairs;
+
+/// Describes an info metric.
+///
+/// Info metrics expose textual information through their label set, which
+/// should not change often during the process lifetime. Common examples are an
+/// application's version, revision control commit, and the version of a
+/// compiler.
+pub trait InfoMetric: Serialize + Send + Sync + 'static {
+    /// The name of the info metric.
+    const NAME: &'static str;
+
+    /// The help message of the info metric.
+    const HELP: &'static str;
+}
+
+/// A reported info metric, with its label set already serialized.
+struct InfoEntry {
+    name: &'static str,
+    help: &'static str,
+    labels: Vec<LabelPair>,
+}
+
+static INFO_METRICS: OnceLock<RwLock<HashMap<TypeId, InfoEntry>>> = OnceLock::new();
+
+/// Returns the info metric store, registering the collector on first use.
+fn info_metrics() -> &'static RwLock<HashMap<TypeId, InfoEntry>> {
+    INFO_METRICS.get_or_init(|| {
+        // A single collector is registered for every info metric: the registry
+        // is append-only, so registering per report would emit a duplicate
+        // family each time the same info metric is reported again.
+        register(
+            Box::new(InfoCollector) as Box<dyn EncodeMetric>,
+            // Info metrics are exposed exactly as reported: they keep their bare
+            // name (e.g. `build_info`) and carry only their own fields as labels.
+            RegistrationMetadata::default()
+                .unprefixed(true)
+                .unlabeled(true),
+        );
+
+        RwLock::new(HashMap::new())
+    })
+}
+
+/// Registers an info metric, i.e. a gauge metric whose value is always `1`.
+///
+/// Reporting the same info metric type again replaces the previously reported
+/// value, so a metric is exposed at most once per type.
+///
+/// Label serialization happens here rather than at collection time; a label set
+/// that cannot be serialized is dropped with a non-fatal diagnostic.
+///
+/// ```
+/// use foundations_metrics::{InfoMetric, report_info};
+/// use serde::Serialize;
+///
+/// /// Build information.
+/// #[derive(Serialize)]
+/// struct BuildInfo {
+///     version: &'static str,
+/// }
+///
+/// impl InfoMetric for BuildInfo {
+///     const NAME: &'static str = "build_info";
+///     const HELP: &'static str = "Build information.";
+/// }
+///
+/// report_info(BuildInfo { version: "1.2.3" });
+/// ```
+pub fn report_info<M>(info_metric: impl Into<Box<M>>)
+where
+    M: InfoMetric,
+{
+    let info_metric = info_metric.into();
+
+    match to_label_pairs(&*info_metric) {
+        Ok(labels) => {
+            info_metrics().write().insert(
+                TypeId::of::<M>(),
+                InfoEntry {
+                    name: M::NAME,
+                    help: M::HELP,
+                    labels,
+                },
+            );
+        }
+        Err(error) => report_collect_error(format_args!(
+            "non-fatal error while reporting info metric {:?}: label serialization failed: {error}",
+            M::NAME
+        )),
+    }
+}
+
+/// Encodes every reported info metric as a gauge family valued `1`.
+struct InfoCollector;
+
+impl EncodeMetric for InfoCollector {
+    fn encode(&self) -> Vec<MetricFamily> {
+        // Read without initializing: the collector is only ever registered from
+        // `info_metrics`, so the store already exists by the time this runs.
+        let Some(info_metrics) = INFO_METRICS.get() else {
+            return Vec::new();
+        };
+
+        info_metrics
+            .read()
+            .values()
+            .map(|entry| MetricFamily {
+                name: Some(entry.name.to_owned()),
+                help: Some(entry.help.to_owned()),
+                r#type: Some(MetricType::Gauge as i32),
+                metric: vec![Metric {
+                    label: entry.labels.clone(),
+                    gauge: Some(Gauge { value: Some(1.0) }),
+                    ..Default::default()
+                }],
+                unit: None,
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Serialize;
+
+    use super::*;
+    use crate::{CollectionOptions, ServiceNameFormat, collect};
+
+    fn family<'a>(families: &'a [MetricFamily], name: &str) -> &'a MetricFamily {
+        families
+            .iter()
+            .find(|family| family.name.as_deref() == Some(name))
+            .unwrap_or_else(|| panic!("family {name:?} should be encoded"))
+    }
+
+    #[derive(Serialize)]
+    struct EncodedInfo {
+        version: &'static str,
+    }
+
+    impl InfoMetric for EncodedInfo {
+        const NAME: &'static str = "info_encoded";
+        const HELP: &'static str = "Encoded information.";
+    }
+
+    #[test]
+    fn encodes_info_metric_as_a_gauge_valued_one() {
+        report_info(EncodedInfo { version: "1.2.3" });
+
+        let families = InfoCollector.encode();
+        let family = family(&families, "info_encoded");
+
+        assert_eq!(family.help.as_deref(), Some("Encoded information."));
+        assert_eq!(family.r#type, Some(MetricType::Gauge as i32));
+        assert_eq!(family.metric.len(), 1);
+        assert_eq!(
+            family.metric[0]
+                .gauge
+                .as_ref()
+                .and_then(|gauge| gauge.value),
+            Some(1.0)
+        );
+        assert_eq!(family.metric[0].label[0].name.as_deref(), Some("version"));
+        assert_eq!(family.metric[0].label[0].value.as_deref(), Some("1.2.3"));
+    }
+
+    #[derive(Serialize)]
+    struct ReplacedInfo {
+        revision: &'static str,
+    }
+
+    impl InfoMetric for ReplacedInfo {
+        const NAME: &'static str = "info_replaced";
+        const HELP: &'static str = "Replaced information.";
+    }
+
+    #[test]
+    fn reporting_the_same_info_metric_replaces_the_previous_value() {
+        report_info(ReplacedInfo { revision: "first" });
+        report_info(ReplacedInfo { revision: "second" });
+
+        let families = InfoCollector.encode();
+        let matching = families
+            .iter()
+            .filter(|family| family.name.as_deref() == Some("info_replaced"))
+            .count();
+
+        assert_eq!(matching, 1, "re-reporting must replace, not duplicate");
+        assert_eq!(
+            family(&families, "info_replaced").metric[0].label[0]
+                .value
+                .as_deref(),
+            Some("second")
+        );
+    }
+
+    #[derive(Serialize)]
+    struct CollectedInfo {
+        version: &'static str,
+    }
+
+    impl InfoMetric for CollectedInfo {
+        const NAME: &'static str = "info_collected";
+        const HELP: &'static str = "Collected information.";
+    }
+
+    #[test]
+    fn collection_keeps_info_metric_names_unprefixed() {
+        report_info(CollectedInfo { version: "4.5.6" });
+
+        let families = collect(CollectionOptions {
+            include_optional: false,
+            service_name: Some("test_service"),
+            service_name_format: ServiceNameFormat::MetricPrefix,
+        });
+
+        assert!(
+            families
+                .iter()
+                .any(|family| family.name.as_deref() == Some("info_collected")),
+            "info metrics keep their bare name"
+        );
+        assert!(
+            !families
+                .iter()
+                .any(|family| family.name.as_deref() == Some("test_service_info_collected")),
+            "info metrics are never service-prefixed"
+        );
+    }
+
+    #[derive(Serialize)]
+    struct LabeledInfo {
+        version: &'static str,
+    }
+
+    impl InfoMetric for LabeledInfo {
+        const NAME: &'static str = "info_labeled";
+        const HELP: &'static str = "Labeled information.";
+    }
+
+    // Adding the service label would change the series identity of every info
+    // metric relative to the representation collectors already scrape.
+    #[test]
+    fn collection_does_not_add_the_service_label_to_info_metrics() {
+        report_info(LabeledInfo { version: "7.8.9" });
+
+        let families = collect(CollectionOptions {
+            include_optional: false,
+            service_name: Some("test_service"),
+            service_name_format: ServiceNameFormat::LabelWithName("service"),
+        });
+
+        let family = family(&families, "info_labeled");
+        let label_names: Vec<_> = family.metric[0]
+            .label
+            .iter()
+            .map(|label| label.name.as_deref().unwrap_or_default())
+            .collect();
+
+        assert_eq!(label_names, ["version"]);
+    }
+}

--- a/foundations-metrics/src/info.rs
+++ b/foundations-metrics/src/info.rs
@@ -38,13 +38,8 @@ static INFO_METRICS: OnceLock<RwLock<HashMap<TypeId, InfoEntry>>> = OnceLock::ne
 /// Returns the info metric store, registering the collector on first use.
 fn info_metrics() -> &'static RwLock<HashMap<TypeId, InfoEntry>> {
     INFO_METRICS.get_or_init(|| {
-        // A single collector is registered for every info metric: the registry
-        // is append-only, so registering per report would emit a duplicate
-        // family each time the same info metric is reported again.
         register(
             Box::new(InfoCollector) as Box<dyn EncodeMetric>,
-            // Info metrics are exposed exactly as reported: they keep their bare
-            // name (e.g. `build_info`) and carry only their own fields as labels.
             RegistrationMetadata::default()
                 .unprefixed(true)
                 .unlabeled(true),
@@ -108,8 +103,6 @@ struct InfoCollector;
 
 impl EncodeMetric for InfoCollector {
     fn encode(&self) -> Vec<MetricFamily> {
-        // Read without initializing: the collector is only ever registered from
-        // `info_metrics`, so the store already exists by the time this runs.
         let Some(info_metrics) = INFO_METRICS.get() else {
             return Vec::new();
         };

--- a/foundations-metrics/src/labels/serializer.rs
+++ b/foundations-metrics/src/labels/serializer.rs
@@ -476,9 +476,6 @@ impl Serializer for LabelValueSerializer {
 
 // Adapted from prometools' `serde::top::check_key`
 // (https://github.com/nox/prometools, licensed MIT OR Apache-2.0).
-//
-// Rejects only names no encoder can express; see `is_valid_name` for why this is
-// intentionally permissive rather than the legacy Prometheus name pattern.
 fn validate_label_name(name: &str) -> Result<(), LabelError> {
     is_valid_name(name).then_some(()).ok_or_else(|| {
         LabelError::new(format!(

--- a/foundations-metrics/src/labels/serializer.rs
+++ b/foundations-metrics/src/labels/serializer.rs
@@ -476,6 +476,9 @@ impl Serializer for LabelValueSerializer {
 
 // Adapted from prometools' `serde::top::check_key`
 // (https://github.com/nox/prometools, licensed MIT OR Apache-2.0).
+//
+// Rejects only names no encoder can express; see `is_valid_name` for why this is
+// intentionally permissive rather than the legacy Prometheus name pattern.
 fn validate_label_name(name: &str) -> Result<(), LabelError> {
     is_valid_name(name).then_some(()).ok_or_else(|| {
         LabelError::new(format!(

--- a/foundations-metrics/src/lib.rs
+++ b/foundations-metrics/src/lib.rs
@@ -4,6 +4,9 @@
 //! and the logic that encodes them into the Prometheus protobuf data model. It
 //! builds on the slow-moving `foundations-metrics-registry` crate, which owns the
 //! shared process-global registry and the stable wire format.
+//!
+//! Reaching these items through `foundations::telemetry::metrics` is a temporary fix,
+//! but still works; see the crate README for how to migrate off that facade.
 #![warn(missing_docs)]
 
 mod collect;

--- a/foundations-metrics/src/lib.rs
+++ b/foundations-metrics/src/lib.rs
@@ -35,4 +35,5 @@ pub use metrics::{
     NativeHistogramBuilder, RangeGauge, TimeHistogram, WithExemplar,
 };
 pub use registered::NamedMetric;
+pub use validation::{NAME_REQUIREMENT, is_valid_name};
 pub use value::EncodeMetricValue;

--- a/foundations-metrics/src/lib.rs
+++ b/foundations-metrics/src/lib.rs
@@ -18,7 +18,9 @@ mod value;
 
 pub use collect::{CollectionOptions, ServiceNameFormat, collect};
 pub use diagnostics::{CollectErrorHookAlreadySet, set_collect_error_hook};
-pub use encoding::{OPENMETRICS_CONTENT_TYPE, encode_to_protobuf, encode_to_text};
+pub use encoding::{
+    OPENMETRICS_CONTENT_TYPE, PROTOBUF_CONTENT_TYPE, encode_to_protobuf, encode_to_text,
+};
 pub use foundations_metrics_registry::{
     EncodeMetric, IntoMetrics, MetricFamily, RegistrationMetadata, proto, register,
 };

--- a/foundations-metrics/src/lib.rs
+++ b/foundations-metrics/src/lib.rs
@@ -20,7 +20,7 @@ pub use collect::{CollectionOptions, ServiceNameFormat, collect};
 pub use diagnostics::{CollectErrorHookAlreadySet, set_collect_error_hook};
 pub use encoding::{OPENMETRICS_CONTENT_TYPE, encode_to_protobuf, encode_to_text};
 pub use foundations_metrics_registry::{
-    EncodeMetric, IntoMetrics, MetricFamily, RegistrationMetadata, register,
+    EncodeMetric, IntoMetrics, MetricFamily, RegistrationMetadata, proto, register,
 };
 pub use info::{InfoMetric, report_info};
 pub use labels::{LabelError, to_label_pairs};
@@ -30,3 +30,4 @@ pub use metrics::{
     NativeHistogramBuilder, RangeGauge, TimeHistogram, WithExemplar,
 };
 pub use registered::NamedMetric;
+pub use value::EncodeMetricValue;

--- a/foundations-metrics/src/lib.rs
+++ b/foundations-metrics/src/lib.rs
@@ -9,6 +9,7 @@
 mod collect;
 mod diagnostics;
 mod encoding;
+mod info;
 mod labels;
 pub mod metrics;
 mod registered;
@@ -21,6 +22,7 @@ pub use encoding::{OPENMETRICS_CONTENT_TYPE, encode_to_protobuf, encode_to_text}
 pub use foundations_metrics_registry::{
     EncodeMetric, IntoMetrics, MetricFamily, RegistrationMetadata, register,
 };
+pub use info::{InfoMetric, report_info};
 pub use labels::{LabelError, to_label_pairs};
 pub use metrics::{
     Counter, CounterAtomic, Family, FamilyMetricGuard, Gauge, GaugeAtomic, GaugeGuard, Histogram,

--- a/foundations-metrics/src/registered.rs
+++ b/foundations-metrics/src/registered.rs
@@ -5,7 +5,7 @@ use crate::{EncodeMetric, MetricFamily, value::EncodeMetricValue};
 /// Storage types (`Counter`, `Gauge`, ...) hold only their value and encode
 /// themselves with relative names (a suffix such as `""`, `_min`, or `_max`).
 /// `NamedMetric` supplies the registered base name and help text, bridging the
-/// internal `EncodeMetricValue` storage trait to the public
+/// [`EncodeMetricValue`](crate::EncodeMetricValue) storage trait to the
 /// [`EncodeMetric`] registry trait.
 pub struct NamedMetric<M> {
     name: &'static str,

--- a/foundations-metrics/src/validation.rs
+++ b/foundations-metrics/src/validation.rs
@@ -29,12 +29,6 @@ impl ValidationContext {
 
 /// Whether a metric or label name can be represented at all.
 ///
-/// This check is deliberately permissive, and tightening it to the legacy
-/// `[a-zA-Z_][a-zA-Z0-9_]*` pattern would be a regression: OpenMetrics 1.0
-/// admits arbitrary UTF-8 names, and the text encoder quotes any name that
-/// needs it, so names outside the legacy pattern still encode correctly. Naming
-/// policy therefore belongs to the encoders, not here.
-///
 /// Only the two cases that no encoder can express are rejected: an empty name
 /// has no rendering, and a NUL byte both breaks the text format and collides
 /// with the `EXEMPLAR_SERIALIZATION_ERROR_LABEL` sentinel, which relies on being

--- a/foundations-metrics/src/validation.rs
+++ b/foundations-metrics/src/validation.rs
@@ -4,7 +4,9 @@ use foundations_metrics_registry::proto::{Exemplar, LabelPair, Metric, MetricFam
 
 use crate::diagnostics::report_collect_error;
 
-pub(crate) const NAME_REQUIREMENT: &str = "a non-empty UTF-8 string without NUL bytes";
+/// Describes what [`is_valid_name`] accepts, for use in diagnostics.
+pub const NAME_REQUIREMENT: &str = "a non-empty UTF-8 string without NUL bytes";
+
 pub(crate) const EXEMPLAR_SERIALIZATION_ERROR_LABEL: &str =
     "\0foundations_metrics_exemplar_serialization_error";
 
@@ -35,9 +37,14 @@ impl ValidationContext {
 ///
 /// Only the two cases that no encoder can express are rejected: an empty name
 /// has no rendering, and a NUL byte both breaks the text format and collides
-/// with the [`EXEMPLAR_SERIALIZATION_ERROR_LABEL`] sentinel, which relies on
-/// being unrepresentable to stay distinguishable from a real label.
-pub(crate) fn is_valid_name(name: &str) -> bool {
+/// with the `EXEMPLAR_SERIALIZATION_ERROR_LABEL` sentinel, which relies on being
+/// unrepresentable to stay distinguishable from a real label.
+///
+/// Exposed so a name taken from configuration can be rejected where it is read
+/// rather than at the first scrape, which is all
+/// [`collect`](crate::collect) can do with it. [`NAME_REQUIREMENT`] describes the
+/// rule for the resulting diagnostic.
+pub fn is_valid_name(name: &str) -> bool {
     !name.is_empty() && !name.contains('\0')
 }
 

--- a/foundations-metrics/src/validation.rs
+++ b/foundations-metrics/src/validation.rs
@@ -25,6 +25,18 @@ impl ValidationContext {
     }
 }
 
+/// Whether a metric or label name can be represented at all.
+///
+/// This check is deliberately permissive, and tightening it to the legacy
+/// `[a-zA-Z_][a-zA-Z0-9_]*` pattern would be a regression: OpenMetrics 1.0
+/// admits arbitrary UTF-8 names, and the text encoder quotes any name that
+/// needs it, so names outside the legacy pattern still encode correctly. Naming
+/// policy therefore belongs to the encoders, not here.
+///
+/// Only the two cases that no encoder can express are rejected: an empty name
+/// has no rendering, and a NUL byte both breaks the text format and collides
+/// with the [`EXEMPLAR_SERIALIZATION_ERROR_LABEL`] sentinel, which relies on
+/// being unrepresentable to stay distinguishable from a real label.
 pub(crate) fn is_valid_name(name: &str) -> bool {
     !name.is_empty() && !name.contains('\0')
 }

--- a/foundations-metrics/src/value.rs
+++ b/foundations-metrics/src/value.rs
@@ -6,7 +6,80 @@ use crate::MetricFamily;
 /// primary series uses `Some("")`; additional series use names such as
 /// `Some("_min")` and `Some("_max")`. [`NamedMetric`](crate::NamedMetric)
 /// prepends the registered metric name and fills in missing help text.
-pub(crate) trait EncodeMetricValue: Send + Sync + 'static {
+/// Implement this to define a custom metric. Pair it with
+/// [`NamedMetric`](crate::NamedMetric) to attach the registered name and help
+/// text, or store it in a [`Family`](crate::Family) to differentiate it by label
+/// set, then hand the result to [`register`](crate::register).
+///
+/// # Compared with [`EncodeMetric`](crate::EncodeMetric)
+///
+/// Both encode into the same [`MetricFamily`] model; they differ in how much of
+/// the output the implementor owns.
+///
+/// |  | [`EncodeMetric`](crate::EncodeMetric) | `EncodeMetricValue` |
+/// |---|---|---|
+/// | Family name | complete, written by the implementor | relative, prepended by [`NamedMetric`](crate::NamedMetric) |
+/// | Help text | written by the implementor | filled in by [`NamedMetric`](crate::NamedMetric) when absent |
+/// | Label sets | the implementor's own storage and serialization | provided by [`Family`](crate::Family) |
+/// | Registered directly | yes | only once wrapped |
+///
+/// Implementing [`EncodeMetric`](crate::EncodeMetric) is the right choice when a
+/// metric must control its own naming or emit several families; otherwise this
+/// trait leaves only the value encoding to write.
+///
+/// ```
+/// use std::sync::atomic::{AtomicU64, Ordering};
+///
+/// use foundations_metrics::proto::{Gauge, Metric, MetricType};
+/// use foundations_metrics::{
+///     EncodeMetric, EncodeMetricValue, Family, MetricFamily, NamedMetric, RegistrationMetadata,
+///     register,
+/// };
+/// use serde::Serialize;
+///
+/// #[derive(Default)]
+/// struct OpenFiles(AtomicU64);
+///
+/// impl EncodeMetricValue for OpenFiles {
+///     fn encode_metric_value(&self) -> Vec<MetricFamily> {
+///         vec![MetricFamily {
+///             // The primary series carries an empty relative name.
+///             name: Some(String::new()),
+///             help: None,
+///             r#type: Some(MetricType::Gauge as i32),
+///             metric: vec![Metric {
+///                 gauge: Some(Gauge {
+///                     value: Some(self.0.load(Ordering::Relaxed) as f64),
+///                 }),
+///                 ..Default::default()
+///             }],
+///             unit: None,
+///         }]
+///     }
+/// }
+///
+/// #[derive(Clone, Eq, Hash, PartialEq, Serialize)]
+/// struct Labels {
+///     mount: &'static str,
+/// }
+///
+/// let open_files = Family::<Labels, OpenFiles>::default();
+///
+/// open_files
+///     .get_or_create(&Labels { mount: "/data" })
+///     .0
+///     .fetch_add(1, Ordering::Relaxed);
+///
+/// register(
+///     Box::new(NamedMetric::new(
+///         "open_files",
+///         "Number of open file descriptors.",
+///         open_files,
+///     )) as Box<dyn EncodeMetric>,
+///     RegistrationMetadata::default(),
+/// );
+/// ```
+pub trait EncodeMetricValue: Send + Sync + 'static {
     /// Encodes the current value into one or more relatively named families.
     fn encode_metric_value(&self) -> Vec<MetricFamily>;
 }

--- a/foundations-metrics/tests/custom_metric.rs
+++ b/foundations-metrics/tests/custom_metric.rs
@@ -1,0 +1,192 @@
+//! Defines and registers custom metrics from outside the crate, which is the
+//! only way to verify that the public API is sufficient on its own.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+
+use foundations_metrics::proto::{Gauge, Metric, MetricType};
+use foundations_metrics::{
+    CollectionOptions, EncodeMetric, EncodeMetricValue, Family, MetricFamily, NamedMetric,
+    RegistrationMetadata, ServiceNameFormat, collect, register, to_label_pairs,
+};
+use serde::Serialize;
+
+#[derive(Clone, Eq, Hash, PartialEq, Serialize)]
+struct Labels {
+    mount: &'static str,
+}
+
+fn gauge(value: u64) -> Option<Gauge> {
+    Some(Gauge {
+        value: Some(value as f64),
+    })
+}
+
+fn collected() -> Vec<MetricFamily> {
+    collect(CollectionOptions {
+        include_optional: false,
+        service_name: None,
+        service_name_format: ServiceNameFormat::MetricPrefix,
+    })
+}
+
+fn family_named<'a>(families: &'a [MetricFamily], name: &str) -> &'a MetricFamily {
+    families
+        .iter()
+        .find(|family| family.name.as_deref() == Some(name))
+        .unwrap_or_else(|| panic!("family {name:?} should be collected"))
+}
+
+/// A metric without labels only needs [`EncodeMetric`], which supplies its own
+/// absolute name.
+#[derive(Default)]
+struct OpenFiles(AtomicU64);
+
+impl EncodeMetric for OpenFiles {
+    fn encode(&self) -> Vec<MetricFamily> {
+        vec![MetricFamily {
+            name: Some("open_files".to_owned()),
+            help: Some("Number of open file descriptors.".to_owned()),
+            r#type: Some(MetricType::Gauge as i32),
+            metric: vec![Metric {
+                gauge: gauge(self.0.load(Ordering::Relaxed)),
+                ..Default::default()
+            }],
+            unit: None,
+        }]
+    }
+}
+
+#[test]
+fn a_custom_metric_can_be_registered_and_collected() {
+    let files = OpenFiles::default();
+    files.0.store(7, Ordering::Relaxed);
+
+    register(
+        Box::new(files) as Box<dyn EncodeMetric>,
+        RegistrationMetadata::default(),
+    );
+
+    let families = collected();
+    let family = family_named(&families, "open_files");
+
+    assert_eq!(
+        family.metric[0]
+            .gauge
+            .as_ref()
+            .and_then(|gauge| gauge.value),
+        Some(7.0)
+    );
+}
+
+/// Differentiating by label set through [`EncodeMetric`] alone means owning the
+/// storage, the sharing, the label serialization, and the row assembly.
+#[derive(Clone, Default)]
+struct OpenFilesPerMount {
+    values: Arc<RwLock<HashMap<Labels, Arc<AtomicU64>>>>,
+}
+
+impl OpenFilesPerMount {
+    fn get_or_create(&self, labels: &Labels) -> Arc<AtomicU64> {
+        if let Some(value) = self.values.read().unwrap().get(labels) {
+            return Arc::clone(value);
+        }
+
+        Arc::clone(
+            self.values
+                .write()
+                .unwrap()
+                .entry(labels.clone())
+                .or_default(),
+        )
+    }
+}
+
+impl EncodeMetric for OpenFilesPerMount {
+    fn encode(&self) -> Vec<MetricFamily> {
+        let values = self.values.read().unwrap();
+        let mut rows = Vec::with_capacity(values.len());
+
+        for (labels, value) in values.iter() {
+            let Ok(label) = to_label_pairs(labels) else {
+                continue;
+            };
+
+            rows.push(Metric {
+                label,
+                gauge: gauge(value.load(Ordering::Relaxed)),
+                ..Default::default()
+            });
+        }
+
+        vec![MetricFamily {
+            name: Some("open_files_per_mount".to_owned()),
+            help: Some("Open file descriptors.".to_owned()),
+            r#type: Some(MetricType::Gauge as i32),
+            metric: rows,
+            unit: None,
+        }]
+    }
+}
+
+/// Implementing [`EncodeMetricValue`] instead delegates all of that to
+/// [`Family`] and [`NamedMetric`]; only the value encoding remains.
+#[derive(Default)]
+struct OpenFilesValue(AtomicU64);
+
+impl EncodeMetricValue for OpenFilesValue {
+    fn encode_metric_value(&self) -> Vec<MetricFamily> {
+        vec![MetricFamily {
+            // Relative name: `NamedMetric` prepends the registered name.
+            name: Some(String::new()),
+            help: None,
+            r#type: Some(MetricType::Gauge as i32),
+            metric: vec![Metric {
+                gauge: gauge(self.0.load(Ordering::Relaxed)),
+                ..Default::default()
+            }],
+            unit: None,
+        }]
+    }
+}
+
+#[test]
+fn both_label_set_approaches_produce_the_same_series() {
+    let manual = OpenFilesPerMount::default();
+    manual
+        .get_or_create(&Labels { mount: "/data" })
+        .store(3, Ordering::Relaxed);
+    register(
+        Box::new(manual.clone()) as Box<dyn EncodeMetric>,
+        RegistrationMetadata::default(),
+    );
+
+    let via_family = Family::<Labels, OpenFilesValue>::default();
+    via_family
+        .get_or_create(&Labels { mount: "/data" })
+        .0
+        .store(3, Ordering::Relaxed);
+    register(
+        Box::new(NamedMetric::new(
+            "open_files_via_family",
+            "Open file descriptors.",
+            via_family,
+        )) as Box<dyn EncodeMetric>,
+        RegistrationMetadata::default(),
+    );
+
+    let families = collected();
+    let manual = &family_named(&families, "open_files_per_mount").metric[0];
+    let via_family = &family_named(&families, "open_files_via_family").metric[0];
+
+    assert_eq!(manual.label, via_family.label);
+    assert_eq!(
+        manual.gauge.as_ref().and_then(|gauge| gauge.value),
+        via_family.gauge.as_ref().and_then(|gauge| gauge.value)
+    );
+    assert_eq!(
+        manual.gauge.as_ref().and_then(|gauge| gauge.value),
+        Some(3.0)
+    );
+}

--- a/foundations-sentry/tests/sentry_hook.rs
+++ b/foundations-sentry/tests/sentry_hook.rs
@@ -34,10 +34,6 @@ fn sentry_hook_increments_metric_on_event() {
     simulate_sentry_event(&hub);
     assert_eq!(metrics::sentry::events_total(Level::Error).get(), 1);
 
-    // Compare the value numerically rather than textually: the classic
-    // Prometheus text format renders integral counters as `1`, while
-    // `foundations-metrics` renders its protobuf double as `1.0`. Both denote the
-    // same series with the same value.
     const SERIES: &str = "sentry_events_total{level=\"error\"} ";
 
     let metrics = foundations::telemetry::metrics::collect(&Default::default()).unwrap();

--- a/foundations-sentry/tests/sentry_hook.rs
+++ b/foundations-sentry/tests/sentry_hook.rs
@@ -34,10 +34,18 @@ fn sentry_hook_increments_metric_on_event() {
     simulate_sentry_event(&hub);
     assert_eq!(metrics::sentry::events_total(Level::Error).get(), 1);
 
+    // Compare the value numerically rather than textually: the classic
+    // Prometheus text format renders integral counters as `1`, while
+    // `foundations-metrics` renders its protobuf double as `1.0`. Both denote the
+    // same series with the same value.
+    const SERIES: &str = "sentry_events_total{level=\"error\"} ";
+
     let metrics = foundations::telemetry::metrics::collect(&Default::default()).unwrap();
-    let has_metric = metrics
-        .lines()
-        .any(|line| line == "sentry_events_total{level=\"error\"} 1");
+    let has_metric = metrics.lines().any(|line| {
+        line.strip_prefix(SERIES)
+            .and_then(|value| value.parse::<f64>().ok())
+            == Some(1.0)
+    });
     assert!(has_metric);
 }
 

--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -218,10 +218,6 @@ tracing-rs-compat = ["dep:tracing-slog"]
 # Selects the `foundations-metrics` implementation behind `telemetry::metrics`.
 # The `metrics` macro expands identically either way: it emits paths that this
 # crate resolves, so the macro needs no feature of its own.
-#
-# The substitution is shape-compatible, which makes this a transition aid and
-# not the destination: depend on `foundations-metrics` and import from it
-# directly instead of reaching it through this facade.
 foundations-metrics-backend = ["dep:foundations-metrics", "dep:foundations-metrics-registry"]
 
 [package.metadata.docs.rs]

--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -218,6 +218,10 @@ tracing-rs-compat = ["dep:tracing-slog"]
 # Selects the `foundations-metrics` implementation behind `telemetry::metrics`.
 # The `metrics` macro expands identically either way: it emits paths that this
 # crate resolves, so the macro needs no feature of its own.
+#
+# The substitution is shape-compatible, which makes this a transition aid and
+# not the destination: depend on `foundations-metrics` and import from it
+# directly instead of reaching it through this facade.
 foundations-metrics-backend = ["dep:foundations-metrics", "dep:foundations-metrics-registry"]
 
 [package.metadata.docs.rs]

--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -33,7 +33,7 @@ pre-release-hook = [
 
 [features]
 # Default set of features.
-default = ["platform-common-default", "security"]
+default = ["platform-common-default", "security", "foundations-metrics-backend"]
 
 # All non platform-specific features
 platform-common-default = [
@@ -215,6 +215,11 @@ telemetry-server-pattern-routing = []
 # logging drain that forwards logs
 tracing-rs-compat = ["dep:tracing-slog"]
 
+# Selects the `foundations-metrics` implementation behind `telemetry::metrics`.
+# The `metrics` macro expands identically either way: it emits paths that this
+# crate resolves, so the macro needs no feature of its own.
+foundations-metrics-backend = ["dep:foundations-metrics", "dep:foundations-metrics-registry"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "foundations_docsrs", "--cfg", "tokio_unstable", "--cfg", "foundations_unstable"]
@@ -229,6 +234,8 @@ workspace = true
 anyhow = { workspace = true, features = ["backtrace", "std"] }
 backtrace = { workspace = true, optional = true }
 foundations-macros = { workspace = true, optional = true, default-features = false }
+foundations-metrics = { workspace = true, optional = true, default-features = false }
+foundations-metrics-registry = { workspace = true, optional = true, default-features = false }
 cf-rustracing = { workspace = true, optional = true }
 cf-rustracing-jaeger = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }

--- a/foundations/src/telemetry/metrics/init.rs
+++ b/foundations/src/telemetry/metrics/init.rs
@@ -44,7 +44,17 @@ pub(super) fn service_name() -> &'static str {
 ///
 /// Must be called before any use of metrics defined
 /// by the `metrics` proc macro attribute.
-pub(crate) fn init(service_info: &ServiceInfo, settings: &MetricsSettings) {
+///
+/// # Errors
+///
+/// Fails if the configured service label name cannot be encoded.
+pub(crate) fn init(
+    service_info: &ServiceInfo,
+    settings: &MetricsSettings,
+) -> crate::BootstrapResult<()> {
+    #[cfg(feature = "foundations-metrics-backend")]
+    validate_service_name_format(settings)?;
+
     #[cfg(not(feature = "foundations-metrics-backend"))]
     let first_install = Registries::init(service_info, settings);
 
@@ -73,5 +83,70 @@ pub(crate) fn init(service_info: &ServiceInfo, settings: &MetricsSettings) {
         report_info(RuntimeInfo {
             pid: std::process::id(),
         });
+    }
+
+    Ok(())
+}
+
+/// Rejects a service label name that collection could not encode.
+///
+/// The setting is fixed for the process lifetime, so checking it here only
+/// changes how it is discovered: collection skips every metric family, leaving a
+/// scrape that reads as a healthy process exporting nothing. Failing startup
+/// names the setting at fault instead.
+#[cfg(feature = "foundations-metrics-backend")]
+fn validate_service_name_format(settings: &MetricsSettings) -> crate::BootstrapResult<()> {
+    use crate::telemetry::settings::ServiceNameFormat;
+
+    if let ServiceNameFormat::LabelWithName(label_name) = &settings.service_name_format
+        && !foundations_metrics::is_valid_name(label_name)
+    {
+        anyhow::bail!(
+            "metrics.service_name_format label name {label_name:?} cannot be encoded; expected {}",
+            foundations_metrics::NAME_REQUIREMENT,
+        );
+    }
+
+    Ok(())
+}
+
+/// Tested here rather than through `telemetry::init`, which refuses to run twice
+/// per process and so cannot assert the accepting and rejecting cases together.
+#[cfg(all(test, feature = "foundations-metrics-backend", feature = "settings"))]
+mod service_name_format_tests {
+    use super::*;
+    use crate::telemetry::settings::ServiceNameFormat;
+
+    fn validate(format: ServiceNameFormat) -> crate::BootstrapResult<()> {
+        validate_service_name_format(&MetricsSettings {
+            service_name_format: format,
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn usable_label_names_are_accepted() {
+        for name in ["service", "app_name", "a", "sérvice", "with space"] {
+            assert!(
+                validate(ServiceNameFormat::LabelWithName(name.to_owned())).is_ok(),
+                "{name:?} is encodable and should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn unencodable_label_names_are_rejected() {
+        for name in ["", "\0", "ser\0vice"] {
+            assert!(
+                validate(ServiceNameFormat::LabelWithName(name.to_owned())).is_err(),
+                "{name:?} cannot be encoded and should be rejected"
+            );
+        }
+    }
+
+    /// Prefixing composes a family name that the encoders validate themselves.
+    #[test]
+    fn metric_prefix_format_is_not_subject_to_the_check() {
+        assert!(validate(ServiceNameFormat::MetricPrefix).is_ok());
     }
 }

--- a/foundations/src/telemetry/metrics/init.rs
+++ b/foundations/src/telemetry/metrics/init.rs
@@ -1,19 +1,75 @@
-use super::internal::{BuildInfo, Registries, RuntimeInfo};
-use super::report_info;
+#[cfg(feature = "foundations-metrics-backend")]
+use std::sync::OnceLock;
+
 use crate::ServiceInfo;
 use crate::telemetry::settings::MetricsSettings;
+
+#[cfg(not(feature = "foundations-metrics-backend"))]
+use super::internal::Registries;
+use super::{info_metric, report_info};
+
+/// Build and version information
+#[info_metric(crate_path = "crate")]
+struct BuildInfo {
+    version: &'static str,
+}
+
+/// Information about the process runtime
+#[info_metric(crate_path = "crate")]
+struct RuntimeInfo {
+    pid: u32,
+}
+
+/// Service name reported before [`init`] has been called.
+#[cfg(feature = "foundations-metrics-backend")]
+static UNINITIALISED_SERVICE_NAME: &str = "undefined";
+
+#[cfg(feature = "foundations-metrics-backend")]
+static SERVICE_NAME: OnceLock<String> = OnceLock::new();
+
+/// Returns the service name to apply when collecting metrics.
+///
+/// Reads without initialising, so collecting before [`init`] falls back to
+/// [`UNINITIALISED_SERVICE_NAME`] without preventing a later [`init`] from
+/// taking effect.
+#[cfg(feature = "foundations-metrics-backend")]
+pub(super) fn service_name() -> &'static str {
+    SERVICE_NAME
+        .get()
+        .map(String::as_str)
+        .unwrap_or(UNINITIALISED_SERVICE_NAME)
+}
 
 /// Initializes the metric system with a system-wide metric prefix.
 ///
 /// Must be called before any use of metrics defined
 /// by the `metrics` proc macro attribute.
 pub(crate) fn init(service_info: &ServiceInfo, settings: &MetricsSettings) {
+    #[cfg(not(feature = "foundations-metrics-backend"))]
     let first_install = Registries::init(service_info, settings);
+
+    // Only the service name is kept. How it is represented is read from the
+    // settings passed to collection.
+    #[cfg(feature = "foundations-metrics-backend")]
+    let first_install = {
+        let _ = settings; // format is read at collect time
+
+        // `foundations-metrics` defaults to reporting non-fatal collection
+        // diagnostics on stderr; route them through telemetry instead. A hook
+        // installed by the service takes precedence.
+        let _ = foundations_metrics::set_collect_error_hook(|args| {
+            super::report_nonfatal_collect_error(&args);
+        });
+
+        SERVICE_NAME
+            .set(service_info.name_in_metrics.clone())
+            .is_ok()
+    };
+
     if first_install {
         report_info(BuildInfo {
             version: service_info.version,
         });
-
         report_info(RuntimeInfo {
             pid: std::process::id(),
         });

--- a/foundations/src/telemetry/metrics/init.rs
+++ b/foundations/src/telemetry/metrics/init.rs
@@ -58,8 +58,6 @@ pub(crate) fn init(
     #[cfg(not(feature = "foundations-metrics-backend"))]
     let first_install = Registries::init(service_info, settings);
 
-    // Only the service name is kept. How it is represented is read from the
-    // settings passed to collection.
     #[cfg(feature = "foundations-metrics-backend")]
     let first_install = {
         let _ = settings; // format is read at collect time

--- a/foundations/src/telemetry/metrics/internal.rs
+++ b/foundations/src/telemetry/metrics/internal.rs
@@ -1,3 +1,9 @@
+//! Registries backing the legacy metrics implementation.
+//!
+//! Extra producers are deprecated but still carried here until this
+//! implementation is removed, so their use is allowed throughout the module.
+#![allow(deprecated)]
+
 use super::rewind::{RewindState, RewindTo};
 use super::{ExtraProducer, InfoMetric, report_nonfatal_collect_error};
 use crate::telemetry::settings::{MetricsSettings, ServiceNameFormat};

--- a/foundations/src/telemetry/metrics/internal.rs
+++ b/foundations/src/telemetry/metrics/internal.rs
@@ -1,4 +1,4 @@
-//! Registries backing the legacy metrics implementation.
+//! Registries backing the deprecated metrics implementation.
 //!
 //! Extra producers are deprecated but still carried here until this
 //! implementation is removed, so their use is allowed throughout the module.

--- a/foundations/src/telemetry/metrics/internal.rs
+++ b/foundations/src/telemetry/metrics/internal.rs
@@ -218,6 +218,26 @@ pub fn wrap_metric(metric: impl SendSyncEncodeMetric + 'static) -> Box<dyn SendS
     Box::new(RewindErrorEncode(metric))
 }
 
+/// Registers a metric declared through the [`metrics`](super::metrics) macro.
+///
+/// `full_name` is unused here: the exported name is composed by the registries
+/// from the service prefix, the `subsystem` sub-registry, and `name`.
+pub fn register_metric<M>(
+    subsystem: &'static str,
+    name: &'static str,
+    _full_name: &'static str,
+    help: &'static str,
+    metric: M,
+    optional: bool,
+    with_service_prefix: bool,
+) where
+    M: SendSyncEncodeMetric + 'static,
+{
+    let mut registry = Registries::get_subsystem(subsystem, optional, with_service_prefix);
+
+    registry.register(name, help, wrap_metric(metric));
+}
+
 fn encode_registry(buffer: &mut Vec<u8>, registry: &Registry<impl EncodeMetric>) -> Result<()> {
     ENCODER_REWIND_STATE.with(|s| {
         let mut writer = s.activate(buffer);

--- a/foundations/src/telemetry/metrics/internal.rs
+++ b/foundations/src/telemetry/metrics/internal.rs
@@ -1,5 +1,5 @@
 use super::rewind::{RewindState, RewindTo};
-use super::{ExtraProducer, InfoMetric, info_metric, report_nonfatal_collect_error};
+use super::{ExtraProducer, InfoMetric, report_nonfatal_collect_error};
 use crate::telemetry::settings::{MetricsSettings, ServiceNameFormat};
 use crate::{Result, ServiceInfo};
 use prometheus_client::encoding::text::{EncodeMetric, Encoder, SendSyncEncodeMetric, encode};
@@ -144,18 +144,6 @@ impl Registries {
             extra_producers: Default::default(),
         })
     }
-}
-
-/// Build and version information
-#[info_metric(crate_path = "crate")]
-pub(super) struct BuildInfo {
-    pub(super) version: &'static str,
-}
-
-/// Information about the process runtime
-#[info_metric(crate_path = "crate")]
-pub(super) struct RuntimeInfo {
-    pub(super) pid: u32,
 }
 
 pub(super) trait ErasedInfoMetric: erased_serde::Serialize + Send + Sync + 'static {

--- a/foundations/src/telemetry/metrics/internal_backend.rs
+++ b/foundations/src/telemetry/metrics/internal_backend.rs
@@ -1,17 +1,11 @@
 //! Registration glue used by the [`metrics`](super::metrics) macro when the
 //! `foundations-metrics` backend is enabled.
-//!
-//! This module mirrors the surface that the macro expects from the legacy
-//! `internal` module, so the macro expands to the same tokens under both
-//! backends.
 
 use foundations_metrics::{EncodeMetric, NamedMetric, RegistrationMetadata, register};
 
 /// Registers a metric declared through the [`metrics`](super::metrics) macro.
 ///
-/// `subsystem` and `name` are only meaningful to the legacy backend, which
-/// composes the exported name through nested registries. Here the macro
-/// supplies the already composed `full_name`, and the service name is applied
+/// Here the macro supplies the already composed `full_name`, and the service name is applied
 /// at collection time.
 pub fn register_metric<M>(
     _subsystem: &'static str,

--- a/foundations/src/telemetry/metrics/internal_backend.rs
+++ b/foundations/src/telemetry/metrics/internal_backend.rs
@@ -1,0 +1,33 @@
+//! Registration glue used by the [`metrics`](super::metrics) macro when the
+//! `foundations-metrics` backend is enabled.
+//!
+//! This module mirrors the surface that the macro expects from the legacy
+//! `internal` module, so the macro expands to the same tokens under both
+//! backends.
+
+use foundations_metrics::{EncodeMetric, NamedMetric, RegistrationMetadata, register};
+
+/// Registers a metric declared through the [`metrics`](super::metrics) macro.
+///
+/// `subsystem` and `name` are only meaningful to the legacy backend, which
+/// composes the exported name through nested registries. Here the macro
+/// supplies the already composed `full_name`, and the service name is applied
+/// at collection time.
+pub fn register_metric<M>(
+    _subsystem: &'static str,
+    _name: &'static str,
+    full_name: &'static str,
+    help: &'static str,
+    metric: M,
+    optional: bool,
+    with_service_prefix: bool,
+) where
+    NamedMetric<M>: EncodeMetric,
+{
+    register(
+        Box::new(NamedMetric::new(full_name, help, metric)) as Box<dyn EncodeMetric>,
+        RegistrationMetadata::default()
+            .optional(optional)
+            .unprefixed(!with_service_prefix),
+    );
+}

--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -111,6 +111,7 @@ pub fn collect(settings: &MetricsSettings) -> Result<String> {
         // is dropped here and re-added once everything has been produced.
         truncate_eof(&mut buffer);
 
+        #[allow(deprecated)]
         if let Some(producers) = EXTRA_PRODUCERS.get() {
             for producer in producers.read().iter() {
                 producer.produce(&mut buffer);
@@ -564,10 +565,14 @@ impl MetricConstructor<TimeHistogram> for HistogramBuilder {
 ///
 /// cache.register_metrics(&mut sub_registry);
 ///
+/// # #[allow(deprecated)]
 /// foundations::telemetry::metrics::add_extra_producer(move |buffer: &mut Vec<u8>| {
 ///     prometheus_client::encoding::text::encode(buffer, &registry).unwrap();
 /// });
 /// ```
+#[deprecated = "Text output bypasses validation and cannot be encoded as protobuf. Implement `EncodeMetric` and pass it to `register` instead, enabling the `foundations-metrics-backend` feature if it is disabled."]
+// TODO: remove before next major release
+#[allow(deprecated)]
 pub fn add_extra_producer<P>(p: P)
 where
     P: ExtraProducer + 'static,
@@ -587,16 +592,20 @@ where
 /// The metric registry only holds metrics that encode into the protobuf data
 /// model, so text-emitting producers are kept here instead.
 #[cfg(feature = "foundations-metrics-backend")]
+#[allow(deprecated)]
 static EXTRA_PRODUCERS: OnceLock<parking_lot::RwLock<Vec<Box<dyn ExtraProducer>>>> =
     OnceLock::new();
 
 /// Describes something that can expand prometheus metrics but appending
 /// them in a text format to a provided buffer.
+#[deprecated = "Text output bypasses validation and cannot be encoded as protobuf. Implement `EncodeMetric` instead, enabling the `foundations-metrics-backend` feature if it is disabled."]
+// TODO: remove before next major release
 pub trait ExtraProducer: Send + Sync {
     /// Takes a buffer and appends prometheus metrics in text format into it.
     fn produce(&self, buffer: &mut Vec<u8>);
 }
 
+#[allow(deprecated)]
 impl<F> ExtraProducer for F
 where
     F: Fn(&mut Vec<u8>) + Send + Sync,

--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -11,38 +11,105 @@
 
 use super::settings::MetricsSettings;
 use crate::Result;
-use prometheus::{Encoder, TextEncoder};
-use serde::Serialize;
-use std::any::TypeId;
 use std::fmt::Display;
 
+#[cfg(not(feature = "foundations-metrics-backend"))]
+use prometheus::{Encoder, TextEncoder};
+#[cfg(not(feature = "foundations-metrics-backend"))]
+use serde::Serialize;
+#[cfg(not(feature = "foundations-metrics-backend"))]
+use std::any::TypeId;
+
+// Aliased so it does not shadow the glob-re-exported `backend::ServiceNameFormat`.
+#[cfg(feature = "foundations-metrics-backend")]
+use super::settings::ServiceNameFormat as SettingsServiceNameFormat;
+#[cfg(feature = "foundations-metrics-backend")]
+use std::sync::OnceLock;
+
+#[cfg(not(feature = "foundations-metrics-backend"))]
 mod gauge;
+#[cfg(not(feature = "foundations-metrics-backend"))]
 mod rewind;
 
 pub(super) mod init;
 
 #[doc(hidden)]
+#[cfg(not(feature = "foundations-metrics-backend"))]
 pub mod internal;
 
+#[doc(hidden)]
+#[cfg(feature = "foundations-metrics-backend")]
+#[path = "internal_backend.rs"]
+pub mod internal;
+
+#[cfg(not(feature = "foundations-metrics-backend"))]
 use internal::{ErasedInfoMetric, Registries};
 
-pub use gauge::{GaugeGuard, RangeGauge};
-pub use prometheus_client::metrics::exemplar::{CounterWithExemplar, HistogramWithExemplars};
-pub use prometheus_client::metrics::family::MetricConstructor;
-pub use prometheus_client::metrics::gauge::Gauge;
-pub use prometheus_client::metrics::histogram::Histogram;
-pub use prometools::histogram::{HistogramTimer, TimeHistogram};
-pub use prometools::nonstandard::NonstandardUnsuffixedCounter as Counter;
-pub use prometools::serde::Family;
+#[cfg(feature = "foundations-metrics-backend")]
+mod backend {
+    pub use foundations_metrics::{
+        Counter, CounterWithExemplar, Family, Gauge, GaugeGuard, Histogram, HistogramTimer,
+        HistogramWithExemplars, InfoMetric, MetricConstructor, RangeGauge, TimeHistogram,
+    };
+}
+#[cfg(not(feature = "foundations-metrics-backend"))]
+mod backend {
+    pub use super::gauge::{GaugeGuard, RangeGauge};
+    pub use prometheus_client::metrics::exemplar::{CounterWithExemplar, HistogramWithExemplars};
+    pub use prometheus_client::metrics::family::MetricConstructor;
+    pub use prometheus_client::metrics::gauge::Gauge;
+    pub use prometheus_client::metrics::histogram::Histogram;
+    pub use prometools::histogram::{HistogramTimer, TimeHistogram};
+    pub use prometools::nonstandard::NonstandardUnsuffixedCounter as Counter;
+    pub use prometools::serde::Family;
+}
+
+pub use backend::*;
 
 /// Collects all metrics in [Prometheus text format].
 ///
 /// [Prometheus text format]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
 pub fn collect(settings: &MetricsSettings) -> Result<String> {
-    let mut buffer = Vec::with_capacity(128);
+    let mut buffer: Vec<u8> = Vec::with_capacity(128);
 
-    Registries::collect(&mut buffer, settings.report_optional)?;
-    TextEncoder::new().encode(&prometheus::gather(), &mut buffer)?;
+    #[cfg(not(feature = "foundations-metrics-backend"))]
+    {
+        Registries::collect(&mut buffer, settings.report_optional)?;
+        TextEncoder::new().encode(&prometheus::gather(), &mut buffer)?;
+    }
+
+    #[cfg(feature = "foundations-metrics-backend")]
+    {
+        // The service name is only known once telemetry is initialized, so it is
+        // applied here rather than at registration time.
+        let service_name_format = match &settings.service_name_format {
+            SettingsServiceNameFormat::MetricPrefix => {
+                foundations_metrics::ServiceNameFormat::MetricPrefix
+            }
+            SettingsServiceNameFormat::LabelWithName(label_name) => {
+                foundations_metrics::ServiceNameFormat::LabelWithName(label_name)
+            }
+        };
+
+        let families = foundations_metrics::collect(foundations_metrics::CollectionOptions {
+            include_optional: settings.report_optional,
+            service_name: Some(init::service_name()),
+            service_name_format,
+        });
+
+        buffer.extend_from_slice(foundations_metrics::encode_to_text(&families).as_bytes());
+
+        // Extra producers append their own terminated output, so the terminator
+        // is dropped here and re-added once everything has been produced.
+        truncate_eof(&mut buffer);
+
+        if let Some(producers) = EXTRA_PRODUCERS.get() {
+            for producer in producers.read().iter() {
+                producer.produce(&mut buffer);
+                truncate_eof(&mut buffer);
+            }
+        }
+    }
 
     buffer.extend_from_slice(b"# EOF\n");
 
@@ -51,6 +118,16 @@ pub fn collect(settings: &MetricsSettings) -> Result<String> {
         String::from_utf8_lossy(err.as_bytes()).into_owned()
     });
     Ok(metrics_str)
+}
+
+/// Removes the trailing OpenMetrics terminator, if present.
+#[cfg(feature = "foundations-metrics-backend")]
+fn truncate_eof(buffer: &mut Vec<u8>) {
+    const EOF_MARKER: &[u8] = b"# EOF\n";
+
+    if buffer.ends_with(EOF_MARKER) {
+        buffer.truncate(buffer.len() - EOF_MARKER.len());
+    }
 }
 
 #[inline]
@@ -343,6 +420,7 @@ pub use foundations_macros::info_metric;
 /// Info metrics are used to expose textual information, through the label set, which should not
 /// change often during process lifetime. Common examples are an application's version, revision
 /// control commit, and the version of a compiler.
+#[cfg(not(feature = "foundations-metrics-backend"))]
 pub trait InfoMetric: Serialize + Send + Sync + 'static {
     /// The name of the info metric.
     const NAME: &'static str;
@@ -372,10 +450,18 @@ pub fn report_info<M>(info_metric: impl Into<Box<M>>)
 where
     M: InfoMetric,
 {
-    Registries::get().info.write().insert(
-        TypeId::of::<M>(),
-        info_metric.into() as Box<dyn ErasedInfoMetric>,
-    );
+    #[cfg(not(feature = "foundations-metrics-backend"))]
+    {
+        Registries::get().info.write().insert(
+            TypeId::of::<M>(),
+            info_metric.into() as Box<dyn ErasedInfoMetric>,
+        );
+    }
+
+    #[cfg(feature = "foundations-metrics-backend")]
+    {
+        foundations_metrics::report_info(info_metric);
+    }
 }
 
 /// A builder suitable for [`Histogram`] and [`TimeHistogram`].
@@ -478,8 +564,23 @@ pub fn add_extra_producer<P>(p: P)
 where
     P: ExtraProducer + 'static,
 {
+    #[cfg(not(feature = "foundations-metrics-backend"))]
     Registries::get().add_extra_producer(Box::new(p));
+
+    #[cfg(feature = "foundations-metrics-backend")]
+    EXTRA_PRODUCERS
+        .get_or_init(Default::default)
+        .write()
+        .push(Box::new(p));
 }
+
+/// Producers appended to the collected metrics, in registration order.
+///
+/// The metric registry only holds metrics that encode into the protobuf data
+/// model, so text-emitting producers are kept here instead.
+#[cfg(feature = "foundations-metrics-backend")]
+static EXTRA_PRODUCERS: OnceLock<parking_lot::RwLock<Vec<Box<dyn ExtraProducer>>>> =
+    OnceLock::new();
 
 /// Describes something that can expand prometheus metrics but appending
 /// them in a text format to a provided buffer.

--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -74,6 +74,28 @@ mod backend {
 
 pub use backend::*;
 
+/// Translates telemetry settings into collection options.
+///
+/// The service name is only known once telemetry is initialized, so it is
+/// applied at collection time rather than at registration time.
+#[cfg(feature = "foundations-metrics-backend")]
+fn collection_options(settings: &MetricsSettings) -> foundations_metrics::CollectionOptions<'_> {
+    let service_name_format = match &settings.service_name_format {
+        SettingsServiceNameFormat::MetricPrefix => {
+            foundations_metrics::ServiceNameFormat::MetricPrefix
+        }
+        SettingsServiceNameFormat::LabelWithName(label_name) => {
+            foundations_metrics::ServiceNameFormat::LabelWithName(label_name)
+        }
+    };
+
+    foundations_metrics::CollectionOptions {
+        include_optional: settings.report_optional,
+        service_name: Some(init::service_name()),
+        service_name_format,
+    }
+}
+
 /// Collects all metrics in [Prometheus text format].
 ///
 /// [Prometheus text format]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
@@ -88,22 +110,7 @@ pub fn collect(settings: &MetricsSettings) -> Result<String> {
 
     #[cfg(feature = "foundations-metrics-backend")]
     {
-        // The service name is only known once telemetry is initialized, so it is
-        // applied here rather than at registration time.
-        let service_name_format = match &settings.service_name_format {
-            SettingsServiceNameFormat::MetricPrefix => {
-                foundations_metrics::ServiceNameFormat::MetricPrefix
-            }
-            SettingsServiceNameFormat::LabelWithName(label_name) => {
-                foundations_metrics::ServiceNameFormat::LabelWithName(label_name)
-            }
-        };
-
-        let families = foundations_metrics::collect(foundations_metrics::CollectionOptions {
-            include_optional: settings.report_optional,
-            service_name: Some(init::service_name()),
-            service_name_format,
-        });
+        let families = foundations_metrics::collect(collection_options(settings));
 
         buffer.extend_from_slice(foundations_metrics::encode_to_text(&families).as_bytes());
 
@@ -127,6 +134,155 @@ pub fn collect(settings: &MetricsSettings) -> Result<String> {
         String::from_utf8_lossy(err.as_bytes()).into_owned()
     });
     Ok(metrics_str)
+}
+
+const LEGACY_CONTENT_TYPE: &str = "application/openmetrics-text; version=1.0.0; charset=utf-8";
+
+/// Wire format a scraper asked for.
+#[cfg(feature = "foundations-metrics-backend")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ScrapeFormat {
+    /// Length-delimited Prometheus protobuf, the only format able to carry
+    /// native histograms.
+    Protobuf,
+
+    /// OpenMetrics text, optionally permitted to quote UTF-8 names.
+    Text { utf8_names: bool },
+}
+
+#[cfg(feature = "foundations-metrics-backend")]
+impl ScrapeFormat {
+    /// The format assumed when a scraper expresses no usable preference.
+    const fn fallback() -> Self {
+        Self::Text { utf8_names: false }
+    }
+
+    /// Content type describing what this format produces.
+    ///
+    /// Each string is owned by the encoder that emits it, so that what is
+    /// advertised cannot drift from what is produced.
+    fn content_type(self) -> &'static str {
+        match self {
+            Self::Protobuf => foundations_metrics::PROTOBUF_CONTENT_TYPE,
+            Self::Text { utf8_names: true } => foundations_metrics::OPENMETRICS_CONTENT_TYPE,
+            Self::Text { utf8_names: false } => LEGACY_CONTENT_TYPE,
+        }
+    }
+}
+
+/// Chooses the most preferred format that the active encoder can produce, given
+/// the value of a request's `Accept` header.
+///
+/// Absent or unusable preferences fall back to legacy OpenMetrics text.
+#[cfg(feature = "foundations-metrics-backend")]
+fn negotiate(accept: Option<&str>) -> ScrapeFormat {
+    let Some(accept) = accept else {
+        return ScrapeFormat::fallback();
+    };
+
+    let mut best: Option<(f32, ScrapeFormat)> = None;
+
+    for range in accept.split(',') {
+        let mut parts = range.split(';').map(str::trim);
+        let Some(media_type) = parts.next().filter(|media| !media.is_empty()) else {
+            continue;
+        };
+
+        let mut quality = 1.0f32;
+        let (mut escaping, mut proto, mut encoding) = (None, None, None);
+
+        for parameter in parts {
+            let Some((name, value)) = parameter.split_once('=') else {
+                continue;
+            };
+
+            let value = value.trim().trim_matches('"');
+            let name = name.trim();
+
+            if name.eq_ignore_ascii_case("q") {
+                quality = value.parse().unwrap_or(1.0);
+            } else if name.eq_ignore_ascii_case("escaping") {
+                escaping = Some(value);
+            } else if name.eq_ignore_ascii_case("proto") {
+                proto = Some(value);
+            } else if name.eq_ignore_ascii_case("encoding") {
+                encoding = Some(value);
+            }
+        }
+
+        // `q=0` refuses a format outright rather than ranking it last.
+        if quality <= 0.0 {
+            continue;
+        }
+
+        let format = if media_type.eq_ignore_ascii_case("application/vnd.google.protobuf") {
+            // Only delimited streams of this message type are produced.
+            if proto.is_some_and(|proto| proto == "io.prometheus.client.MetricFamily")
+                && encoding.is_some_and(|encoding| encoding.eq_ignore_ascii_case("delimited"))
+            {
+                ScrapeFormat::Protobuf
+            } else {
+                continue;
+            }
+        } else if media_type.eq_ignore_ascii_case("application/openmetrics-text") {
+            ScrapeFormat::Text {
+                utf8_names: escaping
+                    .is_some_and(|escaping| escaping.eq_ignore_ascii_case("allow-utf-8")),
+            }
+        } else if media_type.eq_ignore_ascii_case("text/plain") || media_type == "*/*" {
+            ScrapeFormat::Text { utf8_names: false }
+        } else {
+            continue;
+        };
+
+        // Highest quality wins; ties keep the earliest listed.
+        if best.is_none_or(|(best_quality, _)| quality > best_quality) {
+            best = Some((quality, format));
+        }
+    }
+
+    best.map_or_else(ScrapeFormat::fallback, |(_, format)| format)
+}
+
+/// Collects metrics in the format a scraper asked for through its `Accept` header.
+///
+/// The content type is returned alongside the body so that the two cannot
+/// disagree; deriving one separately from the other is how a response ends up
+/// declaring a format it did not encode.
+///
+/// The negotiated escaping is currently reported rather than enforced: the text
+/// encoder quotes a name whenever that name requires it, regardless of what the
+/// scraper asked for. Names produced in-tree are all legacy compatible, so the
+/// two agree in practice.
+pub(crate) fn collect_negotiated(
+    accept: Option<&str>,
+    settings: &MetricsSettings,
+) -> Result<(&'static str, Vec<u8>)> {
+    #[cfg(feature = "foundations-metrics-backend")]
+    {
+        let format = negotiate(accept);
+
+        // Extra producers emit text, so they cannot contribute to a protobuf
+        // response; only registered metrics are encoded for it.
+        if format == ScrapeFormat::Protobuf {
+            let families = foundations_metrics::collect(collection_options(settings));
+
+            return Ok((
+                format.content_type(),
+                foundations_metrics::encode_to_protobuf(&families),
+            ));
+        }
+
+        Ok((format.content_type(), collect(settings)?.into_bytes()))
+    }
+
+    // The legacy encoder produces text only, so there is nothing to negotiate.
+    #[cfg(not(feature = "foundations-metrics-backend"))]
+    {
+        let _ = accept;
+
+        Ok((LEGACY_CONTENT_TYPE, collect(settings)?.into_bytes()))
+    }
 }
 
 /// Removes the trailing OpenMetrics terminator, if present.
@@ -612,5 +768,96 @@ where
 {
     fn produce(&self, buffer: &mut Vec<u8>) {
         self(buffer)
+    }
+}
+
+#[cfg(all(test, feature = "foundations-metrics-backend"))]
+mod negotiation_tests {
+    use super::*;
+
+    const TEXT: ScrapeFormat = ScrapeFormat::Text { utf8_names: false };
+    const TEXT_UTF8: ScrapeFormat = ScrapeFormat::Text { utf8_names: true };
+
+    #[test]
+    fn absent_header_falls_back_to_legacy_text() {
+        assert_eq!(negotiate(None), TEXT);
+    }
+
+    #[test]
+    fn prometheus_default_accept_selects_text() {
+        assert_eq!(
+            negotiate(Some(
+                "application/openmetrics-text;version=1.0.0;q=0.5,\
+                 text/plain;version=0.0.4;q=0.4,*/*;q=0.1"
+            )),
+            TEXT
+        );
+    }
+
+    #[test]
+    fn utf8_escaping_is_detected() {
+        assert_eq!(
+            negotiate(Some(
+                "application/openmetrics-text;version=1.0.0;escaping=allow-utf-8;q=0.5,*/*;q=0.1"
+            )),
+            TEXT_UTF8
+        );
+    }
+
+    #[test]
+    fn delimited_protobuf_wins_when_preferred() {
+        assert_eq!(
+            negotiate(Some(
+                "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;\
+                 encoding=delimited;q=0.5,application/openmetrics-text;version=1.0.0;q=0.4"
+            )),
+            ScrapeFormat::Protobuf
+        );
+    }
+
+    #[test]
+    fn protobuf_without_delimited_encoding_is_not_offered() {
+        assert_eq!(
+            negotiate(Some(
+                "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;q=0.9,\
+                 text/plain;q=0.1"
+            )),
+            TEXT
+        );
+    }
+
+    #[test]
+    fn zero_quality_refuses_a_format() {
+        assert_eq!(
+            negotiate(Some(
+                "application/openmetrics-text;escaping=allow-utf-8;q=0,text/plain;q=0.4"
+            )),
+            TEXT
+        );
+    }
+
+    #[test]
+    fn parameters_tolerate_whitespace_case_and_quoting() {
+        assert_eq!(
+            negotiate(Some(
+                "  APPLICATION/OpenMetrics-Text ; Version=1.0.0 ; Escaping=\"Allow-UTF-8\" ; Q=0.7 "
+            )),
+            TEXT_UTF8
+        );
+    }
+
+    #[test]
+    fn unknown_media_types_are_ignored() {
+        assert_eq!(negotiate(Some("application/json,text/html")), TEXT);
+    }
+
+    #[test]
+    fn ties_keep_the_earliest_listed() {
+        assert_eq!(
+            negotiate(Some(
+                "application/openmetrics-text;escaping=allow-utf-8;q=0.5,text/plain;q=0.5"
+            )),
+            TEXT_UTF8
+        );
     }
 }

--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -173,11 +173,13 @@ impl ScrapeFormat {
 /// Chooses the most preferred format that the active encoder can produce, given
 /// the value of a request's `Accept` header.
 ///
-/// Absent or unusable preferences fall back to legacy OpenMetrics text.
+/// `None` means the header ruled out every format this server can produce, which
+/// the caller answers with `406`. An absent header expresses no preference and
+/// yields the fallback instead.
 #[cfg(feature = "foundations-metrics-backend")]
-fn negotiate(accept: Option<&str>) -> ScrapeFormat {
+fn negotiate(accept: Option<&str>, protobuf_available: bool) -> Option<ScrapeFormat> {
     let Some(accept) = accept else {
-        return ScrapeFormat::fallback();
+        return Some(ScrapeFormat::fallback());
     };
 
     let mut best: Option<(f32, ScrapeFormat)> = None;
@@ -219,8 +221,10 @@ fn negotiate(accept: Option<&str>) -> ScrapeFormat {
         }
 
         let format = if media_type.eq_ignore_ascii_case("application/vnd.google.protobuf") {
-            // Only delimited streams of this message type are produced.
-            if proto.is_some_and(|proto| proto == "io.prometheus.client.MetricFamily")
+            // Only delimited streams of this message type are produced, and only
+            // when protobuf can carry the whole exposition.
+            if protobuf_available
+                && proto.is_some_and(|proto| proto == "io.prometheus.client.MetricFamily")
                 && encoding.is_some_and(|encoding| encoding.eq_ignore_ascii_case("delimited"))
             {
                 ScrapeFormat::Protobuf
@@ -244,7 +248,22 @@ fn negotiate(accept: Option<&str>) -> ScrapeFormat {
         }
     }
 
-    best.map_or_else(ScrapeFormat::fallback, |(_, format)| format)
+    best.map(|(_, format)| format)
+}
+
+/// Reports whether protobuf can represent everything this process exposes.
+///
+/// Extra producers hand over opaque text, which cannot be transcoded into the
+/// protobuf data model, so serving protobuf while any are registered would
+/// silently drop every series they emit.
+///
+/// Evaluated per scrape because producers may be registered at any point.
+#[cfg(feature = "foundations-metrics-backend")]
+#[allow(deprecated)]
+fn protobuf_available() -> bool {
+    EXTRA_PRODUCERS
+        .get()
+        .is_none_or(|producers| producers.read().is_empty())
 }
 
 /// Collects metrics in the format a scraper asked for through its `Accept` header.
@@ -253,6 +272,9 @@ fn negotiate(accept: Option<&str>) -> ScrapeFormat {
 /// disagree; deriving one separately from the other is how a response ends up
 /// declaring a format it did not encode.
 ///
+/// `Ok(None)` means no requested format could be served and the caller should
+/// answer `406`.
+///
 /// The negotiated escaping is currently reported rather than enforced: the text
 /// encoder quotes a name whenever that name requires it, regardless of what the
 /// scraper asked for. Names produced in-tree are all legacy compatible, so the
@@ -260,23 +282,28 @@ fn negotiate(accept: Option<&str>) -> ScrapeFormat {
 pub(crate) fn collect_negotiated(
     accept: Option<&str>,
     settings: &MetricsSettings,
-) -> Result<(&'static str, Vec<u8>)> {
+) -> Result<Option<(&'static str, Vec<u8>)>> {
     #[cfg(feature = "foundations-metrics-backend")]
     {
-        let format = negotiate(accept);
+        let Some(format) = negotiate(accept, protobuf_available()) else {
+            return Ok(None);
+        };
 
-        // Extra producers emit text, so they cannot contribute to a protobuf
-        // response; only registered metrics are encoded for it.
+        // Protobuf is only reachable with no extra producers registered, so the
+        // registry holds everything and skipping them here loses nothing.
         if format == ScrapeFormat::Protobuf {
             let families = foundations_metrics::collect(collection_options(settings));
 
-            return Ok((
+            return Ok(Some((
                 format.content_type(),
                 foundations_metrics::encode_to_protobuf(&families),
-            ));
+            )));
         }
 
-        Ok((format.content_type(), collect(settings)?.into_bytes()))
+        Ok(Some((
+            format.content_type(),
+            collect(settings)?.into_bytes(),
+        )))
     }
 
     // The legacy encoder produces text only, so there is nothing to negotiate.
@@ -284,7 +311,7 @@ pub(crate) fn collect_negotiated(
     {
         let _ = accept;
 
-        Ok((LEGACY_CONTENT_TYPE, collect(settings)?.into_bytes()))
+        Ok(Some((LEGACY_CONTENT_TYPE, collect(settings)?.into_bytes())))
     }
 }
 
@@ -778,110 +805,121 @@ where
 mod negotiation_tests {
     use super::*;
 
-    const TEXT: ScrapeFormat = ScrapeFormat::Text { utf8_names: false };
-    const TEXT_UTF8: ScrapeFormat = ScrapeFormat::Text { utf8_names: true };
+    const TEXT: Option<ScrapeFormat> = Some(ScrapeFormat::Text { utf8_names: false });
+    const TEXT_UTF8: Option<ScrapeFormat> = Some(ScrapeFormat::Text { utf8_names: true });
+    const PROTOBUF: Option<ScrapeFormat> = Some(ScrapeFormat::Protobuf);
+
+    /// What Prometheus sends unless configured to prefer protobuf.
+    const PROMETHEUS_DEFAULT: &str = "application/openmetrics-text;version=1.0.0;q=0.5,\
+                                      text/plain;version=0.0.4;q=0.4,*/*;q=0.1";
+
+    const PROTOBUF_PREFERRED: &str = "application/vnd.google.protobuf;\
+                                      proto=io.prometheus.client.MetricFamily;\
+                                      encoding=delimited;q=0.5,\
+                                      application/openmetrics-text;version=1.0.0;q=0.4";
+
+    /// Delimited protobuf and nothing else: no text range, no `*/*`.
+    const PROTOBUF_ONLY: &str = "application/vnd.google.protobuf;\
+                                 proto=io.prometheus.client.MetricFamily;encoding=delimited";
 
     #[test]
     fn absent_header_falls_back_to_legacy_text() {
-        assert_eq!(negotiate(None), TEXT);
+        assert_eq!(negotiate(None, true), TEXT);
     }
 
     #[test]
     fn prometheus_default_accept_selects_text() {
-        assert_eq!(
-            negotiate(Some(
-                "application/openmetrics-text;version=1.0.0;q=0.5,\
-                 text/plain;version=0.0.4;q=0.4,*/*;q=0.1"
-            )),
-            TEXT
-        );
+        assert_eq!(negotiate(Some(PROMETHEUS_DEFAULT), true), TEXT);
     }
 
     #[test]
     fn utf8_escaping_is_detected() {
-        assert_eq!(
-            negotiate(Some(
-                "application/openmetrics-text;version=1.0.0;escaping=allow-utf-8;q=0.5,*/*;q=0.1"
-            )),
-            TEXT_UTF8
-        );
+        let accept =
+            "application/openmetrics-text;version=1.0.0;escaping=allow-utf-8;q=0.5,*/*;q=0.1";
+
+        assert_eq!(negotiate(Some(accept), true), TEXT_UTF8);
     }
 
     #[test]
     fn delimited_protobuf_wins_when_preferred() {
-        assert_eq!(
-            negotiate(Some(
-                "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;\
-                 encoding=delimited;q=0.5,application/openmetrics-text;version=1.0.0;q=0.4"
-            )),
-            ScrapeFormat::Protobuf
-        );
+        assert_eq!(negotiate(Some(PROTOBUF_PREFERRED), true), PROTOBUF);
     }
 
     #[test]
     fn protobuf_without_delimited_encoding_is_not_offered() {
-        assert_eq!(
-            negotiate(Some(
-                "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;q=0.9,\
-                 text/plain;q=0.1"
-            )),
-            TEXT
-        );
+        let accept = "application/vnd.google.protobuf;\
+                      proto=io.prometheus.client.MetricFamily;q=0.9,text/plain;q=0.1";
+
+        assert_eq!(negotiate(Some(accept), true), TEXT);
     }
 
     #[test]
     fn zero_quality_refuses_a_format() {
-        assert_eq!(
-            negotiate(Some(
-                "application/openmetrics-text;escaping=allow-utf-8;q=0,text/plain;q=0.4"
-            )),
-            TEXT
-        );
+        let accept = "application/openmetrics-text;escaping=allow-utf-8;q=0,text/plain;q=0.4";
+
+        assert_eq!(negotiate(Some(accept), true), TEXT);
     }
 
     #[test]
     fn malformed_quality_refuses_a_format() {
-        assert_eq!(
-            negotiate(Some(
-                "application/openmetrics-text;escaping=allow-utf-8;q=garbage,text/plain;q=0.4"
-            )),
-            TEXT
-        );
-    }
+        let accept = "application/openmetrics-text;escaping=allow-utf-8;q=garbage,text/plain;q=0.4";
 
-    #[test]
-    fn malformed_quality_on_the_only_range_falls_back() {
-        assert_eq!(
-            negotiate(Some(
-                "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;\
-                 encoding=delimited;q="
-            )),
-            TEXT
-        );
+        assert_eq!(negotiate(Some(accept), true), TEXT);
     }
 
     #[test]
     fn parameters_tolerate_whitespace_case_and_quoting() {
-        assert_eq!(
-            negotiate(Some(
-                "  APPLICATION/OpenMetrics-Text ; Version=1.0.0 ; Escaping=\"Allow-UTF-8\" ; Q=0.7 "
-            )),
-            TEXT_UTF8
-        );
-    }
+        let accept =
+            "  APPLICATION/OpenMetrics-Text ; Version=1.0.0 ; Escaping=\"Allow-UTF-8\" ; Q=0.7 ";
 
-    #[test]
-    fn unknown_media_types_are_ignored() {
-        assert_eq!(negotiate(Some("application/json,text/html")), TEXT);
+        assert_eq!(negotiate(Some(accept), true), TEXT_UTF8);
     }
 
     #[test]
     fn ties_keep_the_earliest_listed() {
-        assert_eq!(
-            negotiate(Some(
-                "application/openmetrics-text;escaping=allow-utf-8;q=0.5,text/plain;q=0.5"
-            )),
-            TEXT_UTF8
-        );
+        let accept = "application/openmetrics-text;escaping=allow-utf-8;q=0.5,text/plain;q=0.5";
+
+        assert_eq!(negotiate(Some(accept), true), TEXT_UTF8);
+    }
+
+    #[test]
+    fn protobuf_is_withheld_when_unavailable() {
+        assert_eq!(negotiate(Some(PROTOBUF_PREFERRED), false), TEXT);
+    }
+
+    #[test]
+    fn withholding_protobuf_leaves_text_negotiation_untouched() {
+        let utf8 = "application/openmetrics-text;escaping=allow-utf-8;q=0.9,text/plain;q=0.1";
+
+        assert_eq!(negotiate(Some(utf8), false), TEXT_UTF8);
+        assert_eq!(negotiate(Some(PROMETHEUS_DEFAULT), false), TEXT);
+        assert_eq!(negotiate(None, false), TEXT);
+    }
+
+    /// A scraper accepting only protobuf could not read text, so refusing is more
+    /// informative than sending something it must discard.
+    #[test]
+    fn protobuf_only_is_refused_when_unavailable() {
+        assert_eq!(negotiate(Some(PROTOBUF_ONLY), false), None);
+    }
+
+    #[test]
+    fn protobuf_only_is_served_when_available() {
+        assert_eq!(negotiate(Some(PROTOBUF_ONLY), true), PROTOBUF);
+    }
+
+    #[test]
+    fn unservable_media_types_are_refused() {
+        assert_eq!(negotiate(Some("application/json,text/html"), true), None);
+    }
+
+    /// RFC 9110 §12.4.2 invalidates a range with an unparseable weight, leaving
+    /// nothing acceptable behind.
+    #[test]
+    fn malformed_quality_on_the_only_range_is_refused() {
+        let accept = "application/vnd.google.protobuf;\
+                      proto=io.prometheus.client.MetricFamily;encoding=delimited;q=";
+
+        assert_eq!(negotiate(Some(accept), true), None);
     }
 }

--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -202,10 +202,15 @@ fn negotiate(accept: Option<&str>, protobuf_available: bool) -> Option<ScrapeFor
             let name = name.trim();
 
             if name.eq_ignore_ascii_case("q") {
-                // RFC 9110: an unparseable weight invalidates the
-                // media-range. Zero is the refusal value below, so a malformed
-                // `q` drops the range rather than promoting it to the top.
-                quality = value.parse().unwrap_or(0.0);
+                // RFC 9110: a weight runs from 0 to 1, and an unusable one
+                // invalidates the media-range. Zero is the refusal value below.
+                // The bound also excludes `nan` and `inf`, which `parse`
+                // accepts: `NaN` loses no comparison so it would pin itself as
+                // the winner, and `inf` would outrank a legitimate `q=1.0`.
+                quality = match value.parse::<f32>() {
+                    Ok(parsed) if (0.0..=1.0).contains(&parsed) => parsed,
+                    _ => 0.0,
+                };
             } else if name.eq_ignore_ascii_case("escaping") {
                 escaping = Some(value);
             } else if name.eq_ignore_ascii_case("proto") {
@@ -956,6 +961,54 @@ mod negotiation_tests {
                       proto=io.prometheus.client.MetricFamily;encoding=delimited;q=";
 
         assert_eq!(negotiate(Some(accept), true), None);
+    }
+
+    /// `"nan"` and `"inf"` parse as floats, so parsing alone does not make a
+    /// weight usable.
+    #[test]
+    fn unrankable_quality_matches_nothing() {
+        for weight in [
+            "nan", "NaN", "+nan", "inf", "infinity", "-inf", "2", "1e3", "-0.5",
+        ] {
+            let accept = format!("application/openmetrics-text;q={weight}");
+
+            assert_eq!(
+                negotiate(Some(&accept), true),
+                None,
+                "q={weight} should invalidate the range"
+            );
+        }
+    }
+
+    /// `NaN` loses no comparison, so ranking it last is not enough: it would
+    /// stay `best` and discard the format actually preferred.
+    #[test]
+    fn unrankable_quality_does_not_mask_a_later_range() {
+        let accept = format!("application/openmetrics-text;q=nan,{PROTOBUF_PREFERRED}");
+
+        assert_eq!(negotiate(Some(&accept), true), PROTOBUF);
+    }
+
+    /// The escapings differ so the assertion fails if `q=5` is ranked rather
+    /// than refused.
+    #[test]
+    fn out_of_range_quality_does_not_outrank_the_maximum() {
+        let accept = "application/openmetrics-text;escaping=allow-utf-8;q=5,text/plain;q=1.0";
+
+        assert_eq!(negotiate(Some(accept), true), TEXT);
+    }
+
+    /// The boundary values of the spec range stay usable.
+    #[test]
+    fn quality_bounds_are_accepted() {
+        assert_eq!(
+            negotiate(Some("application/openmetrics-text;q=1.000"), true),
+            TEXT
+        );
+        assert_eq!(
+            negotiate(Some("application/openmetrics-text;q=0.001"), true),
+            TEXT
+        );
     }
 }
 

--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -200,7 +200,10 @@ fn negotiate(accept: Option<&str>) -> ScrapeFormat {
             let name = name.trim();
 
             if name.eq_ignore_ascii_case("q") {
-                quality = value.parse().unwrap_or(1.0);
+                // RFC 9110 §12.4.2: an unparseable weight invalidates the
+                // media-range. Zero is the refusal value below, so a malformed
+                // `q` drops the range rather than promoting it to the top.
+                quality = value.parse().unwrap_or(0.0);
             } else if name.eq_ignore_ascii_case("escaping") {
                 escaping = Some(value);
             } else if name.eq_ignore_ascii_case("proto") {
@@ -831,6 +834,27 @@ mod negotiation_tests {
         assert_eq!(
             negotiate(Some(
                 "application/openmetrics-text;escaping=allow-utf-8;q=0,text/plain;q=0.4"
+            )),
+            TEXT
+        );
+    }
+
+    #[test]
+    fn malformed_quality_refuses_a_format() {
+        assert_eq!(
+            negotiate(Some(
+                "application/openmetrics-text;escaping=allow-utf-8;q=garbage,text/plain;q=0.4"
+            )),
+            TEXT
+        );
+    }
+
+    #[test]
+    fn malformed_quality_on_the_only_range_falls_back() {
+        assert_eq!(
+            negotiate(Some(
+                "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;\
+                 encoding=delimited;q="
             )),
             TEXT
         );

--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -48,9 +48,9 @@ use internal::{ErasedInfoMetric, Registries};
 #[cfg(feature = "foundations-metrics-backend")]
 mod backend {
     pub use foundations_metrics::{
-        Counter, CounterWithExemplar, Family, Gauge, GaugeGuard, Histogram, HistogramTimer,
-        HistogramWithExemplars, InfoMetric, MetricConstructor, NativeHistogram,
-        NativeHistogramBuilder, NativeHistogramWithExemplars, RangeGauge, TimeHistogram,
+        Counter, Family, Gauge, GaugeGuard, Histogram, HistogramTimer, InfoMetric,
+        MetricConstructor, NativeHistogram, NativeHistogramBuilder, RangeGauge, TimeHistogram,
+        WithExemplar,
     };
 
     // Everything needed to define, register, and label a custom metric. The
@@ -380,11 +380,12 @@ fn report_nonfatal_collect_error(err: &dyn Display) {
 /// are reexported from this module for convenience:
 ///
 /// * [`Counter`]
-/// * [`CounterWithExemplar`]
 /// * [`Gauge`]
 /// * [`Histogram`]
-/// * [`HistogramWithExemplars`]
 /// * [`TimeHistogram`]
+///
+/// To attach exemplars, wrap any of the above in the `WithExemplar<T, S>` smart
+/// pointer, which derefs to the metric it wraps.
 ///
 /// The metrics associated with the functions are automatically registered in a global
 /// registry, and they can be collected with the [`collect`] function.
@@ -721,9 +722,20 @@ impl MetricConstructor<Histogram> for HistogramBuilder {
     }
 }
 
+#[cfg(not(feature = "foundations-metrics-backend"))]
 impl<S> MetricConstructor<HistogramWithExemplars<S>> for HistogramBuilder {
     fn new_metric(&self) -> HistogramWithExemplars<S> {
         HistogramWithExemplars::new(self.buckets.iter().cloned())
+    }
+}
+
+// The `foundations-metrics` backend replaces the per-type exemplar wrappers
+// with a single generic `WithExemplar<T, S>`, so the builder constructs that
+// instead.
+#[cfg(feature = "foundations-metrics-backend")]
+impl<S> MetricConstructor<WithExemplar<Histogram, S>> for HistogramBuilder {
+    fn new_metric(&self) -> WithExemplar<Histogram, S> {
+        WithExemplar::new(MetricConstructor::<Histogram>::new_metric(self))
     }
 }
 

--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -202,11 +202,6 @@ fn negotiate(accept: Option<&str>, protobuf_available: bool) -> Option<ScrapeFor
             let name = name.trim();
 
             if name.eq_ignore_ascii_case("q") {
-                // RFC 9110: a weight runs from 0 to 1, and an unusable one
-                // invalidates the media-range. Zero is the refusal value below.
-                // The bound also excludes `nan` and `inf`, which `parse`
-                // accepts: `NaN` loses no comparison so it would pin itself as
-                // the winner, and `inf` would outrank a legitimate `q=1.0`.
                 quality = match value.parse::<f32>() {
                     Ok(parsed) if (0.0..=1.0).contains(&parsed) => parsed,
                     _ => 0.0,
@@ -282,8 +277,7 @@ fn protobuf_available() -> bool {
 ///
 /// The negotiated escaping is currently reported rather than enforced: the text
 /// encoder quotes a name whenever that name requires it, regardless of what the
-/// scraper asked for. Names produced in-tree are all legacy compatible, so the
-/// two agree in practice.
+/// scraper asked for.
 pub fn collect_negotiated(
     accept: Option<&str>,
     settings: &MetricsSettings,
@@ -314,7 +308,6 @@ pub fn collect_negotiated(
         Ok((format.content_type(), collect(settings)?.into_bytes()))
     }
 
-    // The legacy encoder produces text only, so there is nothing to negotiate.
     #[cfg(not(feature = "foundations-metrics-backend"))]
     {
         let _ = accept;
@@ -814,9 +807,6 @@ where
 }
 
 /// Producers appended to the collected metrics, in registration order.
-///
-/// The metric registry only holds metrics that encode into the protobuf data
-/// model, so text-emitting producers are kept here instead.
 #[cfg(feature = "foundations-metrics-backend")]
 #[allow(deprecated)]
 static EXTRA_PRODUCERS: OnceLock<parking_lot::RwLock<Vec<Box<dyn ExtraProducer>>>> =
@@ -900,10 +890,6 @@ mod negotiation_tests {
         assert_eq!(negotiate(Some(accept), true), TEXT);
     }
 
-    /// `q=0` means "not acceptable" (RFC 9110), so a header offering
-    /// nothing else leaves nothing to serve. Refusing the range outright, rather
-    /// than merely ranking it last, is what keeps it from being selected as the
-    /// only remaining candidate.
     #[test]
     fn zero_quality_on_the_only_range_matches_nothing() {
         assert_eq!(
@@ -948,7 +934,6 @@ mod negotiation_tests {
         assert_eq!(negotiate(None, false), TEXT);
     }
 
-    /// Nothing is servable to a protobuf-only scraper once protobuf is withheld.
     #[test]
     fn protobuf_only_matches_nothing_when_unavailable() {
         assert_eq!(negotiate(Some(PROTOBUF_ONLY), false), None);
@@ -964,9 +949,6 @@ mod negotiation_tests {
         assert_eq!(negotiate(Some("application/json,text/html"), true), None);
     }
 
-    /// RFC 9110 invalidates a range with an unparseable weight, leaving
-    /// nothing acceptable behind. A bare `q=` is unparseable, so it invalidates
-    /// the range rather than reading as the default weight of 1.
     #[test]
     fn malformed_quality_on_the_only_range_matches_nothing() {
         let accept = "application/vnd.google.protobuf;\
@@ -975,8 +957,6 @@ mod negotiation_tests {
         assert_eq!(negotiate(Some(accept), true), None);
     }
 
-    /// `"nan"` and `"inf"` parse as floats, so parsing alone does not make a
-    /// weight usable.
     #[test]
     fn unrankable_quality_matches_nothing() {
         for weight in [
@@ -992,8 +972,6 @@ mod negotiation_tests {
         }
     }
 
-    /// `NaN` loses no comparison, so ranking it last is not enough: it would
-    /// stay `best` and discard the format actually preferred.
     #[test]
     fn unrankable_quality_does_not_mask_a_later_range() {
         let accept = format!("application/openmetrics-text;q=nan,{PROTOBUF_PREFERRED}");
@@ -1001,8 +979,6 @@ mod negotiation_tests {
         assert_eq!(negotiate(Some(&accept), true), PROTOBUF);
     }
 
-    /// The escapings differ so the assertion fails if `q=5` is ranked rather
-    /// than refused.
     #[test]
     fn out_of_range_quality_does_not_outrank_the_maximum() {
         let accept = "application/openmetrics-text;escaping=allow-utf-8;q=5,text/plain;q=1.0";
@@ -1010,7 +986,6 @@ mod negotiation_tests {
         assert_eq!(negotiate(Some(accept), true), TEXT);
     }
 
-    /// The boundary values of the spec range stay usable.
     #[test]
     fn quality_bounds_are_accepted() {
         assert_eq!(

--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -51,6 +51,14 @@ mod backend {
         Counter, CounterWithExemplar, Family, Gauge, GaugeGuard, Histogram, HistogramTimer,
         HistogramWithExemplars, InfoMetric, MetricConstructor, RangeGauge, TimeHistogram,
     };
+
+    // Everything needed to define, register, and label a custom metric. The
+    // protobuf data model is re-exported as `proto` so that implementors do not
+    // need a direct dependency on `foundations-metrics-registry`.
+    pub use foundations_metrics::{
+        EncodeMetric, EncodeMetricValue, IntoMetrics, LabelError, MetricFamily, NamedMetric,
+        RegistrationMetadata, proto, register, to_label_pairs,
+    };
 }
 #[cfg(not(feature = "foundations-metrics-backend"))]
 mod backend {

--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -284,7 +284,7 @@ fn protobuf_available() -> bool {
 /// encoder quotes a name whenever that name requires it, regardless of what the
 /// scraper asked for. Names produced in-tree are all legacy compatible, so the
 /// two agree in practice.
-pub(crate) fn collect_negotiated(
+pub fn collect_negotiated(
     accept: Option<&str>,
     settings: &MetricsSettings,
 ) -> Result<(&'static str, Vec<u8>)> {

--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -49,8 +49,8 @@ use internal::{ErasedInfoMetric, Registries};
 mod backend {
     pub use foundations_metrics::{
         Counter, CounterWithExemplar, Family, Gauge, GaugeGuard, Histogram, HistogramTimer,
-        HistogramWithExemplars, InfoMetric, MetricConstructor, RangeGauge, TimeHistogram,
-        NativeHistogram, NativeHistogramBuilder, NativeHistogramWithExemplars
+        HistogramWithExemplars, InfoMetric, MetricConstructor, NativeHistogram,
+        NativeHistogramBuilder, NativeHistogramWithExemplars, RangeGauge, TimeHistogram,
     };
 
     // Everything needed to define, register, and label a custom metric. The
@@ -174,9 +174,8 @@ impl ScrapeFormat {
 /// Chooses the most preferred format that the active encoder can produce, given
 /// the value of a request's `Accept` header.
 ///
-/// `None` means the header ruled out every format this server can produce, which
-/// the caller answers with `406`. An absent header expresses no preference and
-/// yields the fallback instead.
+/// `None` means the header ruled out every format this server can produce. An
+/// absent header expresses no preference and yields the fallback instead.
 #[cfg(feature = "foundations-metrics-backend")]
 fn negotiate(accept: Option<&str>, protobuf_available: bool) -> Option<ScrapeFormat> {
     let Some(accept) = accept else {
@@ -203,7 +202,7 @@ fn negotiate(accept: Option<&str>, protobuf_available: bool) -> Option<ScrapeFor
             let name = name.trim();
 
             if name.eq_ignore_ascii_case("q") {
-                // RFC 9110 §12.4.2: an unparseable weight invalidates the
+                // RFC 9110: an unparseable weight invalidates the
                 // media-range. Zero is the refusal value below, so a malformed
                 // `q` drops the range rather than promoting it to the top.
                 quality = value.parse().unwrap_or(0.0);
@@ -273,8 +272,8 @@ fn protobuf_available() -> bool {
 /// disagree; deriving one separately from the other is how a response ends up
 /// declaring a format it did not encode.
 ///
-/// `Ok(None)` means no requested format could be served and the caller should
-/// answer `406`.
+/// An `Accept` header that rules out every available format is served the
+/// fallback text format, after logging a warning.
 ///
 /// The negotiated escaping is currently reported rather than enforced: the text
 /// encoder quotes a name whenever that name requires it, regardless of what the
@@ -283,28 +282,31 @@ fn protobuf_available() -> bool {
 pub(crate) fn collect_negotiated(
     accept: Option<&str>,
     settings: &MetricsSettings,
-) -> Result<Option<(&'static str, Vec<u8>)>> {
+) -> Result<(&'static str, Vec<u8>)> {
     #[cfg(feature = "foundations-metrics-backend")]
     {
-        let Some(format) = negotiate(accept, protobuf_available()) else {
-            return Ok(None);
-        };
+        let format = negotiate(accept, protobuf_available()).unwrap_or_else(|| {
+            let fallback = ScrapeFormat::fallback();
+
+            // Only a header that was present can rule everything out, so the
+            // default here stands in for a case `negotiate` never reports.
+            report_unsatisfiable_accept(accept.unwrap_or_default(), fallback.content_type());
+
+            fallback
+        });
 
         // Protobuf is only reachable with no extra producers registered, so the
         // registry holds everything and skipping them here loses nothing.
         if format == ScrapeFormat::Protobuf {
             let families = foundations_metrics::collect(collection_options(settings));
 
-            return Ok(Some((
+            return Ok((
                 format.content_type(),
                 foundations_metrics::encode_to_protobuf(&families),
-            )));
+            ));
         }
 
-        Ok(Some((
-            format.content_type(),
-            collect(settings)?.into_bytes(),
-        )))
+        Ok((format.content_type(), collect(settings)?.into_bytes()))
     }
 
     // The legacy encoder produces text only, so there is nothing to negotiate.
@@ -312,8 +314,28 @@ pub(crate) fn collect_negotiated(
     {
         let _ = accept;
 
-        Ok(Some((LEGACY_CONTENT_TYPE, collect(settings)?.into_bytes())))
+        Ok((LEGACY_CONTENT_TYPE, collect(settings)?.into_bytes()))
     }
+}
+
+/// Warns that a scrape's `Accept` header ruled out every available format.
+///
+/// Not routed through [`report_nonfatal_collect_error`], because collection
+/// itself succeeded and the actionable detail is the header.
+#[cfg(feature = "foundations-metrics-backend")]
+fn report_unsatisfiable_accept(accept: &str, served: &str) {
+    #[cfg(feature = "logging")]
+    crate::telemetry::log::warn!(
+        "no requested metrics format can be served, responding with the fallback instead";
+        "accept" => accept,
+        "served" => served,
+    );
+
+    #[cfg(not(feature = "logging"))]
+    eprintln!(
+        "no requested metrics format can be served, responding with the fallback instead: \
+         accept={accept:?} served={served:?}"
+    );
 }
 
 /// Removes the trailing OpenMetrics terminator, if present.
@@ -861,6 +883,18 @@ mod negotiation_tests {
         assert_eq!(negotiate(Some(accept), true), TEXT);
     }
 
+    /// `q=0` means "not acceptable" (RFC 9110), so a header offering
+    /// nothing else leaves nothing to serve. Refusing the range outright, rather
+    /// than merely ranking it last, is what keeps it from being selected as the
+    /// only remaining candidate.
+    #[test]
+    fn zero_quality_on_the_only_range_matches_nothing() {
+        assert_eq!(
+            negotiate(Some("application/openmetrics-text;q=0"), true),
+            None
+        );
+    }
+
     #[test]
     fn malformed_quality_refuses_a_format() {
         let accept = "application/openmetrics-text;escaping=allow-utf-8;q=garbage,text/plain;q=0.4";
@@ -897,10 +931,9 @@ mod negotiation_tests {
         assert_eq!(negotiate(None, false), TEXT);
     }
 
-    /// A scraper accepting only protobuf could not read text, so refusing is more
-    /// informative than sending something it must discard.
+    /// Nothing is servable to a protobuf-only scraper once protobuf is withheld.
     #[test]
-    fn protobuf_only_is_refused_when_unavailable() {
+    fn protobuf_only_matches_nothing_when_unavailable() {
         assert_eq!(negotiate(Some(PROTOBUF_ONLY), false), None);
     }
 
@@ -910,17 +943,60 @@ mod negotiation_tests {
     }
 
     #[test]
-    fn unservable_media_types_are_refused() {
+    fn unservable_media_types_match_nothing() {
         assert_eq!(negotiate(Some("application/json,text/html"), true), None);
     }
 
-    /// RFC 9110 §12.4.2 invalidates a range with an unparseable weight, leaving
-    /// nothing acceptable behind.
+    /// RFC 9110 invalidates a range with an unparseable weight, leaving
+    /// nothing acceptable behind. A bare `q=` is unparseable, so it invalidates
+    /// the range rather than reading as the default weight of 1.
     #[test]
-    fn malformed_quality_on_the_only_range_is_refused() {
+    fn malformed_quality_on_the_only_range_matches_nothing() {
         let accept = "application/vnd.google.protobuf;\
                       proto=io.prometheus.client.MetricFamily;encoding=delimited;q=";
 
         assert_eq!(negotiate(Some(accept), true), None);
+    }
+}
+
+/// Covers the warning emitted when an `Accept` header cannot be satisfied.
+#[cfg(all(test, feature = "foundations-metrics-backend", feature = "logging"))]
+mod fallback_logging_tests {
+    use super::*;
+    use crate::telemetry::TelemetryContext;
+
+    /// Matches nothing on offer whether or not protobuf is available, so it
+    /// reaches the fallback in a test binary that has no extra producers.
+    const UNSERVABLE: &str = "application/json,text/html";
+
+    #[test]
+    fn unsatisfiable_accept_is_served_as_text_with_a_warning() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        let (content_type, body) =
+            collect_negotiated(Some(UNSERVABLE), &MetricsSettings::default())
+                .expect("an unsatisfiable header should still produce a body");
+
+        assert_eq!(content_type, ScrapeFormat::fallback().content_type());
+        assert!(
+            body.ends_with(b"# EOF\n"),
+            "fallback body should be terminated text"
+        );
+
+        let records = ctx.log_records();
+        let warning = records
+            .iter()
+            .find(|record| record.message.contains("no requested metrics format"))
+            .unwrap_or_else(|| panic!("falling back should warn: {records:?}"));
+
+        assert_eq!(warning.level, slog::Level::Warning);
+        assert!(
+            warning
+                .fields
+                .contains(&("accept".to_owned(), UNSERVABLE.to_owned())),
+            "the warning should name the header that could not be satisfied: {:?}",
+            warning.fields
+        );
     }
 }

--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -50,6 +50,7 @@ mod backend {
     pub use foundations_metrics::{
         Counter, CounterWithExemplar, Family, Gauge, GaugeGuard, Histogram, HistogramTimer,
         HistogramWithExemplars, InfoMetric, MetricConstructor, RangeGauge, TimeHistogram,
+        NativeHistogram, NativeHistogramBuilder, NativeHistogramWithExemplars
     };
 
     // Everything needed to define, register, and label a custom metric. The

--- a/foundations/src/telemetry/mod.rs
+++ b/foundations/src/telemetry/mod.rs
@@ -426,7 +426,6 @@ mod tests {
         assert!(is_initialized());
     }
 
-    // We don't need this method in the new backend since the new registry doesn't hold any service name at all.
     /// Ensure that `TelemetryContext::test()` does not default-initialize the metrics registry.
     /// This has caused CI bugs in the past because metrics will be prefixed by `undefined_`.
     #[cfg(not(feature = "foundations-metrics-backend"))]

--- a/foundations/src/telemetry/mod.rs
+++ b/foundations/src/telemetry/mod.rs
@@ -402,7 +402,9 @@ pub fn init(config: TelemetryConfig) -> BootstrapResult<TelemetryDriver> {
 
 #[cfg(test)]
 mod tests {
-    use super::{TelemetryConfig, TelemetryContext, init, is_initialized};
+    #[cfg(not(feature = "foundations-metrics-backend"))]
+    use super::TelemetryContext;
+    use super::{TelemetryConfig, init, is_initialized};
     use crate::service_info;
 
     #[tokio::test]
@@ -424,8 +426,10 @@ mod tests {
         assert!(is_initialized());
     }
 
+    // We don't need this method in the new backend since the new registry doesn't hold any service name at all.
     /// Ensure that `TelemetryContext::test()` does not default-initialize the metrics registry.
     /// This has caused CI bugs in the past because metrics will be prefixed by `undefined_`.
+    #[cfg(not(feature = "foundations-metrics-backend"))]
     #[test]
     fn testing_telemetry_metrics_uninit() {
         let _ctx = TelemetryContext::test();

--- a/foundations/src/telemetry/mod.rs
+++ b/foundations/src/telemetry/mod.rs
@@ -344,7 +344,7 @@ pub fn init(config: TelemetryConfig) -> BootstrapResult<TelemetryDriver> {
     }
 
     #[cfg(feature = "metrics")]
-    self::metrics::init::init(config.service_info, &config.settings.metrics);
+    self::metrics::init::init(config.service_info, &config.settings.metrics)?;
 
     #[cfg(feature = "metrics")]
     crate::panic::install_hook();

--- a/foundations/src/telemetry/server/router.rs
+++ b/foundations/src/telemetry/server/router.rs
@@ -305,7 +305,7 @@ fn not_acceptable() -> Result<Response<TelemetryRouteBody>, Infallible> {
             )
             .map_err(Into::into),
         ))
-        .unwrap())
+        .expect("a static status, content type, and body always build a valid response"))
 }
 
 fn into_response(

--- a/foundations/src/telemetry/server/router.rs
+++ b/foundations/src/telemetry/server/router.rs
@@ -117,12 +117,20 @@ impl Routes {
         self.set(TelemetryServerRoute {
             path: "/metrics".into(),
             methods: vec![Method::GET],
-            handler: Box::new(|_, settings| {
+            handler: Box::new(|req, settings| {
+                let accept = req
+                    .headers()
+                    .get(header::ACCEPT)
+                    .and_then(|v| v.to_str().ok())
+                    .map(str::to_owned);
                 async move {
-                    into_response(
-                        "application/openmetrics-text; version=1.0.0; charset=utf-8",
-                        metrics::collect(&settings.metrics),
-                    )
+                    match metrics::collect_negotiated(accept.as_deref(), &settings.metrics) {
+                        Ok((content_type, body)) => into_response(content_type, Ok(body)),
+                        // Errors are reported as plain text, so the content type
+                        // given here is unused; the body type only needs naming
+                        // because `Err` alone leaves it unconstrained.
+                        Err(err) => into_response("text/plain", Err::<Vec<u8>, _>(err)),
+                    }
                 }
                 .boxed()
             }),

--- a/foundations/src/telemetry/server/router.rs
+++ b/foundations/src/telemetry/server/router.rs
@@ -125,8 +125,7 @@ impl Routes {
                     .map(str::to_owned);
                 async move {
                     match metrics::collect_negotiated(accept.as_deref(), &settings.metrics) {
-                        Ok(Some((content_type, body))) => into_response(content_type, Ok(body)),
-                        Ok(None) => not_acceptable(),
+                        Ok((content_type, body)) => into_response(content_type, Ok(body)),
                         // Errors are reported as plain text, so the content type
                         // given here is unused; the body type only needs naming
                         // because `Err` alone leaves it unconstrained.
@@ -288,24 +287,6 @@ impl Service<Request<Incoming>> for Router {
 
         async move { Ok(router.handle_request(req).await) }.boxed()
     }
-}
-
-/// Refuses a scrape whose `Accept` header excludes every format on offer.
-///
-/// OpenMetrics text is always available, so reaching this means the scraper
-/// refused text and would not have been able to read the response anyway.
-#[cfg(feature = "metrics")]
-fn not_acceptable() -> Result<Response<TelemetryRouteBody>, Infallible> {
-    Ok(Response::builder()
-        .status(StatusCode::NOT_ACCEPTABLE)
-        .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
-        .body(BoxBody::new(
-            Full::from(
-                "no acceptable metrics format; application/openmetrics-text is always offered\n",
-            )
-            .map_err(Into::into),
-        ))
-        .expect("a static status, content type, and body always build a valid response"))
 }
 
 fn into_response(

--- a/foundations/src/telemetry/server/router.rs
+++ b/foundations/src/telemetry/server/router.rs
@@ -125,7 +125,8 @@ impl Routes {
                     .map(str::to_owned);
                 async move {
                     match metrics::collect_negotiated(accept.as_deref(), &settings.metrics) {
-                        Ok((content_type, body)) => into_response(content_type, Ok(body)),
+                        Ok(Some((content_type, body))) => into_response(content_type, Ok(body)),
+                        Ok(None) => not_acceptable(),
                         // Errors are reported as plain text, so the content type
                         // given here is unused; the body type only needs naming
                         // because `Err` alone leaves it unconstrained.
@@ -287,6 +288,24 @@ impl Service<Request<Incoming>> for Router {
 
         async move { Ok(router.handle_request(req).await) }.boxed()
     }
+}
+
+/// Refuses a scrape whose `Accept` header excludes every format on offer.
+///
+/// OpenMetrics text is always available, so reaching this means the scraper
+/// refused text and would not have been able to read the response anyway.
+#[cfg(feature = "metrics")]
+fn not_acceptable() -> Result<Response<TelemetryRouteBody>, Infallible> {
+    Ok(Response::builder()
+        .status(StatusCode::NOT_ACCEPTABLE)
+        .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
+        .body(BoxBody::new(
+            Full::from(
+                "no acceptable metrics format; application/openmetrics-text is always offered\n",
+            )
+            .map_err(Into::into),
+        ))
+        .unwrap())
 }
 
 fn into_response(

--- a/foundations/src/telemetry/server/router.rs
+++ b/foundations/src/telemetry/server/router.rs
@@ -126,9 +126,6 @@ impl Routes {
                 async move {
                     match metrics::collect_negotiated(accept.as_deref(), &settings.metrics) {
                         Ok((content_type, body)) => into_response(content_type, Ok(body)),
-                        // Errors are reported as plain text, so the content type
-                        // given here is unused; the body type only needs naming
-                        // because `Err` alone leaves it unconstrained.
                         Err(err) => into_response("text/plain", Err::<Vec<u8>, _>(err)),
                     }
                 }

--- a/foundations/tests/custom_metric_via_facade.rs
+++ b/foundations/tests/custom_metric_via_facade.rs
@@ -60,6 +60,9 @@ fn a_custom_metric_is_exposed_through_the_facade() {
     };
     let text = metrics::collect(&settings).expect("metrics should be collectable");
 
+    // Telemetry is never initialised here, so the service name prefix is the
+    // `UNINITIALISED_SERVICE_NAME` sentinel from `telemetry::metrics::init`
+    // ("undefined"). If that sentinel changes, this expectation changes with it.
     assert!(
         text.contains("undefined_facade_open_files{mount=\"/data\"} 5"),
         "collected output was: {text}"

--- a/foundations/tests/custom_metric_via_facade.rs
+++ b/foundations/tests/custom_metric_via_facade.rs
@@ -1,0 +1,67 @@
+//! Verifies that a custom metric can be defined and registered through the
+//! `foundations` facade alone, without depending on `foundations-metrics`.
+#![cfg(feature = "foundations-metrics-backend")]
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use foundations::telemetry::metrics::proto::{Gauge, Metric, MetricType};
+use foundations::telemetry::metrics::{
+    self, EncodeMetric, EncodeMetricValue, Family, MetricFamily, NamedMetric, RegistrationMetadata,
+    register,
+};
+use foundations::telemetry::settings::{MetricsSettings, ServiceNameFormat};
+use serde::Serialize;
+
+#[derive(Clone, Eq, Hash, PartialEq, Serialize)]
+struct Labels {
+    mount: &'static str,
+}
+
+#[derive(Default)]
+struct OpenFiles(AtomicU64);
+
+impl EncodeMetricValue for OpenFiles {
+    fn encode_metric_value(&self) -> Vec<MetricFamily> {
+        vec![MetricFamily {
+            name: Some(String::new()),
+            help: None,
+            r#type: Some(MetricType::Gauge as i32),
+            metric: vec![Metric {
+                gauge: Some(Gauge {
+                    value: Some(self.0.load(Ordering::Relaxed) as f64),
+                }),
+                ..Default::default()
+            }],
+            unit: None,
+        }]
+    }
+}
+
+#[test]
+fn a_custom_metric_is_exposed_through_the_facade() {
+    let open_files = Family::<Labels, OpenFiles>::default();
+    open_files
+        .get_or_create(&Labels { mount: "/data" })
+        .0
+        .store(5, Ordering::Relaxed);
+
+    register(
+        Box::new(NamedMetric::new(
+            "facade_open_files",
+            "Number of open file descriptors.",
+            open_files,
+        )) as Box<dyn EncodeMetric>,
+        RegistrationMetadata::default(),
+    );
+
+    let settings = MetricsSettings {
+        service_name_format: ServiceNameFormat::MetricPrefix,
+        report_optional: false,
+    };
+    let text = metrics::collect(&settings).expect("metrics should be collectable");
+
+    assert!(
+        text.contains("undefined_facade_open_files{mount=\"/data\"} 5"),
+        "collected output was: {text}"
+    );
+}

--- a/foundations/tests/info_metrics.rs
+++ b/foundations/tests/info_metrics.rs
@@ -7,10 +7,6 @@ use foundations::telemetry::settings::{MetricsSettings, ServiceNameFormat, Telem
 use foundations::telemetry::{TelemetryConfig, TelemetryContext, metrics};
 
 /// Returns the value of the sample line for `series`, if it was collected.
-///
-/// The value is parsed rather than matched textually: the classic Prometheus
-/// text format renders the `u64` it stores as `1`, while `foundations-metrics`
-/// renders its protobuf double as `1.0`. Both denote the same series.
 fn sample_value(metrics: &str, series: &str) -> Option<f64> {
     metrics.lines().find_map(|line| {
         line.strip_prefix(series)

--- a/foundations/tests/info_metrics.rs
+++ b/foundations/tests/info_metrics.rs
@@ -1,0 +1,65 @@
+//! Info metrics reported during telemetry initialisation must reach the scrape
+//! output with their bare name. Kept in its own test binary because
+//! `telemetry::init` may only run once per process.
+
+use foundations::ServiceInfo;
+use foundations::telemetry::settings::{MetricsSettings, ServiceNameFormat, TelemetrySettings};
+use foundations::telemetry::{TelemetryConfig, TelemetryContext, metrics};
+
+/// Returns the value of the sample line for `series`, if it was collected.
+///
+/// The value is parsed rather than matched textually: the classic Prometheus
+/// text format renders the `u64` it stores as `1`, while `foundations-metrics`
+/// renders its protobuf double as `1.0`. Both denote the same series.
+fn sample_value(metrics: &str, series: &str) -> Option<f64> {
+    metrics.lines().find_map(|line| {
+        line.strip_prefix(series)
+            .and_then(|rest| rest.strip_prefix(' '))
+            .and_then(|value| value.parse::<f64>().ok())
+    })
+}
+
+#[tokio::test]
+async fn init_reports_build_and_runtime_info_unprefixed() {
+    // Keeps the tracing reporter from binding real sockets during the test.
+    let _ctx = TelemetryContext::test();
+
+    let service_info = ServiceInfo {
+        name: "info-svc",
+        name_in_metrics: "info_svc".to_owned(),
+        version: "4.5.6",
+        author: "Foo Bar",
+        description: "An example service",
+    };
+    let telemetry_settings = TelemetrySettings::default();
+
+    foundations::telemetry::init(TelemetryConfig {
+        service_info: &service_info,
+        settings: &telemetry_settings,
+        custom_server_routes: vec![],
+    })
+    .expect("telemetry init should succeed");
+
+    let settings = MetricsSettings {
+        service_name_format: ServiceNameFormat::MetricPrefix,
+        report_optional: false,
+    };
+    let text = metrics::collect(&settings).expect("metrics should be collectable");
+
+    assert_eq!(
+        sample_value(&text, "build_info{version=\"4.5.6\"}"),
+        Some(1.0),
+        "build_info missing from: {text}"
+    );
+    assert!(
+        text.contains("runtime_info{pid=\""),
+        "runtime_info missing from: {text}"
+    );
+
+    // Info metrics keep their bare name even though the service name is
+    // configured as a metric prefix.
+    assert!(
+        !text.contains("info_svc_build_info"),
+        "info metrics must not be service-prefixed: {text}"
+    );
+}

--- a/foundations/tests/metrics.rs
+++ b/foundations/tests/metrics.rs
@@ -3,6 +3,16 @@ use foundations::telemetry::metrics::{self, Counter, Family, metrics};
 use foundations::telemetry::settings::{MetricsSettings, ServiceNameFormat, TelemetrySettings};
 use foundations::telemetry::{TelemetryConfig, TelemetryContext};
 
+/// How an integral sample value is rendered.
+///
+/// The classic Prometheus text format encodes the `u64` counter values it stores
+/// as integers, while `foundations-metrics` stores every value as a protobuf
+/// double and renders it as a float. Both parse to the same series and value.
+#[cfg(not(feature = "foundations-metrics-backend"))]
+const ONE: &str = "1";
+#[cfg(feature = "foundations-metrics-backend")]
+const ONE: &str = "1.0";
+
 #[metrics]
 mod regular {
     pub fn requests() -> Counter;
@@ -52,10 +62,10 @@ fn metrics_unprefixed() {
     let metrics = metrics::collect(&settings).expect("metrics should be collectable");
 
     // Global prefix defaults to "undefined" if not initialized
-    assert!(metrics.contains("\nundefined_regular_requests 1\n"));
+    assert!(metrics.contains(&format!("\nundefined_regular_requests {ONE}\n")));
     assert!(!metrics.contains("\nundefined_regular_optional"));
     assert!(!metrics.contains("\nundefined_regular_dynamic"));
-    assert!(metrics.contains("\nlibrary_calls 1\n"));
+    assert!(metrics.contains(&format!("\nlibrary_calls {ONE}\n")));
     assert!(!metrics.contains("\nlibrary_optional"));
 }
 
@@ -69,12 +79,23 @@ fn encode_error_is_skipped() {
         .get_or_create(&"another label".to_owned())
         .inc();
 
-    // Note the absence of values for the `error_invalid_label` family
+    // Note the absence of values for the `error_invalid_label` family: every one
+    // of its rows fails label serialization.
+    //
+    // `prometheus-client` appends `.` to all help text, so an absent doc comment
+    // renders as `.`; `foundations-metrics` omits help it has none for, and drops
+    // a family once all of its rows are skipped instead of emitting bare metadata.
+    #[cfg(not(feature = "foundations-metrics-backend"))]
     let expected_output = "# HELP undefined_encode_error_valid .
 # TYPE undefined_encode_error_valid counter
 undefined_encode_error_valid 1
 # HELP undefined_encode_error_invalid_label .
 # TYPE undefined_encode_error_invalid_label counter
+";
+
+    #[cfg(feature = "foundations-metrics-backend")]
+    let expected_output = "# TYPE undefined_encode_error_valid counter
+undefined_encode_error_valid 1.0
 ";
 
     let settings = MetricsSettings {
@@ -123,6 +144,6 @@ async fn test_context_cooperates_with_init() {
     let metrics = metrics::collect(&settings.metrics).expect("metrics should be collectable");
 
     // Metrics registry should be initialized with explicit ServiceInfo from `foundations::telemetry::init`
-    assert!(metrics.contains("\nmy_bin_regular_requests 1\n"));
-    assert!(metrics.contains("\nlibrary_calls 1\n"));
+    assert!(metrics.contains(&format!("\nmy_bin_regular_requests {ONE}\n")));
+    assert!(metrics.contains(&format!("\nlibrary_calls {ONE}\n")));
 }

--- a/foundations/tests/metrics.rs
+++ b/foundations/tests/metrics.rs
@@ -3,11 +3,6 @@ use foundations::telemetry::metrics::{self, Counter, Family, metrics};
 use foundations::telemetry::settings::{MetricsSettings, ServiceNameFormat, TelemetrySettings};
 use foundations::telemetry::{TelemetryConfig, TelemetryContext};
 
-/// How an integral sample value is rendered.
-///
-/// The classic Prometheus text format encodes the `u64` counter values it stores
-/// as integers, while `foundations-metrics` stores every value as a protobuf
-/// double and renders it as a float. Both parse to the same series and value.
 #[cfg(not(feature = "foundations-metrics-backend"))]
 const ONE: &str = "1";
 #[cfg(feature = "foundations-metrics-backend")]
@@ -81,10 +76,6 @@ fn encode_error_is_skipped() {
 
     // Note the absence of values for the `error_invalid_label` family: every one
     // of its rows fails label serialization.
-    //
-    // `prometheus-client` appends `.` to all help text, so an absent doc comment
-    // renders as `.`; `foundations-metrics` omits help it has none for, and drops
-    // a family once all of its rows are skipped instead of emitting bare metadata.
     #[cfg(not(feature = "foundations-metrics-backend"))]
     let expected_output = "# HELP undefined_encode_error_valid .
 # TYPE undefined_encode_error_valid counter

--- a/foundations/tests/metrics_negotiation.rs
+++ b/foundations/tests/metrics_negotiation.rs
@@ -71,8 +71,6 @@ async fn metrics_endpoint_serves_the_negotiated_format() {
         }
     };
 
-    // Asking for delimited protobuf must produce protobuf, not text under a
-    // protobuf content type.
     let (content_type, body) = scrape(PROTOBUF_ACCEPT).await;
 
     assert_eq!(content_type, foundations_metrics::PROTOBUF_CONTENT_TYPE);
@@ -87,8 +85,6 @@ async fn metrics_endpoint_serves_the_negotiated_format() {
         "protobuf response carries the text terminator"
     );
 
-    // Asking for text must still produce text, terminated as OpenMetrics
-    // requires.
     let (content_type, body) = scrape(TEXT_ACCEPT).await;
 
     assert!(

--- a/foundations/tests/metrics_negotiation.rs
+++ b/foundations/tests/metrics_negotiation.rs
@@ -1,0 +1,103 @@
+//! The `/metrics` endpoint must serve the format a scraper asks for through its
+//! `Accept` header, and must describe what it served.
+//!
+//! Protobuf is the only format able to carry native histograms, so this covers
+//! the path that makes them reachable at all. That the protobuf bytes are
+//! well formed is covered by unit tests in `foundations-metrics`; what matters
+//! here is that the route pairs the right encoder with the right content type.
+#![cfg(feature = "foundations-metrics-backend")]
+
+use std::future::IntoFuture;
+use std::net::{Ipv4Addr, SocketAddr};
+
+use foundations::telemetry::settings::{TelemetryServerSettings, TelemetrySettings};
+use foundations::telemetry::{TelemetryConfig, TelemetryContext};
+
+const PROTOBUF_ACCEPT: &str = "application/vnd.google.protobuf;\
+                               proto=io.prometheus.client.MetricFamily;\
+                               encoding=delimited;q=0.5,\
+                               application/openmetrics-text;version=1.0.0;q=0.4,\
+                               */*;q=0.1";
+
+const TEXT_ACCEPT: &str = "application/openmetrics-text;version=1.0.0;q=0.5,\
+                           text/plain;version=0.0.4;q=0.4,*/*;q=0.1";
+
+#[tokio::test]
+async fn metrics_endpoint_serves_the_negotiated_format() {
+    let _ctx = TelemetryContext::test();
+    let server_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 1347));
+
+    let settings = TelemetrySettings {
+        server: TelemetryServerSettings {
+            enabled: true,
+            addr: server_addr.into(),
+        },
+        ..Default::default()
+    };
+
+    tokio::spawn(
+        foundations::telemetry::init(TelemetryConfig {
+            service_info: &foundations::service_info!(),
+            settings: &settings,
+            custom_server_routes: vec![],
+        })
+        .unwrap()
+        .into_future(),
+    );
+
+    let client = reqwest::Client::new();
+    let url = format!("http://{server_addr}/metrics");
+
+    let scrape = |accept: &'static str| {
+        let client = client.clone();
+        let url = url.clone();
+        async move {
+            let response = client
+                .get(url)
+                .header(reqwest::header::ACCEPT, accept)
+                .send()
+                .await
+                .unwrap();
+
+            let content_type = response
+                .headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .expect("/metrics should declare a content type")
+                .to_str()
+                .unwrap()
+                .to_owned();
+
+            (content_type, response.bytes().await.unwrap())
+        }
+    };
+
+    // Asking for delimited protobuf must produce protobuf, not text under a
+    // protobuf content type.
+    let (content_type, body) = scrape(PROTOBUF_ACCEPT).await;
+
+    assert_eq!(content_type, foundations_metrics::PROTOBUF_CONTENT_TYPE);
+    assert!(!body.is_empty(), "protobuf response should not be empty");
+    assert!(
+        !body.starts_with(b"# "),
+        "protobuf response looks like text: {:?}",
+        String::from_utf8_lossy(&body[..body.len().min(64)])
+    );
+    assert!(
+        !body.ends_with(b"# EOF\n"),
+        "protobuf response carries the text terminator"
+    );
+
+    // Asking for text must still produce text, terminated as OpenMetrics
+    // requires.
+    let (content_type, body) = scrape(TEXT_ACCEPT).await;
+
+    assert!(
+        content_type.starts_with("application/openmetrics-text"),
+        "unexpected content type: {content_type}"
+    );
+
+    let text = String::from_utf8(body.to_vec()).expect("text response should be UTF-8");
+
+    assert!(text.contains("# TYPE"), "text response was: {text}");
+    assert!(text.ends_with("# EOF\n"), "text response was: {text}");
+}

--- a/foundations/tests/metrics_negotiation_extra_producers.rs
+++ b/foundations/tests/metrics_negotiation_extra_producers.rs
@@ -1,0 +1,124 @@
+//! Protobuf must not be served while text-only extra producers are registered,
+//! since it cannot carry what they emit and the loss would be invisible.
+//!
+//! Separate test binary on purpose: producer registration is process-global and
+//! one-way, so registering one here would make protobuf permanently unreachable
+//! for every other test in the binary.
+#![cfg(feature = "foundations-metrics-backend")]
+
+use std::future::IntoFuture;
+use std::net::{Ipv4Addr, SocketAddr};
+
+use foundations::telemetry::settings::{TelemetryServerSettings, TelemetrySettings};
+use foundations::telemetry::{TelemetryConfig, TelemetryContext};
+
+/// Delimited protobuf preferred, text still acceptable.
+const PROTOBUF_PREFERRED: &str = "application/vnd.google.protobuf;\
+                                  proto=io.prometheus.client.MetricFamily;\
+                                  encoding=delimited;q=0.9,\
+                                  application/openmetrics-text;version=1.0.0;q=0.1";
+
+/// Delimited protobuf and nothing else: no text range, no `*/*`.
+const PROTOBUF_ONLY: &str = "application/vnd.google.protobuf;\
+                             proto=io.prometheus.client.MetricFamily;encoding=delimited";
+
+const PRODUCER_SERIES: &str = "extra_producer_witness_total";
+
+#[tokio::test]
+async fn extra_producers_withhold_protobuf() {
+    let _ctx = TelemetryContext::test();
+    let server_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 1357));
+
+    // Shaped like a service's cache metrics: a self-contained document with its
+    // own terminator, which foundations strips before adding the final one.
+    #[allow(deprecated)]
+    foundations::telemetry::metrics::add_extra_producer(|buffer: &mut Vec<u8>| {
+        buffer.extend_from_slice(
+            b"# TYPE extra_producer_witness counter\n\
+              # HELP extra_producer_witness Emitted only by a text-only extra producer.\n\
+              extra_producer_witness_total 7\n\
+              # EOF\n",
+        );
+    });
+
+    let settings = TelemetrySettings {
+        server: TelemetryServerSettings {
+            enabled: true,
+            addr: server_addr.into(),
+        },
+        ..Default::default()
+    };
+
+    tokio::spawn(
+        foundations::telemetry::init(TelemetryConfig {
+            service_info: &foundations::service_info!(),
+            settings: &settings,
+            custom_server_routes: vec![],
+        })
+        .unwrap()
+        .into_future(),
+    );
+
+    let client = reqwest::Client::new();
+    let url = format!("http://{server_addr}/metrics");
+
+    let scrape = |accept: &'static str| {
+        let client = client.clone();
+        let url = url.clone();
+        async move {
+            let response = client
+                .get(url)
+                .header(reqwest::header::ACCEPT, accept)
+                .send()
+                .await
+                .unwrap();
+
+            let status = response.status();
+            let content_type = response
+                .headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .expect("/metrics should declare a content type")
+                .to_str()
+                .unwrap()
+                .to_owned();
+
+            (status, content_type, response.bytes().await.unwrap())
+        }
+    };
+
+    // Text is acceptable to this scraper, so it gets text with the producer
+    // output intact rather than protobuf without it.
+    let (status, content_type, body) = scrape(PROTOBUF_PREFERRED).await;
+
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert!(
+        content_type.starts_with("application/openmetrics-text"),
+        "protobuf was served despite registered extra producers: {content_type}"
+    );
+
+    let text = String::from_utf8(body.to_vec()).expect("response should be text");
+
+    assert!(
+        text.contains(PRODUCER_SERIES),
+        "extra producer output missing, body was: {text}"
+    );
+    assert!(
+        text.contains("# TYPE"),
+        "registered metrics missing, body was: {text}"
+    );
+    assert!(
+        text.ends_with("# EOF\n"),
+        "response was not terminated, body was: {text}"
+    );
+    assert_eq!(
+        text.matches("# EOF").count(),
+        1,
+        "expected exactly one terminator, body was: {text}"
+    );
+
+    // This scraper cannot read text, so it is refused rather than sent a body it
+    // would have to discard.
+    let (status, ..) = scrape(PROTOBUF_ONLY).await;
+
+    assert_eq!(status, reqwest::StatusCode::NOT_ACCEPTABLE);
+}

--- a/foundations/tests/metrics_negotiation_extra_producers.rs
+++ b/foundations/tests/metrics_negotiation_extra_producers.rs
@@ -116,9 +116,15 @@ async fn extra_producers_withhold_protobuf() {
         "expected exactly one terminator, body was: {text}"
     );
 
-    // This scraper cannot read text, so it is refused rather than sent a body it
-    // would have to discard.
-    let (status, ..) = scrape(PROTOBUF_ONLY).await;
+    // Nothing this scraper accepts can be served: protobuf is withheld and it
+    // offers no text range. A 406 would cost the scrape entirely, so it is sent
+    // text it did not ask for instead, which the body assertions above already
+    // cover since both responses take the same encoding path.
+    let (status, content_type, ..) = scrape(PROTOBUF_ONLY).await;
 
-    assert_eq!(status, reqwest::StatusCode::NOT_ACCEPTABLE);
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert!(
+        content_type.starts_with("application/openmetrics-text"),
+        "unsatisfiable Accept should fall back to text, got: {content_type}"
+    );
 }

--- a/foundations/tests/metrics_negotiation_extra_producers.rs
+++ b/foundations/tests/metrics_negotiation_extra_producers.rs
@@ -117,9 +117,7 @@ async fn extra_producers_withhold_protobuf() {
     );
 
     // Nothing this scraper accepts can be served: protobuf is withheld and it
-    // offers no text range. A 406 would cost the scrape entirely, so it is sent
-    // text it did not ask for instead, which the body assertions above already
-    // cover since both responses take the same encoding path.
+    // offers no text range, so it receives the fallback text format.
     let (status, content_type, ..) = scrape(PROTOBUF_ONLY).await;
 
     assert_eq!(status, reqwest::StatusCode::OK);

--- a/foundations/tests/metrics_service_label_validation.rs
+++ b/foundations/tests/metrics_service_label_validation.rs
@@ -1,0 +1,53 @@
+//! An unencodable service label name must stop startup rather than surface as an
+//! empty exposition later.
+//!
+//! Separate test binary on purpose: a successful `telemetry::init` elsewhere in
+//! the binary would make these observe its once-per-process refusal instead.
+#![cfg(all(feature = "foundations-metrics-backend", feature = "settings"))]
+
+use foundations::telemetry::TelemetryConfig;
+use foundations::telemetry::settings::{ServiceNameFormat, TelemetrySettings};
+
+fn init_with(format: ServiceNameFormat) -> foundations::BootstrapResult<()> {
+    let mut settings = TelemetrySettings::default();
+    settings.metrics.service_name_format = format;
+
+    foundations::telemetry::init(TelemetryConfig {
+        service_info: &foundations::service_info!(),
+        settings: &settings,
+        custom_server_routes: vec![],
+    })
+    .map(|_| ())
+}
+
+/// The reachable case: the setting is a plain config string, so unsubstituted
+/// templating yields exactly this.
+#[test]
+fn empty_service_label_name_is_rejected_at_startup() {
+    let error = init_with(ServiceNameFormat::LabelWithName(String::new()))
+        .expect_err("an unencodable service label name should stop startup");
+
+    let message = error.to_string();
+
+    assert!(
+        message.contains("service_name_format"),
+        "the error should name the setting at fault: {message}"
+    );
+    assert!(
+        message.contains("non-empty"),
+        "the error should state what was expected: {message}"
+    );
+}
+
+/// The other unencodable case, so narrowing the rule to emptiness alone would be
+/// caught.
+#[test]
+fn service_label_name_with_nul_is_rejected_at_startup() {
+    let error = init_with(ServiceNameFormat::LabelWithName("ser\0vice".to_owned()))
+        .expect_err("a label name with a NUL byte should stop startup");
+
+    assert!(
+        error.to_string().contains("service_name_format"),
+        "the error should name the setting at fault: {error}"
+    );
+}

--- a/foundations/tests/metrics_service_label_validation.rs
+++ b/foundations/tests/metrics_service_label_validation.rs
@@ -20,8 +20,6 @@ fn init_with(format: ServiceNameFormat) -> foundations::BootstrapResult<()> {
     .map(|_| ())
 }
 
-/// The reachable case: the setting is a plain config string, so unsubstituted
-/// templating yields exactly this.
 #[test]
 fn empty_service_label_name_is_rejected_at_startup() {
     let error = init_with(ServiceNameFormat::LabelWithName(String::new()))
@@ -39,8 +37,6 @@ fn empty_service_label_name_is_rejected_at_startup() {
     );
 }
 
-/// The other unencodable case, so narrowing the rule to emptiness alone would be
-/// caught.
 #[test]
 fn service_label_name_with_nul_is_rejected_at_startup() {
     let error = init_with(ServiceNameFormat::LabelWithName("ser\0vice".to_owned()))

--- a/foundations/tests/panic_hook.rs
+++ b/foundations/tests/panic_hook.rs
@@ -39,8 +39,6 @@ fn panic_hook_metrics_are_well_formed() {
     simulate_panic();
     assert_eq!(metrics::panics::total().get(), 1);
 
-    // `foundations-metrics` stores every value as a protobuf double, so integral
-    // counters render as floats. Both parse to the same series and value.
     #[cfg(not(feature = "foundations-metrics-backend"))]
     let expected = "panics_total 1";
     #[cfg(feature = "foundations-metrics-backend")]

--- a/foundations/tests/panic_hook.rs
+++ b/foundations/tests/panic_hook.rs
@@ -39,8 +39,15 @@ fn panic_hook_metrics_are_well_formed() {
     simulate_panic();
     assert_eq!(metrics::panics::total().get(), 1);
 
+    // `foundations-metrics` stores every value as a protobuf double, so integral
+    // counters render as floats. Both parse to the same series and value.
+    #[cfg(not(feature = "foundations-metrics-backend"))]
+    let expected = "panics_total 1";
+    #[cfg(feature = "foundations-metrics-backend")]
+    let expected = "panics_total 1.0";
+
     let metrics = foundations::telemetry::metrics::collect(&Default::default()).unwrap();
-    let has_metric = metrics.lines().any(|line| line == "panics_total 1");
+    let has_metric = metrics.lines().any(|line| line == expected);
     assert!(has_metric);
 }
 


### PR DESCRIPTION
## Overview

- Enables the `foundations-metrics-backend` feature by default.
- Replaces the legacy `prometheus-client`/`prometools` backend while keeping typical call sites source-compatible.
- Adds `Accept`-header negotiation to `/metrics`.
- Adds a public API for custom metrics.
- Makes `foundations-metrics` and `foundations-metrics-registry` publishable.

## Behaviour Changes

- **Exposition output:** Integral values render as `1.0`, empty `HELP` lines are omitted, and families with no serialisable rows are dropped.
- **Global registry:** Metrics registered only through `prometheus::register` are no longer collected. Register them through the foundations metrics API instead.
- **Content negotiation:** `/metrics` can return OpenMetrics text or length-delimited protobuf based on `Accept`.
- **Negotiation fallback:** Unsupported or invalid preferences fall back to text with a warning rather than failing the scrape.
- **Extra producers:** Registering any text-only `ExtraProducer` disables protobuf output process-wide.
- **Startup validation:** Invalid service label names now fail telemetry initialisation instead of producing empty scrapes.

## Public API

- Custom metrics can implement `EncodeMetricValue` and use `NamedMetric`, or implement `EncodeMetric` directly.
- Metrics are registered with `register(Box<dyn EncodeMetric>, RegistrationMetadata)`.
- The backend re-exports native histograms, `WithExemplar`, encoding traits, registration types, protobuf types, and label helpers through `telemetry::metrics`.
- Existing metric facade names now resolve to the new backend types when the feature is enabled.

## Deprecations

- Deprecates `add_extra_producer` and `ExtraProducer` in favor of `EncodeMetric` and `register`.
- The deprecated APIs remain functional with both backends but only support text output.

## Other Changes

- Applies the service name during collection, avoiding early collection permanently setting an `undefined_` prefix.
- Routes collection diagnostics through telemetry instead of stderr.
- Updates `#[metrics]` to reference metric types through the public facade.
- Adds a migration guide and documents metric name, label, and histogram validation behaviour.
- Adds the metadata required to publish both metrics crates.
- Builds the seccomp probe in a scratch directory so artifacts do not remain in `OUT_DIR`.

## Testing

- Adds coverage for custom metrics, info metrics, content negotiation, protobuf output, fallback behaviour, and startup validation.
- Run with `cargo nextest run`.
- Two tests in `foundations/tests/metrics.rs` fail under plain `cargo test` because they share the global registry; this also occurs at the base commit.
