### PR TITLE
Release foundations version 5.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "5.8.0"
+version = "5.8.1"
 repository = "https://github.com/cloudflare/foundations"
 edition = "2024"
 authors = ["Cloudflare"]
@@ -42,8 +42,8 @@ check-cfg = [
 [workspace.dependencies]
 anyhow = "1.0.102"
 backtrace = "0.3.76"
-foundations = { version = "5.8.0", path = "./foundations", default-features = false }
-foundations-macros = { version = "=5.8.0", path = "./foundations-macros", default-features = false }
+foundations = { version = "5.8.1", path = "./foundations", default-features = false }
+foundations-macros = { version = "=5.8.1", path = "./foundations-macros", default-features = false }
 foundations-metrics-registry = { version = "0.1.0", path = "./foundations-metrics-registry" }
 bindgen = { version = "0.72.1", default-features = false }
 cc = "1.2.61"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,21 @@
 
+5.8.1
+- 2026-08-03 Add pause syscall to seccomp SERVICE_BASICS allowlist (#241)
+- 2026-07-31 feat(metrics): add metric validation + UTF-8 support (#238)
+- 2026-07-30 feat(metrics): add protobuf and OpenMetrics text encoders and collection (#237)
+- 2026-07-17 Remove seccomp probe results
+- 2026-07-28 feat(metrics): add support for classic, time, and native histograms. (#236)
+- 2026-07-21 feat(metrics): add support for metric families and label serialisation (#234)
+- 2026-07-16 Apply suggestions from code review
+- 2026-07-16 doc(metrics): apply doc suggestions from code review.
+- 2026-07-15 docs(metrics): improve comments & examples in gauge.rs
+- 2026-07-14 feat(metrics): re-export registry API
+- 2026-07-13 refactor(metrics): own scalar metric atomic storage
+- 2026-07-13 chore(metrics): cleanup comments
+- 2026-07-13 fix(metrics): add Counter inner accessor
+- 2026-07-13 feat(metrics): implement Gauge, RangeGauge and GaugeGuard
+- 2026-07-13 feat(metrics): add Counter implementation.
+
 5.8.0
 - 2026-06-17 Bump tikv-jemallocator to 0.7.0
 - 2026-07-16 Add user-facing tracing pipeline


### PR DESCRIPTION
### Fixed
- The probe file used to detect `seccomp` kernel headers is now cleaned up after detection (#235)
- The `SERVICE_BASICS` seccomp allowlist now includes the `pause` syscall, which is used in `std::process::exit` to avoid concurrent calls to `libc::exit`. `SERVICE_BASICS` also includes the `exit` syscall, so it made sense to include it there. (#241)