### PR TITLE
feat(foundations): migrate the metrics facade to foundations-metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,8 @@ anyhow = "1.0.102"
 backtrace = "0.3.76"
 foundations = { version = "5.8.1", path = "./foundations", default-features = false }
 foundations-macros = { version = "=5.8.1", path = "./foundations-macros", default-features = false }
-foundations-metrics-registry = { version = "0.1.0", path = "./foundations-metrics-registry" }
+foundations-metrics-registry = { version = "0.1.0", path = "./foundations-metrics-registry", default-features = false }
+foundations-metrics = { version = "0.1.0", path = "./foundations-metrics", default-features = false }
 bindgen = { version = "0.72.1", default-features = false }
 cc = "1.2.61"
 cf-rustracing = "1.4.0"

--- a/foundations-macros/src/metrics/mod.rs
+++ b/foundations-macros/src/metrics/mod.rs
@@ -158,28 +158,9 @@ fn expand_from_parsed(args: MacroArgs, extern_: Mod) -> proc_macro2::TokenStream
         .iter()
         .filter_map(|fn_| label_set_struct(foundations, fn_));
 
-    let registry_init = |var: &str, opt: bool| {
-        let var = Ident::new(var, Span::call_site());
-        let optional = format_ident!("{opt}");
-
-        quote! {
-            let #var = &mut *#foundations::telemetry::metrics::internal::Registries::get_subsystem(
-                stringify!(#mod_name), #optional, #with_service_prefix
-            );
-        }
-    };
-
-    let init_registry = fns
+    let metric_inits = fns
         .iter()
-        .any(|fn_| !fn_.attrs.optional)
-        .then(|| registry_init("registry", false));
-
-    let init_opt_registry = fns
-        .iter()
-        .any(|fn_| fn_.attrs.optional)
-        .then(|| registry_init("opt_registry", true));
-
-    let metric_inits = fns.iter().map(|fn_| metric_init(foundations, fn_));
+        .map(|fn_| metric_init(foundations, &mod_name, &with_service_prefix, fn_));
 
     let metric_fns = fns
         .iter()
@@ -199,9 +180,6 @@ fn expand_from_parsed(args: MacroArgs, extern_: Mod) -> proc_macro2::TokenStream
             #[allow(non_upper_case_globals)]
             static #metrics_struct: ::std::sync::LazyLock<#metrics_struct> =
                 ::std::sync::LazyLock::new(|| {
-                    #init_registry
-                    #init_opt_registry
-
                     #metrics_struct {
                         #(#metric_inits,)*
                     }
@@ -229,7 +207,7 @@ fn metric_field(foundations: &Path, fn_: &ItemFn) -> proc_macro2::TokenStream {
     }) = ctor
     {
         quote! {
-            #foundations::reexports_for_macros::prometools::serde::Family<
+            #foundations::telemetry::metrics::Family<
                 #metric_name,
                 #metric_ty,
                 #ctor_path,
@@ -237,7 +215,7 @@ fn metric_field(foundations: &Path, fn_: &ItemFn) -> proc_macro2::TokenStream {
         }
     } else {
         quote! {
-            #foundations::reexports_for_macros::prometools::serde::Family<
+            #foundations::telemetry::metrics::Family<
                 #metric_name,
                 #metric_ty,
             >
@@ -291,7 +269,12 @@ fn label_set_struct(foundations: &Path, fn_: &ItemFn) -> Option<proc_macro2::Tok
     })
 }
 
