### PR TITLE
feat(metrics): add info and custom metrics

### DIFF
--- a/foundations-metrics-registry/src/encode_metric.rs
+++ b/foundations-metrics-registry/src/encode_metric.rs
@@ -4,6 +4,50 @@ use crate::proto::MetricFamily;
 ///
 /// Encoding is best-effort: implementations skip (and internally report) any
 /// metric or series that fails, so an empty `Vec` is a valid result.
+///
+/// This is the trait the registry stores, so an implementor controls its entire
+/// output: it names its own families and owns any label set it exposes.
+///
+/// `foundations-metrics` also provides an `EncodeMetricValue` trait, whose
+/// implementors encode only a *value* under a relative name. Pairing that with
+/// `NamedMetric` supplies the name, and storing it in a `Family` supplies label
+/// set storage and serialization. Prefer `EncodeMetricValue` unless a metric
+/// needs to control naming or emit several families itself.
+///
+/// # Examples
+///
+/// ```
+/// use foundations_metrics_registry::proto::{Gauge, LabelPair, Metric, MetricType};
+/// use foundations_metrics_registry::{EncodeMetric, MetricFamily, RegistrationMetadata, register};
+///
+/// struct BuildRevision(&'static str);
+///
+/// impl EncodeMetric for BuildRevision {
+///     fn encode(&self) -> Vec<MetricFamily> {
+///         vec![MetricFamily {
+///             // Complete producer-level name: nothing is prepended to it.
+///             name: Some("build_revision".to_owned()),
+///             help: Some("Revision the binary was built from.".to_owned()),
+///             r#type: Some(MetricType::Gauge as i32),
+///             metric: vec![Metric {
+///                 // Labels are this implementation's own responsibility.
+///                 label: vec![LabelPair {
+///                     name: Some("revision".to_owned()),
+///                     value: Some(self.0.to_owned()),
+///                 }],
+///                 gauge: Some(Gauge { value: Some(1.0) }),
+///                 ..Default::default()
+///             }],
+///             unit: None,
+///         }]
+///     }
+/// }
+///
+/// register(
+///     Box::new(BuildRevision("9f2c1ab")) as Box<dyn EncodeMetric>,
+///     RegistrationMetadata::default(),
+/// );
+/// ```
 pub trait EncodeMetric: Send + Sync + 'static {
     /// Encodes this metric into zero or more [`MetricFamily`] messages.
     ///

