### PR TITLE
ZTC-3215: Add pause syscall to seccomp SERVICE_BASICS allowlist

### DIFF
--- a/foundations/src/security/common_syscall_allow_lists.rs
+++ b/foundations/src/security/common_syscall_allow_lists.rs
@@ -33,6 +33,7 @@ allow_list! {
         ..RUST_BASICS,
         exit,
         exit_group,
+        pause, // pause can be invoked by std::process::exit() if multiple threads call it simultaneously
         kill if [ ArgCmp::Equal { arg_idx: 0, value: std::process::id().into() } ],
         tgkill if [ ArgCmp::Equal { arg_idx: 0, value: std::process::id().into() } ],
         getpid,

--- a/foundations/src/security/common_syscall_allow_lists.rs
+++ b/foundations/src/security/common_syscall_allow_lists.rs
@@ -33,7 +33,15 @@ allow_list! {
         ..RUST_BASICS,
         exit,
         exit_group,
-        pause, // pause can be invoked by std::process::exit() if multiple threads call it simultaneously
+        #[cfg(target_arch = "x86_64")]
+        pause, // `pause` can be invoked by std::process::exit() if multiple threads call it simultaneously
+        #[cfg(target_arch = "aarch64")]
+        ppoll if [ // glibc implements `pause` using ppoll with the following arguments on aarch64
+            ArgCmp::Equal { arg_idx: 0, value: 0 }, // fds = NULL
+            ArgCmp::Equal { arg_idx: 1, value: 0 }, // nfds = 0
+            ArgCmp::Equal { arg_idx: 2, value: 0 }, // timeout = NULL
+            ArgCmp::Equal { arg_idx: 3, value: 0 }  // sigmask = NULL
+        ],
         kill if [ ArgCmp::Equal { arg_idx: 0, value: std::process::id().into() } ],
         tgkill if [ ArgCmp::Equal { arg_idx: 0, value: std::process::id().into() } ],
         getpid,

--- a/foundations/src/security/common_syscall_allow_lists.rs
+++ b/foundations/src/security/common_syscall_allow_lists.rs
@@ -37,10 +37,10 @@ allow_list! {
         pause, // `pause` can be invoked by std::process::exit() if multiple threads call it simultaneously
         #[cfg(target_arch = "aarch64")]
         ppoll if [ // glibc implements `pause` using ppoll with the following arguments on aarch64
-            ArgCmp::Equal { arg_idx: 0, value: 0 }, // fds = NULL
-            ArgCmp::Equal { arg_idx: 1, value: 0 }, // nfds = 0
-            ArgCmp::Equal { arg_idx: 2, value: 0 }, // timeout = NULL
-            ArgCmp::Equal { arg_idx: 3, value: 0 }  // sigmask = NULL
+            ArgCmp::Equal { arg_idx: 0, value: 0_u64.into() }, // fds = NULL
+            ArgCmp::Equal { arg_idx: 1, value: 0_u64.into() }, // nfds = 0
+            ArgCmp::Equal { arg_idx: 2, value: 0_u64.into() }, // timeout = NULL
+            ArgCmp::Equal { arg_idx: 3, value: 0_u64.into() }  // sigmask = NULL
         ],
         kill if [ ArgCmp::Equal { arg_idx: 0, value: std::process::id().into() } ],
         tgkill if [ ArgCmp::Equal { arg_idx: 0, value: std::process::id().into() } ],


### PR DESCRIPTION
`std::process::exit()` has a [safeguard](https://github.com/rust-lang/rust/blob/fc0f51f5ca44d4586b0e309181382608cd6a8441/library/std/src/sys/exit.rs#L53) on linux against `libc::exit` thread unsafety which will pause a thread if it tried to exit simultaneously with another thread. This pause uses the [pause](https://man7.org/linux/man-pages/man2/pause.2.html) syscall.

If this race condition is triggered with the default seccomp configuration, the process will be killed by seccomp. This has been observed in a production environment.

This PR adds the `pause` syscall to the default seccomp allowlist to avoid this issue.

I don't think this poses any meaningful additional security risk by allowing potential malicious code to invoke it - at most, it can suspend a thread indefinitely, which I believe could already be accomplished with the `futex` syscall, which is already in the `RUST_BASICS` allowlist.