-fn metric_init(foundations: &Path, fn_: &ItemFn) -> proc_macro2::TokenStream {
+fn metric_init(
+    foundations: &Path,
+    mod_name: &Ident,
+    with_service_prefix: &Ident,
+    fn_: &ItemFn,
+) -> proc_macro2::TokenStream {
     let ItemFn {
         attrs:
             FnAttrs {
@@ -306,15 +289,7 @@ fn metric_init(foundations: &Path, fn_: &ItemFn) -> proc_macro2::TokenStream {
         ..
     } = fn_;
 
-    let reexports = quote! { #foundations::reexports_for_macros };
-    let registry = Ident::new(
-        if *optional {
-            "opt_registry"
-        } else {
-            "registry"
-        },
-        Span::call_site(),
-    );
+    let optional = format_ident!("{optional}");
 
     // Validate histogram buckets at compile time if this is a HistogramBuilder
     if let Some(ctor) = ctor
@@ -327,10 +302,10 @@ fn metric_init(foundations: &Path, fn_: &ItemFn) -> proc_macro2::TokenStream {
 
     let metric_init = match ctor {
         Some(ctor) if args.is_empty() => quote! {
-            #reexports::prometheus_client::metrics::family::MetricConstructor::new_metric(&(#ctor))
+            #foundations::telemetry::metrics::MetricConstructor::new_metric(&(#ctor))
         },
         Some(ctor) => quote! {
-            #reexports::prometools::serde::Family::new_with_constructor(#ctor)
+            #foundations::telemetry::metrics::Family::new_with_constructor(#ctor)
         },
         None => quote! { ::std::default::Default::default() },
     };
@@ -340,11 +315,18 @@ fn metric_init(foundations: &Path, fn_: &ItemFn) -> proc_macro2::TokenStream {
         #field_name: {
             let metric = #metric_init;
 
-            #reexports::prometheus_client::registry::Registry::register(
-                #registry,
+            #foundations::telemetry::metrics::internal::register_metric(
+                ::std::stringify!(#mod_name),
                 ::std::stringify!(#field_name),
+                ::std::concat!(
+                    ::std::stringify!(#mod_name),
+                    "_",
+                    ::std::stringify!(#field_name),
+                ),
                 str::trim(#doc),
-                #foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
+                ::std::clone::Clone::clone(&metric),
+                #optional,
+                #with_service_prefix,
             );
 
             metric
@@ -386,7 +368,7 @@ fn metric_fn(foundations: &Path, metrics_struct: &Ident, fn_: &ItemFn) -> proc_m
 
         let accessor = quote! {
             ::std::clone::Clone::clone(
-                &#foundations::reexports_for_macros::prometools::serde::Family::get_or_create(
+                &#foundations::telemetry::metrics::Family::get_or_create(
                     &#metrics_struct.#metric_name,
                     &__args,
                 )
@@ -413,7 +395,7 @@ fn metric_fn(foundations: &Path, metrics_struct: &Ident, fn_: &ItemFn) -> proc_m
             #(#cfg)*
             #fn_vis #fn_token #remove_ident(#(#fn_args,)*) #arrow_token bool {
                 #convert_args
-                #foundations::reexports_for_macros::prometools::serde::Family::remove(
+                #foundations::telemetry::metrics::Family::remove(
                     &#metrics_struct.#metric_name,
                     &__args,
                 )
@@ -422,7 +404,7 @@ fn metric_fn(foundations: &Path, metrics_struct: &Ident, fn_: &ItemFn) -> proc_m
             #[doc = #clear_doc]
             #(#cfg)*
             #fn_vis #fn_token #clear_ident() {
-                #foundations::reexports_for_macros::prometools::serde::Family::clear(
+                #foundations::telemetry::metrics::Family::clear(
                     &#metrics_struct.#metric_name,
                 )
             }
@@ -509,17 +491,22 @@ mod tests {
                 #[allow(non_upper_case_globals)]
                 static __oxy_Metrics: ::std::sync::LazyLock<__oxy_Metrics> =
                     ::std::sync::LazyLock::new(|| {
-                        let registry = &mut *tarmac::telemetry::metrics::internal::Registries::get_subsystem(stringify!(oxy), false, true);
-
                         __oxy_Metrics {
                             connections_total: {
                                 let metric = ::std::default::Default::default();
 
-                                tarmac::reexports_for_macros::prometheus_client::registry::Registry::register(
-                                    registry,
+                                tarmac::telemetry::metrics::internal::register_metric(
+                                    ::std::stringify!(oxy),
                                     ::std::stringify!(connections_total),
+                                    ::std::concat!(
+                                        ::std::stringify!(oxy),
+                                        "_",
+                                        ::std::stringify!(connections_total),
+                                    ),
                                     str::trim(" Total number of connections"),
-                                    tarmac::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
+                                    ::std::clone::Clone::clone(&metric),
+                                    false,
+                                    true,
                                 );
 
                                 metric
@@ -566,17 +553,22 @@ mod tests {
                 #[allow(non_upper_case_globals)]
                 static __oxy_Metrics: ::std::sync::LazyLock<__oxy_Metrics> =
                     ::std::sync::LazyLock::new(|| {
-                        let opt_registry = &mut *::foundations::telemetry::metrics::internal::Registries::get_subsystem(stringify!(oxy), true, true);
-
                         __oxy_Metrics {
                             connections_total: {
                                 let metric = ::std::default::Default::default();
 
-                                ::foundations::reexports_for_macros::prometheus_client::registry::Registry::register(
-                                    opt_registry,
+                                ::foundations::telemetry::metrics::internal::register_metric(
+                                    ::std::stringify!(oxy),
                                     ::std::stringify!(connections_total),
+                                    ::std::concat!(
+                                        ::std::stringify!(oxy),
+                                        "_",
+                                        ::std::stringify!(connections_total),
+                                    ),
                                     str::trim(" Total number of connections"),
-                                    ::foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
+                                    ::std::clone::Clone::clone(&metric),
+                                    true,
+                                    true,
                                 );
 
                                 metric
@@ -627,18 +619,22 @@ mod tests {
                 #[allow(non_upper_case_globals)]
                 static __oxy_Metrics: ::std::sync::LazyLock<__oxy_Metrics> =
                     ::std::sync::LazyLock::new(|| {
-                        let registry = &mut *::foundations::telemetry::metrics::internal::Registries::get_subsystem(stringify!(oxy), false, false);
-                        let opt_registry = &mut *::foundations::telemetry::metrics::internal::Registries::get_subsystem(stringify!(oxy), true, false);
-
                         __oxy_Metrics {
                             requests_total: {
                                 let metric = ::std::default::Default::default();
 
-                                ::foundations::reexports_for_macros::prometheus_client::registry::Registry::register(
-                                    registry,
+                                ::foundations::telemetry::metrics::internal::register_metric(
+                                    ::std::stringify!(oxy),
                                     ::std::stringify!(requests_total),
+                                    ::std::concat!(
+                                        ::std::stringify!(oxy),
+                                        "_",
+                                        ::std::stringify!(requests_total),
+                                    ),
                                     str::trim(" Total number of requests"),
-                                    ::foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
+                                    ::std::clone::Clone::clone(&metric),
+                                    false,
+                                    false,
                                 );
 
                                 metric
@@ -646,11 +642,18 @@ mod tests {
                             connections_total: {
                                 let metric = ::std::default::Default::default();
 
-                                ::foundations::reexports_for_macros::prometheus_client::registry::Registry::register(
-                                    opt_registry,
+                                ::foundations::telemetry::metrics::internal::register_metric(
+                                    ::std::stringify!(oxy),
                                     ::std::stringify!(connections_total),
+                                    ::std::concat!(
+                                        ::std::stringify!(oxy),
+                                        "_",
+                                        ::std::stringify!(connections_total),
+                                    ),
                                     str::trim(" Total number of connections"),
-                                    ::foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
+                                    ::std::clone::Clone::clone(&metric),
+                                    true,
+                                    false,
                                 );
 
                                 metric
@@ -704,7 +707,7 @@ mod tests {
                 #[allow(non_camel_case_types)]
                 struct __oxy_Metrics {
                     connections_errors_total:
-                        ::foundations::reexports_for_macros::prometools::serde::Family<
+                        ::foundations::telemetry::metrics::Family<
                             connections_errors_total,
                             Counter,
                         >,
@@ -732,17 +735,22 @@ mod tests {
                 #[allow(non_upper_case_globals)]
                 static __oxy_Metrics: ::std::sync::LazyLock<__oxy_Metrics> =
                     ::std::sync::LazyLock::new(|| {
-                        let registry = &mut *::foundations::telemetry::metrics::internal::Registries::get_subsystem(stringify!(oxy), false, true);
-
                         __oxy_Metrics {
                             connections_errors_total: {
                                 let metric = ::std::default::Default::default();
 
-                                ::foundations::reexports_for_macros::prometheus_client::registry::Registry::register(
-                                    registry,
+                                ::foundations::telemetry::metrics::internal::register_metric(
+                                    ::std::stringify!(oxy),
                                     ::std::stringify!(connections_errors_total),
+                                    ::std::concat!(
+                                        ::std::stringify!(oxy),
+                                        "_",
+                                        ::std::stringify!(connections_errors_total),
+                                    ),
                                     str::trim(" Total number of connection errors"),
-                                    ::foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
+                                    ::std::clone::Clone::clone(&metric),
+                                    false,
+                                    true,
                                 );
 
                                 metric
@@ -765,7 +773,7 @@ mod tests {
                         error: ::std::convert::Into::into(error),
                     };
                     ::std::clone::Clone::clone(
-                        &::foundations::reexports_for_macros::prometools::serde::Family::get_or_create(
+                        &::foundations::telemetry::metrics::Family::get_or_create(
                             &__oxy_Metrics.connections_errors_total,
                             &__args,
                         )
@@ -805,7 +813,7 @@ mod tests {
                 struct __oxy_Metrics {
                     connections_latency: Histogram,
                     requests_per_connection:
-                        ::foundations::reexports_for_macros::prometools::serde::Family<
+                        ::foundations::telemetry::metrics::Family<
                             requests_per_connection,
                             Histogram,
                             HistogramBuilder,
@@ -828,33 +836,45 @@ mod tests {
                 #[allow(non_upper_case_globals)]
                 static __oxy_Metrics: ::std::sync::LazyLock<__oxy_Metrics> =
                     ::std::sync::LazyLock::new(|| {
-                        let registry = &mut *::foundations::telemetry::metrics::internal::Registries::get_subsystem(stringify!(oxy), false, true);
-
                         __oxy_Metrics {
                             connections_latency: {
-                                let metric = ::foundations::reexports_for_macros::prometheus_client::metrics::family::MetricConstructor::new_metric(
+                                let metric = ::foundations::telemetry::metrics::MetricConstructor::new_metric(
                                     &(HistogramBuilder { buckets: &[0.5, 1.] })
                                 );
 
-                                ::foundations::reexports_for_macros::prometheus_client::registry::Registry::register(
-                                    registry,
+                                ::foundations::telemetry::metrics::internal::register_metric(
+                                    ::std::stringify!(oxy),
                                     ::std::stringify!(connections_latency),
+                                    ::std::concat!(
+                                        ::std::stringify!(oxy),
+                                        "_",
+                                        ::std::stringify!(connections_latency),
+                                    ),
                                     str::trim(" Latency of connections"),
-                                    ::foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
+                                    ::std::clone::Clone::clone(&metric),
+                                    false,
+                                    true,
                                 );
 
                                 metric
                             },
                             requests_per_connection: {
-                                let metric = ::foundations::reexports_for_macros::prometools::serde::Family::new_with_constructor(
+                                let metric = ::foundations::telemetry::metrics::Family::new_with_constructor(
                                     HistogramBuilder { buckets: &[2., 3.] }
                                 );
 
-                                ::foundations::reexports_for_macros::prometheus_client::registry::Registry::register(
-                                    registry,
+                                ::foundations::telemetry::metrics::internal::register_metric(
+                                    ::std::stringify!(oxy),
                                     ::std::stringify!(requests_per_connection),
+                                    ::std::concat!(
+                                        ::std::stringify!(oxy),
+                                        "_",
+                                        ::std::stringify!(requests_per_connection),
+                                    ),
                                     str::trim(" Number of requests per connection"),
-                                    ::foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
+                                    ::std::clone::Clone::clone(&metric),
+                                    false,
+                                    true,
                                 );
 
                                 metric
@@ -875,7 +895,7 @@ mod tests {
                 ) -> Histogram {
                     let __args = requests_per_connection { endpoint, };
                     ::std::clone::Clone::clone(
-                        &::foundations::reexports_for_macros::prometools::serde::Family::get_or_create(
+                        &::foundations::telemetry::metrics::Family::get_or_create(
                             &__oxy_Metrics.requests_per_connection,
                             &__args,
                         )
@@ -911,7 +931,7 @@ mod tests {
                 #[allow(non_camel_case_types)]
                 struct __oxy_Metrics {
                     requests_total:
-                        ::foundations::reexports_for_macros::prometools::serde::Family<
+                        ::foundations::telemetry::metrics::Family<
                             requests_total,
                             Counter,
                         >,
@@ -933,17 +953,22 @@ mod tests {
                 #[allow(non_upper_case_globals)]
                 static __oxy_Metrics: ::std::sync::LazyLock<__oxy_Metrics> =
                     ::std::sync::LazyLock::new(|| {
-                        let registry = &mut *::foundations::telemetry::metrics::internal::Registries::get_subsystem(stringify!(oxy), false, true);
-
                         __oxy_Metrics {
                             requests_total: {
                                 let metric = ::std::default::Default::default();
 
-                                ::foundations::reexports_for_macros::prometheus_client::registry::Registry::register(
-                                    registry,
+                                ::foundations::telemetry::metrics::internal::register_metric(
+                                    ::std::stringify!(oxy),
                                     ::std::stringify!(requests_total),
+                                    ::std::concat!(
+                                        ::std::stringify!(oxy),
+                                        "_",
+                                        ::std::stringify!(requests_total),
+                                    ),
                                     str::trim(" Total number of requests"),
-                                    ::foundations::telemetry::metrics::internal::wrap_metric(::std::clone::Clone::clone(&metric)),
+                                    ::std::clone::Clone::clone(&metric),
+                                    false,
+                                    true,
                                 );
 
                                 metric
@@ -956,7 +981,7 @@ mod tests {
                 pub(crate) fn requests_total(status: u16,) -> Counter {
                     let __args = requests_total { status, };
                     ::std::clone::Clone::clone(
-                        &::foundations::reexports_for_macros::prometools::serde::Family::get_or_create(
+                        &::foundations::telemetry::metrics::Family::get_or_create(
                             &__oxy_Metrics.requests_total,
                             &__args,
                         )
@@ -966,7 +991,7 @@ mod tests {
                 #[doc = "Removes one label set from the `requests_total` family."]
                 pub(crate) fn requests_total_remove(status: u16,) -> bool {
                     let __args = requests_total { status, };
-                    ::foundations::reexports_for_macros::prometools::serde::Family::remove(
+                    ::foundations::telemetry::metrics::Family::remove(
                         &__oxy_Metrics.requests_total,
                         &__args,
                     )
@@ -974,7 +999,7 @@ mod tests {
 
                 #[doc = "Removes all label sets from the `requests_total` family."]
                 pub(crate) fn requests_total_clear() {
-                    ::foundations::reexports_for_macros::prometools::serde::Family::clear(
+                    ::foundations::telemetry::metrics::Family::clear(
                         &__oxy_Metrics.requests_total,
                     )
                 }

--- a/foundations-metrics-registry/src/metadata.rs
+++ b/foundations-metrics-registry/src/metadata.rs
@@ -14,8 +14,8 @@ pub struct RegistrationMetadata {
     /// With service name `api` and `MetricPrefix`, enabling this changes:
     ///
     /// ```text
-    /// Before: api_requests_total 1.0
-    /// After:  requests_total 1.0
+    /// Before: api_requests_total 1
+    /// After:  requests_total 1
     /// ```
     pub unprefixed: bool,
 
@@ -24,8 +24,8 @@ pub struct RegistrationMetadata {
     /// With service name `api` and `LabelWithName("service")`, enabling this changes:
     ///
     /// ```text
-    /// Before: requests_total{service="api"} 1.0
-    /// After:  requests_total 1.0
+    /// Before: requests_total{service="api"} 1
+    /// After:  requests_total 1
     /// ```
     ///
     /// Independent of [`unprefixed`](Self::unprefixed): a metric that opts out

--- a/foundations-metrics/src/encoding/text.rs
+++ b/foundations-metrics/src/encoding/text.rs
@@ -13,9 +13,9 @@ pub const OPENMETRICS_CONTENT_TYPE: &str =
 
 /// Encodes metric families as UTF-8 OpenMetrics text.
 ///
-/// Label names are always quoted. Metric names outside the legacy Prometheus
-/// grammar use the quoted metric-name form. Serve the output with
-/// [`OPENMETRICS_CONTENT_TYPE`] so scrapers retain UTF-8 names.
+/// Metric and label names outside their legacy Prometheus grammars use quoted
+/// forms. Serve the output with [`OPENMETRICS_CONTENT_TYPE`] so scrapers retain
+/// UTF-8 names.
 pub fn encode_to_text(families: &[MetricFamily]) -> String {
     let mut output = String::new();
 
@@ -94,7 +94,7 @@ fn encode_metric(output: &mut String, name: &str, metric_type: MetricType, metri
                 "",
                 metric,
                 None,
-                SampleValue::Float(counter.value.unwrap_or_default()),
+                SampleValue::LegacyCompatibleFloat(counter.value.unwrap_or_default()),
                 counter.exemplar.as_ref(),
             );
         }
@@ -108,7 +108,7 @@ fn encode_metric(output: &mut String, name: &str, metric_type: MetricType, metri
                 name,
                 "",
                 metric,
-                SampleValue::Float(gauge.value.unwrap_or_default()),
+                SampleValue::LegacyCompatibleFloat(gauge.value.unwrap_or_default()),
             );
         }
         MetricType::Summary => {
@@ -266,6 +266,9 @@ fn has_native_buckets(histogram: &Histogram) -> bool {
 #[derive(Clone, Copy)]
 enum SampleValue {
     Float(f64),
+    // Removes `.0` from integral counters & gauges which protobuf produces
+    // to preserve compatibility with older foundations versions.
+    LegacyCompatibleFloat(f64),
     Unsigned(u64),
 }
 
@@ -292,6 +295,7 @@ fn write_sample(
     output.push(' ');
     match value {
         SampleValue::Float(value) => write_float(output, value),
+        SampleValue::LegacyCompatibleFloat(value) => write_legacy_compatible_float(output, value),
         SampleValue::Unsigned(value) => {
             write!(output, "{value}").expect("writing to a String cannot fail");
         }
@@ -436,6 +440,14 @@ fn write_quoted(output: &mut String, value: &str) {
 }
 
 fn write_float(output: &mut String, value: f64) {
+    write_float_impl(output, value, true);
+}
+
+fn write_legacy_compatible_float(output: &mut String, value: f64) {
+    write_float_impl(output, value, false);
+}
+
+fn write_float_impl(output: &mut String, value: f64, preserve_float_syntax: bool) {
     if value.is_nan() {
         output.push_str("NaN");
     } else if value == f64::INFINITY {
@@ -445,8 +457,13 @@ fn write_float(output: &mut String, value: f64) {
     } else {
         let mut buffer = ryu::Buffer::new();
         let formatted = buffer.format(value);
+        let formatted = if preserve_float_syntax {
+            formatted
+        } else {
+            formatted.strip_suffix(".0").unwrap_or(formatted)
+        };
         output.push_str(formatted);
-        if !formatted.contains(['.', 'e', 'E']) {
+        if preserve_float_syntax && !formatted.contains(['.', 'e', 'E']) {
             output.push_str(".0");
         }
     }
@@ -514,7 +531,7 @@ mod tests {
         assert_eq!(
             encode_to_text(&families),
             "# TYPE requests counter\n\
-requests{route=\"/test\",_internal9=\"yes\",\"trace:id\"=\"abc\",\"label.name\"=\"dotted\",\"indicateur_\u{8017}\u{65f6}\"=\"utf8\"} 1.0\n\
+requests{route=\"/test\",_internal9=\"yes\",\"trace:id\"=\"abc\",\"label.name\"=\"dotted\",\"indicateur_\u{8017}\u{65f6}\"=\"utf8\"} 1\n\
 # EOF\n"
         );
     }
@@ -538,7 +555,7 @@ requests{route=\"/test\",_internal9=\"yes\",\"trace:id\"=\"abc\",\"label.name\"=
         assert_eq!(
             encode_to_text(&families),
             "# TYPE requests counter\n\
-requests 1.0\n\
+requests 1\n\
 # EOF\n"
         );
     }
@@ -576,7 +593,7 @@ requests 1.0\n\
             encode_to_text(&families),
             "# HELP requests A \\\"quoted\\\" help\\\\line\\nnext\n\
 # TYPE requests counter\n\
-requests{kind=\"a\\\"b\\\\c\\nd\"} 1.0 1.5 # {trace_id=\"abc\"} 2.0\n\
+requests{kind=\"a\\\"b\\\\c\\nd\"} 1 1.5 # {trace_id=\"abc\"} 2.0\n\
 # EOF\n"
         );
     }
@@ -718,6 +735,7 @@ queue_depth_bucket{le=\"+Inf\"} 3\n\
             r#type: Some(MetricType::Gauge as i32),
             metric: [f64::NAN, f64::INFINITY, f64::NEG_INFINITY]
                 .into_iter()
+                .chain([1.0, 1.5])
                 .map(|value| Metric {
                     gauge: Some(Gauge { value: Some(value) }),
                     ..Default::default()
@@ -732,6 +750,8 @@ queue_depth_bucket{le=\"+Inf\"} 3\n\
 temperature NaN\n\
 temperature +Inf\n\
 temperature -Inf\n\
+temperature 1\n\
+temperature 1.5\n\
 # EOF\n"
         );
     }
@@ -757,7 +777,7 @@ temperature -Inf\n\
             encode_to_text(&families),
             "# HELP build_info Build information.\n\
 # TYPE build_info gauge\n\
-build_info{version=\"1.2.3\"} 1.0\n\
+build_info{version=\"1.2.3\"} 1\n\
 # EOF\n"
         );
     }
@@ -835,9 +855,9 @@ build_info{version=\"1.2.3\"} 1.0\n\
             encode_to_text(&families),
             "# HELP \"bad\\n# HELP injected metadata\" Escaped help.\n\
 # TYPE \"bad\\n# HELP injected metadata\" gauge\n\
-{\"bad\\n# HELP injected metadata\",\"路由.name\\n\"=\"值\"} 99.0\n\
+{\"bad\\n# HELP injected metadata\",\"路由.name\\n\"=\"值\"} 99\n\
 # TYPE valid:metric gauge\n\
-valid:metric 1.0\n\
+valid:metric 1\n\
 # EOF\n"
         );
     }
@@ -930,9 +950,9 @@ valid:metric 1.0\n\
         ];
 
         let output = encode_to_text(&families);
-        assert!(output.contains("row_gauge{id=\"valid\"} 1.0\n"));
-        assert!(output.contains("row_gauge{\"bad name\"=\"nonstandard\"} 99.0\n"));
-        assert!(!output.contains("98.0"));
+        assert!(output.contains("row_gauge{id=\"valid\"} 1\n"));
+        assert!(output.contains("row_gauge{\"bad name\"=\"nonstandard\"} 99\n"));
+        assert!(!output.contains(" 98\n"));
         assert_eq!(output.matches("row_histogram_sum").count(), 1);
         assert_eq!(output.matches("row_summary_sum").count(), 1);
         assert_eq!(output.matches("row_gauge_histogram_gsum").count(), 1);
@@ -1004,11 +1024,10 @@ valid:metric 1.0\n\
 
         let output = encode_to_text(&families);
         assert!(
-            output.contains(
-                "exemplar_counter{id=\"nonstandard\"} 1.0 # {\"trace:id\"=\"bad\"} 2.0\n"
-            )
+            output
+                .contains("exemplar_counter{id=\"nonstandard\"} 1 # {\"trace:id\"=\"bad\"} 2.0\n")
         );
-        assert!(output.contains("exemplar_counter{id=\"valid\"} 3.0 # {trace_id=\"good\"} 4.0\n"));
+        assert!(output.contains("exemplar_counter{id=\"valid\"} 3 # {trace_id=\"good\"} 4.0\n"));
         assert!(output.contains("exemplar_histogram_bucket{le=\"1.0\"} 1\n"));
         assert!(!output.contains("\"dup\"="));
     }

--- a/foundations-metrics/src/metrics/exemplar.rs
+++ b/foundations-metrics/src/metrics/exemplar.rs
@@ -561,7 +561,7 @@ mod tests {
         counter.inc_by_with_exemplar((), 2);
 
         let families = NamedMetric::new("empty_exemplar", "", counter).encode();
-        assert!(encode_to_text(&families).contains("empty_exemplar 2.0 # {} 2.0\n"));
+        assert!(encode_to_text(&families).contains("empty_exemplar 2 # {} 2.0\n"));
     }
 
     #[test]
@@ -698,7 +698,7 @@ mod tests {
 
         let text = encode_to_text(std::slice::from_ref(family));
         assert!(
-            text.contains("registered_counter_with_exemplar 4.0 # {trace_id=\"registered\"} 4.0\n")
+            text.contains("registered_counter_with_exemplar 4 # {trace_id=\"registered\"} 4.0\n")
         );
     }
 

--- a/foundations-sentry/tests/sentry_hook.rs
+++ b/foundations-sentry/tests/sentry_hook.rs
@@ -34,10 +34,14 @@ fn sentry_hook_increments_metric_on_event() {
     simulate_sentry_event(&hub);
     assert_eq!(metrics::sentry::events_total(Level::Error).get(), 1);
 
+    const SERIES: &str = "sentry_events_total{level=\"error\"} ";
+
     let metrics = foundations::telemetry::metrics::collect(&Default::default()).unwrap();
-    let has_metric = metrics
-        .lines()
-        .any(|line| line == "sentry_events_total{level=\"error\"} 1");
+    let has_metric = metrics.lines().any(|line| {
+        line.strip_prefix(SERIES)
+            .and_then(|value| value.parse::<f64>().ok())
+            == Some(1.0)
+    });
     assert!(has_metric);
 }
 

--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -33,7 +33,7 @@ pre-release-hook = [
 
 [features]
 # Default set of features.
-default = ["platform-common-default", "security"]
+default = ["platform-common-default", "security", "foundations-metrics-backend"]
 
 # All non platform-specific features
 platform-common-default = [
@@ -215,6 +215,11 @@ telemetry-server-pattern-routing = []
 # logging drain that forwards logs
 tracing-rs-compat = ["dep:tracing-slog"]
 
+# Selects the `foundations-metrics` implementation behind `telemetry::metrics`.
+# The `metrics` macro expands identically either way: it emits paths that this
+# crate resolves, so the macro needs no feature of its own.
+foundations-metrics-backend = ["dep:foundations-metrics", "dep:foundations-metrics-registry"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "foundations_docsrs", "--cfg", "tokio_unstable", "--cfg", "foundations_unstable"]
@@ -229,6 +234,8 @@ workspace = true
 anyhow = { workspace = true, features = ["backtrace", "std"] }
 backtrace = { workspace = true, optional = true }
 foundations-macros = { workspace = true, optional = true, default-features = false }
+foundations-metrics = { workspace = true, optional = true, default-features = false }
+foundations-metrics-registry = { workspace = true, optional = true, default-features = false }
 cf-rustracing = { workspace = true, optional = true }
 cf-rustracing-jaeger = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }

--- a/foundations/src/telemetry/metrics/init.rs
+++ b/foundations/src/telemetry/metrics/init.rs
@@ -1,19 +1,73 @@
-use super::internal::{BuildInfo, Registries, RuntimeInfo};
-use super::report_info;
+#[cfg(feature = "foundations-metrics-backend")]
+use std::sync::OnceLock;
+
 use crate::ServiceInfo;
 use crate::telemetry::settings::MetricsSettings;
+
+#[cfg(not(feature = "foundations-metrics-backend"))]
+use super::internal::Registries;
+use super::{info_metric, report_info};
+
+/// Build and version information
+#[info_metric(crate_path = "crate")]
+struct BuildInfo {
+    version: &'static str,
+}
+
+/// Information about the process runtime
+#[info_metric(crate_path = "crate")]
+struct RuntimeInfo {
+    pid: u32,
+}
+
+/// Service name reported before [`init`] has been called.
+#[cfg(feature = "foundations-metrics-backend")]
+static UNINITIALISED_SERVICE_NAME: &str = "undefined";
+
+#[cfg(feature = "foundations-metrics-backend")]
+static SERVICE_NAME: OnceLock<String> = OnceLock::new();
+
+/// Returns the service name to apply when collecting metrics.
+///
+/// Reads without initialising, so collecting before [`init`] falls back to
+/// [`UNINITIALISED_SERVICE_NAME`] without preventing a later [`init`] from
+/// taking effect.
+#[cfg(feature = "foundations-metrics-backend")]
+pub(super) fn service_name() -> &'static str {
+    SERVICE_NAME
+        .get()
+        .map(String::as_str)
+        .unwrap_or(UNINITIALISED_SERVICE_NAME)
+}
 
 /// Initializes the metric system with a system-wide metric prefix.
 ///
 /// Must be called before any use of metrics defined
 /// by the `metrics` proc macro attribute.
 pub(crate) fn init(service_info: &ServiceInfo, settings: &MetricsSettings) {
+    #[cfg(not(feature = "foundations-metrics-backend"))]
     let first_install = Registries::init(service_info, settings);
+
+    #[cfg(feature = "foundations-metrics-backend")]
+    let first_install = {
+        let _ = settings; // format is read at collect time
+
+        // `foundations-metrics` defaults to reporting non-fatal collection
+        // diagnostics on stderr; route them through telemetry instead. A hook
+        // installed by the service takes precedence.
+        let _ = foundations_metrics::set_collect_error_hook(|args| {
+            super::report_nonfatal_collect_error(&args);
+        });
+
+        SERVICE_NAME
+            .set(service_info.name_in_metrics.clone())
+            .is_ok()
+    };
+
     if first_install {
         report_info(BuildInfo {
             version: service_info.version,
         });
-
         report_info(RuntimeInfo {
             pid: std::process::id(),
         });

--- a/foundations/src/telemetry/metrics/internal.rs
+++ b/foundations/src/telemetry/metrics/internal.rs
@@ -1,5 +1,5 @@
 use super::rewind::{RewindState, RewindTo};
-use super::{ExtraProducer, InfoMetric, info_metric, report_nonfatal_collect_error};
+use super::{ExtraProducer, InfoMetric, report_nonfatal_collect_error};
 use crate::telemetry::settings::{MetricsSettings, ServiceNameFormat};
 use crate::{Result, ServiceInfo};
 use prometheus_client::encoding::text::{EncodeMetric, Encoder, SendSyncEncodeMetric, encode};
@@ -146,18 +146,6 @@ impl Registries {
     }
 }
 
-/// Build and version information
-#[info_metric(crate_path = "crate")]
-pub(super) struct BuildInfo {
-    pub(super) version: &'static str,
-}
-
-/// Information about the process runtime
-#[info_metric(crate_path = "crate")]
-pub(super) struct RuntimeInfo {
-    pub(super) pid: u32,
-}
-
 pub(super) trait ErasedInfoMetric: erased_serde::Serialize + Send + Sync + 'static {
     fn name(&self) -> &'static str;
 
@@ -216,6 +204,26 @@ impl<M: EncodeMetric> EncodeMetric for RewindErrorEncode<M> {
 /// Wraps a metric in our private error-handling type, without making the type public.
 pub fn wrap_metric(metric: impl SendSyncEncodeMetric + 'static) -> Box<dyn SendSyncEncodeMetric> {
     Box::new(RewindErrorEncode(metric))
+}
+
+/// Registers a metric declared through the [`metrics`](super::metrics) macro.
+///
+/// `full_name` is unused here: the exported name is composed by the registries
+/// from the service prefix, the `subsystem` sub-registry, and `name`.
+pub fn register_metric<M>(
+    subsystem: &'static str,
+    name: &'static str,
+    _full_name: &'static str,
+    help: &'static str,
+    metric: M,
+    optional: bool,
+    with_service_prefix: bool,
+) where
+    M: SendSyncEncodeMetric + 'static,
+{
+    let mut registry = Registries::get_subsystem(subsystem, optional, with_service_prefix);
+
+    registry.register(name, help, wrap_metric(metric));
 }
 
 fn encode_registry(buffer: &mut Vec<u8>, registry: &Registry<impl EncodeMetric>) -> Result<()> {

--- a/foundations/src/telemetry/metrics/internal_backend.rs
+++ b/foundations/src/telemetry/metrics/internal_backend.rs
@@ -1,0 +1,27 @@
+//! Registration glue used by the [`metrics`](super::metrics) macro when the
+//! `foundations-metrics` backend is enabled.
+
+use foundations_metrics::{EncodeMetric, NamedMetric, RegistrationMetadata, register};
+
+/// Registers a metric declared through the [`metrics`](super::metrics) macro.
+///
+/// Here the macro supplies the already composed `full_name`, and the service name is applied
+/// at collection time.
+pub fn register_metric<M>(
+    _subsystem: &'static str,
+    _name: &'static str,
+    full_name: &'static str,
+    help: &'static str,
+    metric: M,
+    optional: bool,
+    with_service_prefix: bool,
+) where
+    NamedMetric<M>: EncodeMetric,
+{
+    register(
+        Box::new(NamedMetric::new(full_name, help, metric)) as Box<dyn EncodeMetric>,
+        RegistrationMetadata::default()
+            .optional(optional)
+            .unprefixed(!with_service_prefix),
+    );
+}

--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -11,38 +11,114 @@
 
 use super::settings::MetricsSettings;
 use crate::Result;
-use prometheus::{Encoder, TextEncoder};
-use serde::Serialize;
-use std::any::TypeId;
 use std::fmt::Display;
 
+#[cfg(not(feature = "foundations-metrics-backend"))]
+use prometheus::{Encoder, TextEncoder};
+#[cfg(not(feature = "foundations-metrics-backend"))]
+use serde::Serialize;
+#[cfg(not(feature = "foundations-metrics-backend"))]
+use std::any::TypeId;
+
+// Aliased so it does not shadow the glob-re-exported `backend::ServiceNameFormat`.
+#[cfg(feature = "foundations-metrics-backend")]
+use super::settings::ServiceNameFormat as SettingsServiceNameFormat;
+#[cfg(feature = "foundations-metrics-backend")]
+use std::sync::OnceLock;
+
+#[cfg(not(feature = "foundations-metrics-backend"))]
 mod gauge;
+#[cfg(not(feature = "foundations-metrics-backend"))]
 mod rewind;
 
 pub(super) mod init;
 
 #[doc(hidden)]
+#[cfg(not(feature = "foundations-metrics-backend"))]
 pub mod internal;
 
+#[doc(hidden)]
+#[cfg(feature = "foundations-metrics-backend")]
+#[path = "internal_backend.rs"]
+pub mod internal;
+
+#[cfg(not(feature = "foundations-metrics-backend"))]
 use internal::{ErasedInfoMetric, Registries};
 
-pub use gauge::{GaugeGuard, RangeGauge};
-pub use prometheus_client::metrics::exemplar::{CounterWithExemplar, HistogramWithExemplars};
-pub use prometheus_client::metrics::family::MetricConstructor;
-pub use prometheus_client::metrics::gauge::Gauge;
-pub use prometheus_client::metrics::histogram::Histogram;
-pub use prometools::histogram::{HistogramTimer, TimeHistogram};
-pub use prometools::nonstandard::NonstandardUnsuffixedCounter as Counter;
-pub use prometools::serde::Family;
+#[cfg(feature = "foundations-metrics-backend")]
+mod backend {
+    pub use foundations_metrics::{
+        Counter, Family, Gauge, GaugeGuard, Histogram, HistogramTimer, InfoMetric,
+        MetricConstructor, NativeHistogram, NativeHistogramBuilder, RangeGauge, TimeHistogram,
+        WithExemplar,
+    };
+
+    // Everything needed to define, register, and label a custom metric. The
+    // protobuf data model is re-exported as `proto` so that implementors do not
+    // need a direct dependency on `foundations-metrics-registry`.
+    pub use foundations_metrics::{
+        EncodeMetric, EncodeMetricValue, IntoMetrics, LabelError, MetricFamily, NamedMetric,
+        RegistrationMetadata, proto, register, to_label_pairs,
+    };
+}
+#[cfg(not(feature = "foundations-metrics-backend"))]
+mod backend {
+    pub use super::gauge::{GaugeGuard, RangeGauge};
+    pub use prometheus_client::metrics::exemplar::{CounterWithExemplar, HistogramWithExemplars};
+    pub use prometheus_client::metrics::family::MetricConstructor;
+    pub use prometheus_client::metrics::gauge::Gauge;
+    pub use prometheus_client::metrics::histogram::Histogram;
+    pub use prometools::histogram::{HistogramTimer, TimeHistogram};
+    pub use prometools::nonstandard::NonstandardUnsuffixedCounter as Counter;
+    pub use prometools::serde::Family;
+}
+
+pub use backend::*;
 
 /// Collects all metrics in [Prometheus text format].
 ///
 /// [Prometheus text format]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
 pub fn collect(settings: &MetricsSettings) -> Result<String> {
-    let mut buffer = Vec::with_capacity(128);
+    let mut buffer: Vec<u8> = Vec::with_capacity(128);
 
-    Registries::collect(&mut buffer, settings.report_optional)?;
-    TextEncoder::new().encode(&prometheus::gather(), &mut buffer)?;
+    #[cfg(not(feature = "foundations-metrics-backend"))]
+    {
+        Registries::collect(&mut buffer, settings.report_optional)?;
+        TextEncoder::new().encode(&prometheus::gather(), &mut buffer)?;
+    }
+
+    #[cfg(feature = "foundations-metrics-backend")]
+    {
+        // The service name is only known once telemetry is initialized, so it is
+        // applied here rather than at registration time.
+        let service_name_format = match &settings.service_name_format {
+            SettingsServiceNameFormat::MetricPrefix => {
+                foundations_metrics::ServiceNameFormat::MetricPrefix
+            }
+            SettingsServiceNameFormat::LabelWithName(label_name) => {
+                foundations_metrics::ServiceNameFormat::LabelWithName(label_name)
+            }
+        };
+
+        let families = foundations_metrics::collect(foundations_metrics::CollectionOptions {
+            include_optional: settings.report_optional,
+            service_name: Some(init::service_name()),
+            service_name_format,
+        });
+
+        buffer.extend_from_slice(foundations_metrics::encode_to_text(&families).as_bytes());
+
+        // Extra producers append their own terminated output, so the terminator
+        // is dropped here and re-added once everything has been produced.
+        truncate_eof(&mut buffer);
+
+        if let Some(producers) = EXTRA_PRODUCERS.get() {
+            for producer in producers.read().iter() {
+                producer.produce(&mut buffer);
+                truncate_eof(&mut buffer);
+            }
+        }
+    }
 
     buffer.extend_from_slice(b"# EOF\n");
 
@@ -51,6 +127,16 @@ pub fn collect(settings: &MetricsSettings) -> Result<String> {
         String::from_utf8_lossy(err.as_bytes()).into_owned()
     });
     Ok(metrics_str)
+}
+
+/// Removes the trailing OpenMetrics terminator, if present.
+#[cfg(feature = "foundations-metrics-backend")]
+fn truncate_eof(buffer: &mut Vec<u8>) {
+    const EOF_MARKER: &[u8] = b"# EOF\n";
+
+    if buffer.ends_with(EOF_MARKER) {
+        buffer.truncate(buffer.len() - EOF_MARKER.len());
+    }
 }
 
 #[inline]
@@ -76,15 +162,15 @@ fn report_nonfatal_collect_error(err: &dyn Display) {
 /// # Labels
 /// Arguments of the bodyless functions become labels for that metric.
 ///
-/// The metric types must implement [`prometheus_client::metrics::MetricType`], they
-/// are reexported from this module for convenience:
+/// Supported metric types are reexported from this module for convenience:
 ///
 /// * [`Counter`]
-/// * [`CounterWithExemplar`]
 /// * [`Gauge`]
 /// * [`Histogram`]
-/// * [`HistogramWithExemplars`]
 /// * [`TimeHistogram`]
+///
+/// To attach exemplars, wrap any of the above in [`WithExemplar<T, S>`], which
+/// derefs to the metric it wraps.
 ///
 /// The metrics associated with the functions are automatically registered in a global
 /// registry, and they can be collected with the [`collect`] function.
@@ -95,8 +181,8 @@ fn report_nonfatal_collect_error(err: &dyn Display) {
 ///
 /// ## `#[ctor]`
 ///
-/// `#[ctor]` attribute allows specifying how the metric should be built (e.g. [`HistogramBuilder`]).
-/// Constructor should implement the [`MetricConstructor<MetricType>`] trait.
+/// `#[ctor]` allows specifying how the metric should be built (e.g. [`HistogramBuilder`]).
+/// The constructor should implement [`MetricConstructor`] for the metric type.
 ///
 /// ## `#[optional]`
 ///
@@ -343,6 +429,7 @@ pub use foundations_macros::info_metric;
 /// Info metrics are used to expose textual information, through the label set, which should not
 /// change often during process lifetime. Common examples are an application's version, revision
 /// control commit, and the version of a compiler.
+#[cfg(not(feature = "foundations-metrics-backend"))]
 pub trait InfoMetric: Serialize + Send + Sync + 'static {
     /// The name of the info metric.
     const NAME: &'static str;
@@ -372,10 +459,18 @@ pub fn report_info<M>(info_metric: impl Into<Box<M>>)
 where
     M: InfoMetric,
 {
-    Registries::get().info.write().insert(
-        TypeId::of::<M>(),
-        info_metric.into() as Box<dyn ErasedInfoMetric>,
-    );
+    #[cfg(not(feature = "foundations-metrics-backend"))]
+    {
+        Registries::get().info.write().insert(
+            TypeId::of::<M>(),
+            info_metric.into() as Box<dyn ErasedInfoMetric>,
+        );
+    }
+
+    #[cfg(feature = "foundations-metrics-backend")]
+    {
+        foundations_metrics::report_info(info_metric);
+    }
 }
 
 /// A builder suitable for [`Histogram`] and [`TimeHistogram`].
@@ -412,9 +507,20 @@ impl MetricConstructor<Histogram> for HistogramBuilder {
     }
 }
 
+#[cfg(not(feature = "foundations-metrics-backend"))]
 impl<S> MetricConstructor<HistogramWithExemplars<S>> for HistogramBuilder {
     fn new_metric(&self) -> HistogramWithExemplars<S> {
         HistogramWithExemplars::new(self.buckets.iter().cloned())
+    }
+}
+
+// The `foundations-metrics` backend replaces the per-type exemplar wrappers
+// with a single generic `WithExemplar<T, S>`, so the builder constructs that
+// instead.
+#[cfg(feature = "foundations-metrics-backend")]
+impl<S> MetricConstructor<WithExemplar<Histogram, S>> for HistogramBuilder {
+    fn new_metric(&self) -> WithExemplar<Histogram, S> {
+        WithExemplar::new(MetricConstructor::<Histogram>::new_metric(self))
     }
 }
 
@@ -478,8 +584,23 @@ pub fn add_extra_producer<P>(p: P)
 where
     P: ExtraProducer + 'static,
 {
+    #[cfg(not(feature = "foundations-metrics-backend"))]
     Registries::get().add_extra_producer(Box::new(p));
+
+    #[cfg(feature = "foundations-metrics-backend")]
+    EXTRA_PRODUCERS
+        .get_or_init(Default::default)
+        .write()
+        .push(Box::new(p));
 }
+
+/// Producers appended to the collected metrics, in registration order.
+///
+/// The metric registry only holds metrics that encode into the protobuf data
+/// model, so text-emitting producers are kept here instead.
+#[cfg(feature = "foundations-metrics-backend")]
+static EXTRA_PRODUCERS: OnceLock<parking_lot::RwLock<Vec<Box<dyn ExtraProducer>>>> =
+    OnceLock::new();
 
 /// Describes something that can expand prometheus metrics but appending
 /// them in a text format to a provided buffer.

--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -172,6 +172,11 @@ fn report_nonfatal_collect_error(err: &dyn Display) {
 /// To attach exemplars, wrap any of the above in [`WithExemplar<T, S>`], which
 /// derefs to the metric it wraps.
 ///
+/// ```ignore
+/// let requests: WithExemplar<Counter, TraceLabels> = WithExemplar::default();
+/// requests.inc_by_with_exemplar(TraceLabels { trace_id: "abc123" }, 1);
+/// ```
+///
 /// The metrics associated with the functions are automatically registered in a global
 /// registry, and they can be collected with the [`collect`] function.
 ///

--- a/foundations/src/telemetry/mod.rs
+++ b/foundations/src/telemetry/mod.rs
@@ -402,7 +402,9 @@ pub fn init(config: TelemetryConfig) -> BootstrapResult<TelemetryDriver> {
 
 #[cfg(test)]
 mod tests {
-    use super::{TelemetryConfig, TelemetryContext, init, is_initialized};
+    #[cfg(not(feature = "foundations-metrics-backend"))]
+    use super::TelemetryContext;
+    use super::{TelemetryConfig, init, is_initialized};
     use crate::service_info;
 
     #[tokio::test]
@@ -426,6 +428,7 @@ mod tests {
 
     /// Ensure that `TelemetryContext::test()` does not default-initialize the metrics registry.
     /// This has caused CI bugs in the past because metrics will be prefixed by `undefined_`.
+    #[cfg(not(feature = "foundations-metrics-backend"))]
     #[test]
     fn testing_telemetry_metrics_uninit() {
         let _ctx = TelemetryContext::test();

--- a/foundations/tests/custom_metric_via_facade.rs
+++ b/foundations/tests/custom_metric_via_facade.rs
@@ -1,0 +1,70 @@
+//! Verifies that a custom metric can be defined and registered through the
+//! `foundations` facade alone, without depending on `foundations-metrics`.
+#![cfg(feature = "foundations-metrics-backend")]
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use foundations::telemetry::metrics::proto::{Gauge, Metric, MetricType};
+use foundations::telemetry::metrics::{
+    self, EncodeMetric, EncodeMetricValue, Family, MetricFamily, NamedMetric, RegistrationMetadata,
+    register,
+};
+use foundations::telemetry::settings::{MetricsSettings, ServiceNameFormat};
+use serde::Serialize;
+
+#[derive(Clone, Eq, Hash, PartialEq, Serialize)]
+struct Labels {
+    mount: &'static str,
+}
+
+#[derive(Default)]
+struct OpenFiles(AtomicU64);
+
+impl EncodeMetricValue for OpenFiles {
+    fn encode_metric_value(&self) -> Vec<MetricFamily> {
+        vec![MetricFamily {
+            name: Some(String::new()),
+            help: None,
+            r#type: Some(MetricType::Gauge as i32),
+            metric: vec![Metric {
+                gauge: Some(Gauge {
+                    value: Some(self.0.load(Ordering::Relaxed) as f64),
+                }),
+                ..Default::default()
+            }],
+            unit: None,
+        }]
+    }
+}
+
+#[test]
+fn a_custom_metric_is_exposed_through_the_facade() {
+    let open_files = Family::<Labels, OpenFiles>::default();
+    open_files
+        .get_or_create(&Labels { mount: "/data" })
+        .0
+        .store(5, Ordering::Relaxed);
+
+    register(
+        Box::new(NamedMetric::new(
+            "facade_open_files",
+            "Number of open file descriptors.",
+            open_files,
+        )) as Box<dyn EncodeMetric>,
+        RegistrationMetadata::default(),
+    );
+
+    let settings = MetricsSettings {
+        service_name_format: ServiceNameFormat::MetricPrefix,
+        report_optional: false,
+    };
+    let text = metrics::collect(&settings).expect("metrics should be collectable");
+
+    // Telemetry is never initialised here, so the service name prefix is the
+    // `UNINITIALISED_SERVICE_NAME` sentinel from `telemetry::metrics::init`
+    // ("undefined"). If that sentinel changes, this expectation changes with it.
+    assert!(
+        text.contains("undefined_facade_open_files{mount=\"/data\"} 5"),
+        "collected output was: {text}"
+    );
+}

--- a/foundations/tests/info_metrics.rs
+++ b/foundations/tests/info_metrics.rs
@@ -1,0 +1,61 @@
+//! Info metrics reported during telemetry initialisation must reach the scrape
+//! output with their bare name. Kept in its own test binary because
+//! `telemetry::init` may only run once per process.
+
+use foundations::ServiceInfo;
+use foundations::telemetry::settings::{MetricsSettings, ServiceNameFormat, TelemetrySettings};
+use foundations::telemetry::{TelemetryConfig, TelemetryContext, metrics};
+
+/// Returns the value of the sample line for `series`, if it was collected.
+fn sample_value(metrics: &str, series: &str) -> Option<f64> {
+    metrics.lines().find_map(|line| {
+        line.strip_prefix(series)
+            .and_then(|rest| rest.strip_prefix(' '))
+            .and_then(|value| value.parse::<f64>().ok())
+    })
+}
+
+#[tokio::test]
+async fn init_reports_build_and_runtime_info_unprefixed() {
+    // Keeps the tracing reporter from binding real sockets during the test.
+    let _ctx = TelemetryContext::test();
+
+    let service_info = ServiceInfo {
+        name: "info-svc",
+        name_in_metrics: "info_svc".to_owned(),
+        version: "4.5.6",
+        author: "Foo Bar",
+        description: "An example service",
+    };
+    let telemetry_settings = TelemetrySettings::default();
+
+    foundations::telemetry::init(TelemetryConfig {
+        service_info: &service_info,
+        settings: &telemetry_settings,
+        custom_server_routes: vec![],
+    })
+    .expect("telemetry init should succeed");
+
+    let settings = MetricsSettings {
+        service_name_format: ServiceNameFormat::MetricPrefix,
+        report_optional: false,
+    };
+    let text = metrics::collect(&settings).expect("metrics should be collectable");
+
+    assert_eq!(
+        sample_value(&text, "build_info{version=\"4.5.6\"}"),
+        Some(1.0),
+        "build_info missing from: {text}"
+    );
+    assert!(
+        text.contains("runtime_info{pid=\""),
+        "runtime_info missing from: {text}"
+    );
+
+    // Info metrics keep their bare name even though the service name is
+    // configured as a metric prefix.
+    assert!(
+        !text.contains("info_svc_build_info"),
+        "info metrics must not be service-prefixed: {text}"
+    );
+}

--- a/foundations/tests/metrics.rs
+++ b/foundations/tests/metrics.rs
@@ -3,6 +3,11 @@ use foundations::telemetry::metrics::{self, Counter, Family, metrics};
 use foundations::telemetry::settings::{MetricsSettings, ServiceNameFormat, TelemetrySettings};
 use foundations::telemetry::{TelemetryConfig, TelemetryContext};
 
+#[cfg(not(feature = "foundations-metrics-backend"))]
+const ONE: &str = "1";
+#[cfg(feature = "foundations-metrics-backend")]
+const ONE: &str = "1.0";
+
 #[metrics]
 mod regular {
     pub fn requests() -> Counter;
@@ -52,10 +57,10 @@ fn metrics_unprefixed() {
     let metrics = metrics::collect(&settings).expect("metrics should be collectable");
 
     // Global prefix defaults to "undefined" if not initialized
-    assert!(metrics.contains("\nundefined_regular_requests 1\n"));
+    assert!(metrics.contains(&format!("\nundefined_regular_requests {ONE}\n")));
     assert!(!metrics.contains("\nundefined_regular_optional"));
     assert!(!metrics.contains("\nundefined_regular_dynamic"));
-    assert!(metrics.contains("\nlibrary_calls 1\n"));
+    assert!(metrics.contains(&format!("\nlibrary_calls {ONE}\n")));
     assert!(!metrics.contains("\nlibrary_optional"));
 }
 
@@ -69,12 +74,19 @@ fn encode_error_is_skipped() {
         .get_or_create(&"another label".to_owned())
         .inc();
 
-    // Note the absence of values for the `error_invalid_label` family
+    // Note the absence of values for the `error_invalid_label` family: every one
+    // of its rows fails label serialization.
+    #[cfg(not(feature = "foundations-metrics-backend"))]
     let expected_output = "# HELP undefined_encode_error_valid .
 # TYPE undefined_encode_error_valid counter
 undefined_encode_error_valid 1
 # HELP undefined_encode_error_invalid_label .
 # TYPE undefined_encode_error_invalid_label counter
+";
+
+    #[cfg(feature = "foundations-metrics-backend")]
+    let expected_output = "# TYPE undefined_encode_error_valid counter
+undefined_encode_error_valid 1.0
 ";
 
     let settings = MetricsSettings {
@@ -123,6 +135,6 @@ async fn test_context_cooperates_with_init() {
     let metrics = metrics::collect(&settings.metrics).expect("metrics should be collectable");
 
     // Metrics registry should be initialized with explicit ServiceInfo from `foundations::telemetry::init`
-    assert!(metrics.contains("\nmy_bin_regular_requests 1\n"));
-    assert!(metrics.contains("\nlibrary_calls 1\n"));
+    assert!(metrics.contains(&format!("\nmy_bin_regular_requests {ONE}\n")));
+    assert!(metrics.contains(&format!("\nlibrary_calls {ONE}\n")));
 }

--- a/foundations/tests/metrics.rs
+++ b/foundations/tests/metrics.rs
@@ -3,10 +3,7 @@ use foundations::telemetry::metrics::{self, Counter, Family, metrics};
 use foundations::telemetry::settings::{MetricsSettings, ServiceNameFormat, TelemetrySettings};
 use foundations::telemetry::{TelemetryConfig, TelemetryContext};
 
-#[cfg(not(feature = "foundations-metrics-backend"))]
 const ONE: &str = "1";
-#[cfg(feature = "foundations-metrics-backend")]
-const ONE: &str = "1.0";
 
 #[metrics]
 mod regular {
@@ -86,7 +83,7 @@ undefined_encode_error_valid 1
 
     #[cfg(feature = "foundations-metrics-backend")]
     let expected_output = "# TYPE undefined_encode_error_valid counter
-undefined_encode_error_valid 1.0
+undefined_encode_error_valid 1
 ";
 
     let settings = MetricsSettings {

--- a/foundations/tests/panic_hook.rs
+++ b/foundations/tests/panic_hook.rs
@@ -39,10 +39,7 @@ fn panic_hook_metrics_are_well_formed() {
     simulate_panic();
     assert_eq!(metrics::panics::total().get(), 1);
 
-    #[cfg(not(feature = "foundations-metrics-backend"))]
     let expected = "panics_total 1";
-    #[cfg(feature = "foundations-metrics-backend")]
-    let expected = "panics_total 1.0";
 
     let metrics = foundations::telemetry::metrics::collect(&Default::default()).unwrap();
     let has_metric = metrics.lines().any(|line| line == expected);

--- a/foundations/tests/panic_hook.rs
+++ b/foundations/tests/panic_hook.rs
@@ -39,8 +39,13 @@ fn panic_hook_metrics_are_well_formed() {
     simulate_panic();
     assert_eq!(metrics::panics::total().get(), 1);
 
+    #[cfg(not(feature = "foundations-metrics-backend"))]
+    let expected = "panics_total 1";
+    #[cfg(feature = "foundations-metrics-backend")]
+    let expected = "panics_total 1.0";
+
     let metrics = foundations::telemetry::metrics::collect(&Default::default()).unwrap();
-    let has_metric = metrics.lines().any(|line| line == "panics_total 1");
+    let has_metric = metrics.lines().any(|line| line == expected);
     assert!(has_metric);
 }
 


### PR DESCRIPTION
## Summary

- Enable `foundations-metrics-backend` by default and route the public metrics facade through `foundations-metrics`.
- Update `#[metrics]` expansion to use the public facade while retaining the legacy backend feature path.
- Re-export the new backend types, including info metrics, custom metric APIs, native histograms, and `WithExemplar`.
- Update telemetry and hook tests for the backend-neutral facade.

## Testing

- Full nextest suite passed.
- Strict clippy passed.
- Legacy no-default-features backend check passed.