--- a/foundations-metrics-registry/src/metadata.rs
+++ b/foundations-metrics-registry/src/metadata.rs
@@ -11,6 +11,15 @@ pub struct RegistrationMetadata {
 
     /// Whether to suppress the service-name prefix for this metric.
     pub unprefixed: bool,
+
+    /// Whether to suppress the service-name label for this metric.
+    ///
+    /// Independent of [`unprefixed`](Self::unprefixed): a metric that opts out
+    /// of the service-name prefix is still labelled with the service name under
+    /// [`ServiceNameFormat::LabelWithName`]. Info metrics opt out of both.
+    ///
+    /// [`ServiceNameFormat::LabelWithName`]: https://docs.rs/foundations-metrics
+    pub unlabeled: bool,
 }
 
 impl RegistrationMetadata {
@@ -25,6 +34,13 @@ impl RegistrationMetadata {
     #[must_use]
     pub fn unprefixed(mut self, unprefixed: bool) -> Self {
         self.unprefixed = unprefixed;
+        self
+    }
+
+    /// Sets [`unlabeled`](Self::unlabeled)
+    #[must_use]
+    pub fn unlabeled(mut self, unlabeled: bool) -> Self {
+        self.unlabeled = unlabeled;
         self
     }
 }

--- a/foundations-metrics-registry/src/metadata.rs
+++ b/foundations-metrics-registry/src/metadata.rs
@@ -15,10 +15,8 @@ pub struct RegistrationMetadata {
     /// Whether to suppress the service-name label for this metric.
     ///
     /// Independent of [`unprefixed`](Self::unprefixed): a metric that opts out
-    /// of the service-name prefix is still labelled with the service name under
-    /// [`ServiceNameFormat::LabelWithName`]. Info metrics opt out of both.
-    ///
-    /// [`ServiceNameFormat::LabelWithName`]: https://docs.rs/foundations-metrics
+    /// of the service-name prefix is still labelled with the service name when
+    /// collection represents it as a label. Info metrics opt out of both.
     pub unlabeled: bool,
 }
 

--- a/foundations-metrics-registry/src/metadata.rs
+++ b/foundations-metrics-registry/src/metadata.rs
@@ -10,9 +10,23 @@ pub struct RegistrationMetadata {
     pub optional: bool,
 
     /// Whether to suppress the service-name prefix for this metric.
+    ///
+    /// With service name `api` and `MetricPrefix`, enabling this changes:
+    ///
+    /// ```text
+    /// Before: api_requests_total 1.0
+    /// After:  requests_total 1.0
+    /// ```
     pub unprefixed: bool,
 
     /// Whether to suppress the service-name label for this metric.
+    ///
+    /// With service name `api` and `LabelWithName("service")`, enabling this changes:
+    ///
+    /// ```text
+    /// Before: requests_total{service="api"} 1.0
+    /// After:  requests_total 1.0
+    /// ```
     ///
     /// Independent of [`unprefixed`](Self::unprefixed): a metric that opts out
     /// of the service-name prefix is still labelled with the service name when

--- a/foundations-metrics/src/collect.rs
+++ b/foundations-metrics/src/collect.rs
@@ -59,6 +59,7 @@ pub fn collect(options: CollectionOptions) -> Vec<MetricFamily> {
                 service_name,
                 options.service_name_format,
                 metadata.unprefixed,
+                metadata.unlabeled,
             );
         }
 
@@ -75,6 +76,7 @@ fn apply_service_name(
     service_name: &str,
     format: ServiceNameFormat<'_>,
     unprefixed: bool,
+    unlabeled: bool,
 ) {
     match format {
         ServiceNameFormat::MetricPrefix if !unprefixed => {
@@ -85,10 +87,10 @@ fn apply_service_name(
                 }
             }
         }
-        ServiceNameFormat::LabelWithName(label_name) => {
+        ServiceNameFormat::LabelWithName(label_name) if !unlabeled => {
             apply_service_label(families, label_name, service_name);
         }
-        ServiceNameFormat::MetricPrefix => {}
+        ServiceNameFormat::MetricPrefix | ServiceNameFormat::LabelWithName(_) => {}
     }
 }
 

--- a/foundations-metrics/src/info.rs
+++ b/foundations-metrics/src/info.rs
@@ -1,0 +1,275 @@
+//! Info metrics: gauges whose value is always `1`, carrying their data in labels.
+
+use std::any::TypeId;
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use foundations_metrics_registry::proto::{Gauge, LabelPair, Metric, MetricType};
+use foundations_metrics_registry::{EncodeMetric, MetricFamily, RegistrationMetadata, register};
+use parking_lot::RwLock;
+use serde::Serialize;
+
+use crate::diagnostics::report_collect_error;
+use crate::labels::to_label_pairs;
+
+/// Describes an info metric.
+///
+/// Info metrics expose textual information through their label set, which
+/// should not change often during the process lifetime. Common examples are an
+/// application's version, revision control commit, and the version of a
+/// compiler.
+pub trait InfoMetric: Serialize + Send + Sync + 'static {
+    /// The name of the info metric.
+    const NAME: &'static str;
+
+    /// The help message of the info metric.
+    const HELP: &'static str;
+}
+
+/// A reported info metric, with its label set already serialized.
+struct InfoEntry {
+    name: &'static str,
+    help: &'static str,
+    labels: Vec<LabelPair>,
+}
+
+static INFO_METRICS: OnceLock<RwLock<HashMap<TypeId, InfoEntry>>> = OnceLock::new();
+
+/// Returns the info metric store, registering the collector on first use.
+fn info_metrics() -> &'static RwLock<HashMap<TypeId, InfoEntry>> {
+    INFO_METRICS.get_or_init(|| {
+        // A single collector is registered for every info metric: the registry
+        // is append-only, so registering per report would emit a duplicate
+        // family each time the same info metric is reported again.
+        register(
+            Box::new(InfoCollector) as Box<dyn EncodeMetric>,
+            // Info metrics are exposed exactly as reported: they keep their bare
+            // name (e.g. `build_info`) and carry only their own fields as labels.
+            RegistrationMetadata::default()
+                .unprefixed(true)
+                .unlabeled(true),
+        );
+
+        RwLock::new(HashMap::new())
+    })
+}
+
+/// Registers an info metric, i.e. a gauge metric whose value is always `1`.
+///
+/// Reporting the same info metric type again replaces the previously reported
+/// value, so a metric is exposed at most once per type.
+///
+/// Label serialization happens here rather than at collection time; a label set
+/// that cannot be serialized is dropped with a non-fatal diagnostic.
+///
+/// ```
+/// use foundations_metrics::{InfoMetric, report_info};
+/// use serde::Serialize;
+///
+/// /// Build information.
+/// #[derive(Serialize)]
+/// struct BuildInfo {
+///     version: &'static str,
+/// }
+///
+/// impl InfoMetric for BuildInfo {
+///     const NAME: &'static str = "build_info";
+///     const HELP: &'static str = "Build information.";
+/// }
+///
+/// report_info(BuildInfo { version: "1.2.3" });
+/// ```
+pub fn report_info<M>(info_metric: impl Into<Box<M>>)
+where
+    M: InfoMetric,
+{
+    let info_metric = info_metric.into();
+
+    match to_label_pairs(&*info_metric) {
+        Ok(labels) => {
+            info_metrics().write().insert(
+                TypeId::of::<M>(),
+                InfoEntry {
+                    name: M::NAME,
+                    help: M::HELP,
+                    labels,
+                },
+            );
+        }
+        Err(error) => report_collect_error(format_args!(
+            "non-fatal error while reporting info metric {:?}: label serialization failed: {error}",
+            M::NAME
+        )),
+    }
+}
+
+/// Encodes every reported info metric as a gauge family valued `1`.
+struct InfoCollector;
+
+impl EncodeMetric for InfoCollector {
+    fn encode(&self) -> Vec<MetricFamily> {
+        // Read without initializing: the collector is only ever registered from
+        // `info_metrics`, so the store already exists by the time this runs.
+        let Some(info_metrics) = INFO_METRICS.get() else {
+            return Vec::new();
+        };
+
+        info_metrics
+            .read()
+            .values()
+            .map(|entry| MetricFamily {
+                name: Some(entry.name.to_owned()),
+                help: Some(entry.help.to_owned()),
+                r#type: Some(MetricType::Gauge as i32),
+                metric: vec![Metric {
+                    label: entry.labels.clone(),
+                    gauge: Some(Gauge { value: Some(1.0) }),
+                    ..Default::default()
+                }],
+                unit: None,
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Serialize;
+
+    use super::*;
+    use crate::{CollectionOptions, ServiceNameFormat, collect};
+
+    fn family<'a>(families: &'a [MetricFamily], name: &str) -> &'a MetricFamily {
+        families
+            .iter()
+            .find(|family| family.name.as_deref() == Some(name))
+            .unwrap_or_else(|| panic!("family {name:?} should be encoded"))
+    }
+
+    #[derive(Serialize)]
+    struct EncodedInfo {
+        version: &'static str,
+    }
+
+    impl InfoMetric for EncodedInfo {
+        const NAME: &'static str = "info_encoded";
+        const HELP: &'static str = "Encoded information.";
+    }
+
+    #[test]
+    fn encodes_info_metric_as_a_gauge_valued_one() {
+        report_info(EncodedInfo { version: "1.2.3" });
+
+        let families = InfoCollector.encode();
+        let family = family(&families, "info_encoded");
+
+        assert_eq!(family.help.as_deref(), Some("Encoded information."));
+        assert_eq!(family.r#type, Some(MetricType::Gauge as i32));
+        assert_eq!(family.metric.len(), 1);
+        assert_eq!(
+            family.metric[0]
+                .gauge
+                .as_ref()
+                .and_then(|gauge| gauge.value),
+            Some(1.0)
+        );
+        assert_eq!(family.metric[0].label[0].name.as_deref(), Some("version"));
+        assert_eq!(family.metric[0].label[0].value.as_deref(), Some("1.2.3"));
+    }
+
+    #[derive(Serialize)]
+    struct ReplacedInfo {
+        revision: &'static str,
+    }
+
+    impl InfoMetric for ReplacedInfo {
+        const NAME: &'static str = "info_replaced";
+        const HELP: &'static str = "Replaced information.";
+    }
+
+    #[test]
+    fn reporting_the_same_info_metric_replaces_the_previous_value() {
+        report_info(ReplacedInfo { revision: "first" });
+        report_info(ReplacedInfo { revision: "second" });
+
+        let families = InfoCollector.encode();
+        let matching = families
+            .iter()
+            .filter(|family| family.name.as_deref() == Some("info_replaced"))
+            .count();
+
+        assert_eq!(matching, 1, "re-reporting must replace, not duplicate");
+        assert_eq!(
+            family(&families, "info_replaced").metric[0].label[0]
+                .value
+                .as_deref(),
+            Some("second")
+        );
+    }
+
+    #[derive(Serialize)]
+    struct CollectedInfo {
+        version: &'static str,
+    }
+
+    impl InfoMetric for CollectedInfo {
+        const NAME: &'static str = "info_collected";
+        const HELP: &'static str = "Collected information.";
+    }
+
+    #[test]
+    fn collection_keeps_info_metric_names_unprefixed() {
+        report_info(CollectedInfo { version: "4.5.6" });
+
+        let families = collect(CollectionOptions {
+            include_optional: false,
+            service_name: Some("test_service"),
+            service_name_format: ServiceNameFormat::MetricPrefix,
+        });
+
+        assert!(
+            families
+                .iter()
+                .any(|family| family.name.as_deref() == Some("info_collected")),
+            "info metrics keep their bare name"
+        );
+        assert!(
+            !families
+                .iter()
+                .any(|family| family.name.as_deref() == Some("test_service_info_collected")),
+            "info metrics are never service-prefixed"
+        );
+    }
+
+    #[derive(Serialize)]
+    struct LabeledInfo {
+        version: &'static str,
+    }
+
+    impl InfoMetric for LabeledInfo {
+        const NAME: &'static str = "info_labeled";
+        const HELP: &'static str = "Labeled information.";
+    }
+
+    // Adding the service label would change the series identity of every info
+    // metric relative to the representation collectors already scrape.
+    #[test]
+    fn collection_does_not_add_the_service_label_to_info_metrics() {
+        report_info(LabeledInfo { version: "7.8.9" });
+
+        let families = collect(CollectionOptions {
+            include_optional: false,
+            service_name: Some("test_service"),
+            service_name_format: ServiceNameFormat::LabelWithName("service"),
+        });
+
+        let family = family(&families, "info_labeled");
+        let label_names: Vec<_> = family.metric[0]
+            .label
+            .iter()
+            .map(|label| label.name.as_deref().unwrap_or_default())
+            .collect();
+
+        assert_eq!(label_names, ["version"]);
+    }
+}

--- a/foundations-metrics/src/info.rs
+++ b/foundations-metrics/src/info.rs
@@ -38,13 +38,8 @@ static INFO_METRICS: OnceLock<RwLock<HashMap<TypeId, InfoEntry>>> = OnceLock::ne
 /// Returns the info metric store, registering the collector on first use.
 fn info_metrics() -> &'static RwLock<HashMap<TypeId, InfoEntry>> {
     INFO_METRICS.get_or_init(|| {
-        // A single collector is registered for every info metric: the registry
-        // is append-only, so registering per report would emit a duplicate
-        // family each time the same info metric is reported again.
         register(
             Box::new(InfoCollector) as Box<dyn EncodeMetric>,
-            // Info metrics are exposed exactly as reported: they keep their bare
-            // name (e.g. `build_info`) and carry only their own fields as labels.
             RegistrationMetadata::default()
                 .unprefixed(true)
                 .unlabeled(true),
@@ -108,8 +103,6 @@ struct InfoCollector;
 
 impl EncodeMetric for InfoCollector {
     fn encode(&self) -> Vec<MetricFamily> {
-        // Read without initializing: the collector is only ever registered from
-        // `info_metrics`, so the store already exists by the time this runs.
         let Some(info_metrics) = INFO_METRICS.get() else {
             return Vec::new();
         };

--- a/foundations-metrics/src/lib.rs
+++ b/foundations-metrics/src/lib.rs
@@ -20,7 +20,7 @@ pub use collect::{CollectionOptions, ServiceNameFormat, collect};
 pub use diagnostics::{CollectErrorHookAlreadySet, set_collect_error_hook};
 pub use encoding::{OPENMETRICS_CONTENT_TYPE, encode_to_protobuf, encode_to_text};
 pub use foundations_metrics_registry::{
-    EncodeMetric, IntoMetrics, MetricFamily, RegistrationMetadata, register,
+    EncodeMetric, IntoMetrics, MetricFamily, RegistrationMetadata, proto, register,
 };
 pub use info::{InfoMetric, report_info};
 pub use labels::{LabelError, to_label_pairs};
@@ -30,3 +30,4 @@ pub use metrics::{
     NativeHistogramBuilder, RangeGauge, TimeHistogram, WithExemplar,
 };
 pub use registered::NamedMetric;
+pub use value::EncodeMetricValue;

--- a/foundations-metrics/src/lib.rs
+++ b/foundations-metrics/src/lib.rs
@@ -9,6 +9,7 @@
 mod collect;
 mod diagnostics;
 mod encoding;
+mod info;
 mod labels;
 pub mod metrics;
 mod registered;
@@ -21,6 +22,7 @@ pub use encoding::{OPENMETRICS_CONTENT_TYPE, encode_to_protobuf, encode_to_text}
 pub use foundations_metrics_registry::{
     EncodeMetric, IntoMetrics, MetricFamily, RegistrationMetadata, register,
 };
+pub use info::{InfoMetric, report_info};
 pub use labels::{LabelError, to_label_pairs};
 pub use metrics::{
     Counter, CounterAtomic, Family, FamilyMetricGuard, Gauge, GaugeAtomic, GaugeGuard, Histogram,

--- a/foundations-metrics/src/registered.rs
+++ b/foundations-metrics/src/registered.rs
@@ -5,7 +5,7 @@ use crate::{EncodeMetric, MetricFamily, value::EncodeMetricValue};
 /// Storage types (`Counter`, `Gauge`, ...) hold only their value and encode
 /// themselves with relative names (a suffix such as `""`, `_min`, or `_max`).
 /// `NamedMetric` supplies the registered base name and help text, bridging the
-/// [`EncodeMetricValue`](crate::EncodeMetricValue) storage trait to the
+/// [`EncodeMetricValue`] storage trait to the
 /// [`EncodeMetric`] registry trait.
 pub struct NamedMetric<M> {
     name: &'static str,

--- a/foundations-metrics/src/registered.rs
+++ b/foundations-metrics/src/registered.rs
@@ -5,7 +5,7 @@ use crate::{EncodeMetric, MetricFamily, value::EncodeMetricValue};
 /// Storage types (`Counter`, `Gauge`, ...) hold only their value and encode
 /// themselves with relative names (a suffix such as `""`, `_min`, or `_max`).
 /// `NamedMetric` supplies the registered base name and help text, bridging the
-/// internal `EncodeMetricValue` storage trait to the public
+/// [`EncodeMetricValue`](crate::EncodeMetricValue) storage trait to the
 /// [`EncodeMetric`] registry trait.
 pub struct NamedMetric<M> {
     name: &'static str,

--- a/foundations-metrics/src/value.rs
+++ b/foundations-metrics/src/value.rs
@@ -6,7 +6,80 @@ use crate::MetricFamily;
 /// primary series uses `Some("")`; additional series use names such as
 /// `Some("_min")` and `Some("_max")`. [`NamedMetric`](crate::NamedMetric)
 /// prepends the registered metric name and fills in missing help text.
-pub(crate) trait EncodeMetricValue: Send + Sync + 'static {
+/// Implement this to define a custom metric. Pair it with
+/// [`NamedMetric`](crate::NamedMetric) to attach the registered name and help
+/// text, or store it in a [`Family`](crate::Family) to differentiate it by label
+/// set, then hand the result to [`register`](crate::register).
+///
+/// # Compared with [`EncodeMetric`](crate::EncodeMetric)
+///
+/// Both encode into the same [`MetricFamily`] model; they differ in how much of
+/// the output the implementor owns.
+///
+/// |  | [`EncodeMetric`](crate::EncodeMetric) | `EncodeMetricValue` |
+/// |---|---|---|
+/// | Family name | complete, written by the implementor | relative, prepended by [`NamedMetric`](crate::NamedMetric) |
+/// | Help text | written by the implementor | filled in by [`NamedMetric`](crate::NamedMetric) when absent |
+/// | Label sets | the implementor's own storage and serialization | provided by [`Family`](crate::Family) |
+/// | Registered directly | yes | only once wrapped |
+///
+/// Implementing [`EncodeMetric`](crate::EncodeMetric) is the right choice when a
+/// metric must control its own naming or emit several families; otherwise this
+/// trait leaves only the value encoding to write.
+///
+/// ```
+/// use std::sync::atomic::{AtomicU64, Ordering};
+///
+/// use foundations_metrics::proto::{Gauge, Metric, MetricType};
+/// use foundations_metrics::{
+///     EncodeMetric, EncodeMetricValue, Family, MetricFamily, NamedMetric, RegistrationMetadata,
+///     register,
+/// };
+/// use serde::Serialize;
+///
+/// #[derive(Default)]
+/// struct OpenFiles(AtomicU64);
+///
+/// impl EncodeMetricValue for OpenFiles {
+///     fn encode_metric_value(&self) -> Vec<MetricFamily> {
+///         vec![MetricFamily {
+///             // The primary series carries an empty relative name.
+///             name: Some(String::new()),
+///             help: None,
+///             r#type: Some(MetricType::Gauge as i32),
+///             metric: vec![Metric {
+///                 gauge: Some(Gauge {
+///                     value: Some(self.0.load(Ordering::Relaxed) as f64),
+///                 }),
+///                 ..Default::default()
+///             }],
+///             unit: None,
+///         }]
+///     }
+/// }
+///
+/// #[derive(Clone, Eq, Hash, PartialEq, Serialize)]
+/// struct Labels {
+///     mount: &'static str,
+/// }
+///
+/// let open_files = Family::<Labels, OpenFiles>::default();
+///
+/// open_files
+///     .get_or_create(&Labels { mount: "/data" })
+///     .0
+///     .fetch_add(1, Ordering::Relaxed);
+///
+/// register(
+///     Box::new(NamedMetric::new(
+///         "open_files",
+///         "Number of open file descriptors.",
+///         open_files,
+///     )) as Box<dyn EncodeMetric>,
+///     RegistrationMetadata::default(),
+/// );
+/// ```
+pub trait EncodeMetricValue: Send + Sync + 'static {
     /// Encodes the current value into one or more relatively named families.
     fn encode_metric_value(&self) -> Vec<MetricFamily>;
 }

--- a/foundations-metrics/tests/custom_metric.rs
+++ b/foundations-metrics/tests/custom_metric.rs
@@ -1,0 +1,192 @@
+//! Defines and registers custom metrics from outside the crate, which is the
+//! only way to verify that the public API is sufficient on its own.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+
+use foundations_metrics::proto::{Gauge, Metric, MetricType};
+use foundations_metrics::{
+    CollectionOptions, EncodeMetric, EncodeMetricValue, Family, MetricFamily, NamedMetric,
+    RegistrationMetadata, ServiceNameFormat, collect, register, to_label_pairs,
+};
+use serde::Serialize;
+
+#[derive(Clone, Eq, Hash, PartialEq, Serialize)]
+struct Labels {
+    mount: &'static str,
+}
+
+fn gauge(value: u64) -> Option<Gauge> {
+    Some(Gauge {
+        value: Some(value as f64),
+    })
+}
+
+fn collected() -> Vec<MetricFamily> {
+    collect(CollectionOptions {
+        include_optional: false,
+        service_name: None,
+        service_name_format: ServiceNameFormat::MetricPrefix,
+    })
+}
+
+fn family_named<'a>(families: &'a [MetricFamily], name: &str) -> &'a MetricFamily {
+    families
+        .iter()
+        .find(|family| family.name.as_deref() == Some(name))
+        .unwrap_or_else(|| panic!("family {name:?} should be collected"))
+}
+
+/// A metric without labels only needs [`EncodeMetric`], which supplies its own
+/// absolute name.
+#[derive(Default)]
+struct OpenFiles(AtomicU64);
+
+impl EncodeMetric for OpenFiles {
+    fn encode(&self) -> Vec<MetricFamily> {
+        vec![MetricFamily {
+            name: Some("open_files".to_owned()),
+            help: Some("Number of open file descriptors.".to_owned()),
+            r#type: Some(MetricType::Gauge as i32),
+            metric: vec![Metric {
+                gauge: gauge(self.0.load(Ordering::Relaxed)),
+                ..Default::default()
+            }],
+            unit: None,
+        }]
+    }
+}
+
+#[test]
+fn a_custom_metric_can_be_registered_and_collected() {
+    let files = OpenFiles::default();
+    files.0.store(7, Ordering::Relaxed);
+
+    register(
+        Box::new(files) as Box<dyn EncodeMetric>,
+        RegistrationMetadata::default(),
+    );
+
+    let families = collected();
+    let family = family_named(&families, "open_files");
+
+    assert_eq!(
+        family.metric[0]
+            .gauge
+            .as_ref()
+            .and_then(|gauge| gauge.value),
+        Some(7.0)
+    );
+}
+
+/// Differentiating by label set through [`EncodeMetric`] alone means owning the
+/// storage, the sharing, the label serialization, and the row assembly.
+#[derive(Clone, Default)]
+struct OpenFilesPerMount {
+    values: Arc<RwLock<HashMap<Labels, Arc<AtomicU64>>>>,
+}
+
+impl OpenFilesPerMount {
+    fn get_or_create(&self, labels: &Labels) -> Arc<AtomicU64> {
+        if let Some(value) = self.values.read().unwrap().get(labels) {
+            return Arc::clone(value);
+        }
+
+        Arc::clone(
+            self.values
+                .write()
+                .unwrap()
+                .entry(labels.clone())
+                .or_default(),
+        )
+    }
+}
+
+impl EncodeMetric for OpenFilesPerMount {
+    fn encode(&self) -> Vec<MetricFamily> {
+        let values = self.values.read().unwrap();
+        let mut rows = Vec::with_capacity(values.len());
+
+        for (labels, value) in values.iter() {
+            let Ok(label) = to_label_pairs(labels) else {
+                continue;
+            };
+
+            rows.push(Metric {
+                label,
+                gauge: gauge(value.load(Ordering::Relaxed)),
+                ..Default::default()
+            });
+        }
+
+        vec![MetricFamily {
+            name: Some("open_files_per_mount".to_owned()),
+            help: Some("Open file descriptors.".to_owned()),
+            r#type: Some(MetricType::Gauge as i32),
+            metric: rows,
+            unit: None,
+        }]
+    }
+}
+
+/// Implementing [`EncodeMetricValue`] instead delegates all of that to
+/// [`Family`] and [`NamedMetric`]; only the value encoding remains.
+#[derive(Default)]
+struct OpenFilesValue(AtomicU64);
+
+impl EncodeMetricValue for OpenFilesValue {
+    fn encode_metric_value(&self) -> Vec<MetricFamily> {
+        vec![MetricFamily {
+            // Relative name: `NamedMetric` prepends the registered name.
+            name: Some(String::new()),
+            help: None,
+            r#type: Some(MetricType::Gauge as i32),
+            metric: vec![Metric {
+                gauge: gauge(self.0.load(Ordering::Relaxed)),
+                ..Default::default()
+            }],
+            unit: None,
+        }]
+    }
+}
+
+#[test]
+fn both_label_set_approaches_produce_the_same_series() {
+    let manual = OpenFilesPerMount::default();
+    manual
+        .get_or_create(&Labels { mount: "/data" })
+        .store(3, Ordering::Relaxed);
+    register(
+        Box::new(manual.clone()) as Box<dyn EncodeMetric>,
+        RegistrationMetadata::default(),
+    );
+
+    let via_family = Family::<Labels, OpenFilesValue>::default();
+    via_family
+        .get_or_create(&Labels { mount: "/data" })
+        .0
+        .store(3, Ordering::Relaxed);
+    register(
+        Box::new(NamedMetric::new(
+            "open_files_via_family",
+            "Open file descriptors.",
+            via_family,
+        )) as Box<dyn EncodeMetric>,
+        RegistrationMetadata::default(),
+    );
+
+    let families = collected();
+    let manual = &family_named(&families, "open_files_per_mount").metric[0];
+    let via_family = &family_named(&families, "open_files_via_family").metric[0];
+
+    assert_eq!(manual.label, via_family.label);
+    assert_eq!(
+        manual.gauge.as_ref().and_then(|gauge| gauge.value),
+        via_family.gauge.as_ref().and_then(|gauge| gauge.value)
+    );
+    assert_eq!(
+        manual.gauge.as_ref().and_then(|gauge| gauge.value),
+        Some(3.0)
+    );
+}


### PR DESCRIPTION
## Summary

- Add `InfoMetric` for registering one-hot build and runtime metadata as labels.
- Add collection support and registration metadata for unlabeled info metrics.
- Make the registry encoding interface public for user-defined metric implementations.
- Add `EncodeMetricValue` to public interface so custom values can use `NamedMetric` and `Family` without owning naming or family construction.
- Add integration coverage for direct encoders, value encoders, families, metadata, and registration.

## Testing

- `foundations-metrics` tests passed.
- Focused custom metric tests passed.
- Doctests passed.
- Strict clippy passed.