### PR TITLE
feat(foundations): negotiate metrics scrape formats

### DIFF
--- a/foundations-metrics/src/collect.rs
+++ b/foundations-metrics/src/collect.rs
@@ -103,25 +103,23 @@ fn apply_service_label(families: &mut [MetricFamily], label_name: &str, service_
     for family in families {
         let family_name = family.name.as_deref().unwrap_or_default();
         family.metric.retain_mut(|metric| {
-            let mut has_same_value = false;
-            for label in &metric.label {
-                if label.name.as_deref() != Some(label_name) {
-                    continue;
-                }
-
-                if label.value.as_deref() != Some(service_name) {
+            match metric
+                .label
+                .iter()
+                .find(|label| label.name.as_deref() == Some(label_name))
+            {
+                Some(label) if label.value.as_deref() != Some(service_name) => {
                     report_collect_error(format_args!(
                         "non-fatal error while collecting metrics: skipped row in metric family {family_name:?}; service label {label_name:?} already has a different value"
                     ));
-                    return false;
+                    false
                 }
-                has_same_value = true;
+                Some(_) => true,
+                None => {
+                    metric.label.insert(0, service_label.clone());
+                    true
+                }
             }
-
-            if !has_same_value {
-                metric.label.insert(0, service_label.clone());
-            }
-            true
         });
     }
 }

--- a/foundations-metrics/src/encoding/mod.rs
+++ b/foundations-metrics/src/encoding/mod.rs
@@ -7,6 +7,10 @@ use crate::validation::{ValidationContext, sanitized_metric_family};
 
 pub use text::{OPENMETRICS_CONTENT_TYPE, encode_to_text};
 
+/// Content type of length-delimited Prometheus protobuf response.
+pub const PROTOBUF_CONTENT_TYPE: &str =
+    "application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited";
+
 /// Encodes metric families as length-delimited Prometheus protobuf messages.
 pub fn encode_to_protobuf(families: &[MetricFamily]) -> Vec<u8> {
     let mut output = Vec::new();

--- a/foundations-metrics/src/lib.rs
+++ b/foundations-metrics/src/lib.rs
@@ -18,7 +18,9 @@ mod value;
 
 pub use collect::{CollectionOptions, ServiceNameFormat, collect};
 pub use diagnostics::{CollectErrorHookAlreadySet, set_collect_error_hook};
-pub use encoding::{OPENMETRICS_CONTENT_TYPE, encode_to_protobuf, encode_to_text};
+pub use encoding::{
+    OPENMETRICS_CONTENT_TYPE, PROTOBUF_CONTENT_TYPE, encode_to_protobuf, encode_to_text,
+};
 pub use foundations_metrics_registry::{
     EncodeMetric, IntoMetrics, MetricFamily, RegistrationMetadata, proto, register,
 };
@@ -30,4 +32,5 @@ pub use metrics::{
     NativeHistogramBuilder, RangeGauge, TimeHistogram, WithExemplar,
 };
 pub use registered::NamedMetric;
+pub use validation::{NAME_REQUIREMENT, is_valid_name};
 pub use value::EncodeMetricValue;

--- a/foundations-metrics/src/validation.rs
+++ b/foundations-metrics/src/validation.rs
@@ -4,7 +4,9 @@ use foundations_metrics_registry::proto::{Exemplar, LabelPair, Metric, MetricFam
 
 use crate::diagnostics::report_collect_error;
 
-pub(crate) const NAME_REQUIREMENT: &str = "a non-empty UTF-8 string without NUL bytes";
+/// Describes what [`is_valid_name`] accepts, for use in diagnostics.
+pub const NAME_REQUIREMENT: &str = "a non-empty UTF-8 string without NUL bytes";
+
 pub(crate) const EXEMPLAR_SERIALIZATION_ERROR_LABEL: &str =
     "\0foundations_metrics_exemplar_serialization_error";
 
@@ -25,7 +27,18 @@ impl ValidationContext {
     }
 }
 
-pub(crate) fn is_valid_name(name: &str) -> bool {
+/// Whether a metric or label name can be represented at all.
+///
+/// Only the two cases that no encoder can express are rejected: an empty name
+/// has no rendering, and a NUL byte both breaks the text format and collides
+/// with the `EXEMPLAR_SERIALIZATION_ERROR_LABEL` sentinel, which relies on being
+/// unrepresentable to stay distinguishable from a real label.
+///
+/// Exposed so a name taken from configuration can be rejected where it is read
+/// rather than at the first scrape, which is all
+/// [`collect`](crate::collect) can do with it. [`NAME_REQUIREMENT`] describes the
+/// rule for the resulting diagnostic.
+pub fn is_valid_name(name: &str) -> bool {
     !name.is_empty() && !name.contains('\0')
 }
 

--- a/foundations-metrics/src/validation.rs
+++ b/foundations-metrics/src/validation.rs
@@ -36,7 +36,7 @@ impl ValidationContext {
 ///
 /// Exposed so a name taken from configuration can be rejected where it is read
 /// rather than at the first scrape, which is all
-/// [`collect`](crate::collect) can do with it. [`NAME_REQUIREMENT`] describes the
+/// [`collect`](crate::collect()) can do with it. [`NAME_REQUIREMENT`] describes the
 /// rule for the resulting diagnostic.
 pub fn is_valid_name(name: &str) -> bool {
     !name.is_empty() && !name.contains('\0')

--- a/foundations/src/telemetry/metrics/init.rs
+++ b/foundations/src/telemetry/metrics/init.rs
@@ -44,7 +44,17 @@ pub(super) fn service_name() -> &'static str {
 ///
 /// Must be called before any use of metrics defined
 /// by the `metrics` proc macro attribute.
-pub(crate) fn init(service_info: &ServiceInfo, settings: &MetricsSettings) {
+///
+/// # Errors
+///
+/// Fails if the configured service label name cannot be encoded.
+pub(crate) fn init(
+    service_info: &ServiceInfo,
+    settings: &MetricsSettings,
+) -> crate::BootstrapResult<()> {
+    #[cfg(feature = "foundations-metrics-backend")]
+    validate_service_name_format(settings)?;
+
     #[cfg(not(feature = "foundations-metrics-backend"))]
     let first_install = Registries::init(service_info, settings);
 
@@ -71,5 +81,70 @@ pub(crate) fn init(service_info: &ServiceInfo, settings: &MetricsSettings) {
         report_info(RuntimeInfo {
             pid: std::process::id(),
         });
+    }
+
+    Ok(())
+}
+
+/// Rejects a service label name that collection could not encode.
+///
+/// The setting is fixed for the process lifetime, so checking it here only
+/// changes how it is discovered: collection skips every metric family, leaving a
+/// scrape that reads as a healthy process exporting nothing. Failing startup
+/// names the setting at fault instead.
+#[cfg(feature = "foundations-metrics-backend")]
+fn validate_service_name_format(settings: &MetricsSettings) -> crate::BootstrapResult<()> {
+    use crate::telemetry::settings::ServiceNameFormat;
+
+    if let ServiceNameFormat::LabelWithName(label_name) = &settings.service_name_format
+        && !foundations_metrics::is_valid_name(label_name)
+    {
+        anyhow::bail!(
+            "metrics.service_name_format label name {label_name:?} cannot be encoded; expected {}",
+            foundations_metrics::NAME_REQUIREMENT,
+        );
+    }
+
+    Ok(())
+}
+
+/// Tested here rather than through `telemetry::init`, which refuses to run twice
+/// per process and so cannot assert the accepting and rejecting cases together.
+#[cfg(all(test, feature = "foundations-metrics-backend", feature = "settings"))]
+mod service_name_format_tests {
+    use super::*;
+    use crate::telemetry::settings::ServiceNameFormat;
+
+    fn validate(format: ServiceNameFormat) -> crate::BootstrapResult<()> {
+        validate_service_name_format(&MetricsSettings {
+            service_name_format: format,
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn usable_label_names_are_accepted() {
+        for name in ["service", "app_name", "a", "sérvice", "with space"] {
+            assert!(
+                validate(ServiceNameFormat::LabelWithName(name.to_owned())).is_ok(),
+                "{name:?} is encodable and should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn unencodable_label_names_are_rejected() {
+        for name in ["", "\0", "ser\0vice"] {
+            assert!(
+                validate(ServiceNameFormat::LabelWithName(name.to_owned())).is_err(),
+                "{name:?} cannot be encoded and should be rejected"
+            );
+        }
+    }
+
+    /// Prefixing composes a family name that the encoders validate themselves.
+    #[test]
+    fn metric_prefix_format_is_not_subject_to_the_check() {
+        assert!(validate(ServiceNameFormat::MetricPrefix).is_ok());
     }
 }

--- a/foundations/src/telemetry/metrics/internal.rs
+++ b/foundations/src/telemetry/metrics/internal.rs
@@ -1,3 +1,9 @@
+//! Registries backing the deprecated metrics implementation.
+//!
+//! Extra producers are deprecated but still carried here until this
+//! implementation is removed, so their use is allowed throughout the module.
+#![allow(deprecated)]
+
 use super::rewind::{RewindState, RewindTo};
 use super::{ExtraProducer, InfoMetric, report_nonfatal_collect_error};
 use crate::telemetry::settings::{MetricsSettings, ServiceNameFormat};

--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -75,6 +75,28 @@ mod backend {
 
 pub use backend::*;
 
+/// Translates telemetry settings into collection options.
+///
+/// The service name is only known once telemetry is initialized, so it is
+/// applied at collection time rather than at registration time.
+#[cfg(feature = "foundations-metrics-backend")]
+fn collection_options(settings: &MetricsSettings) -> foundations_metrics::CollectionOptions<'_> {
+    let service_name_format = match &settings.service_name_format {
+        SettingsServiceNameFormat::MetricPrefix => {
+            foundations_metrics::ServiceNameFormat::MetricPrefix
+        }
+        SettingsServiceNameFormat::LabelWithName(label_name) => {
+            foundations_metrics::ServiceNameFormat::LabelWithName(label_name)
+        }
+    };
+
+    foundations_metrics::CollectionOptions {
+        include_optional: settings.report_optional,
+        service_name: Some(init::service_name()),
+        service_name_format,
+    }
+}
+
 /// Collects all metrics in [Prometheus text format].
 ///
 /// [Prometheus text format]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
@@ -89,22 +111,7 @@ pub fn collect(settings: &MetricsSettings) -> Result<String> {
 
     #[cfg(feature = "foundations-metrics-backend")]
     {
-        // The service name is only known once telemetry is initialized, so it is
-        // applied here rather than at registration time.
-        let service_name_format = match &settings.service_name_format {
-            SettingsServiceNameFormat::MetricPrefix => {
-                foundations_metrics::ServiceNameFormat::MetricPrefix
-            }
-            SettingsServiceNameFormat::LabelWithName(label_name) => {
-                foundations_metrics::ServiceNameFormat::LabelWithName(label_name)
-            }
-        };
-
-        let families = foundations_metrics::collect(foundations_metrics::CollectionOptions {
-            include_optional: settings.report_optional,
-            service_name: Some(init::service_name()),
-            service_name_format,
-        });
+        let families = foundations_metrics::collect(collection_options(settings));
 
         buffer.extend_from_slice(foundations_metrics::encode_to_text(&families).as_bytes());
 
@@ -112,6 +119,7 @@ pub fn collect(settings: &MetricsSettings) -> Result<String> {
         // is dropped here and re-added once everything has been produced.
         truncate_eof(&mut buffer);
 
+        #[allow(deprecated)]
         if let Some(producers) = EXTRA_PRODUCERS.get() {
             for producer in producers.read().iter() {
                 producer.produce(&mut buffer);
@@ -127,6 +135,205 @@ pub fn collect(settings: &MetricsSettings) -> Result<String> {
         String::from_utf8_lossy(err.as_bytes()).into_owned()
     });
     Ok(metrics_str)
+}
+
+const LEGACY_CONTENT_TYPE: &str = "application/openmetrics-text; version=1.0.0; charset=utf-8";
+
+/// Wire format a scraper asked for.
+#[cfg(feature = "foundations-metrics-backend")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ScrapeFormat {
+    /// Length-delimited Prometheus protobuf, the only format able to carry
+    /// native histograms.
+    Protobuf,
+
+    /// OpenMetrics text, optionally permitted to quote UTF-8 names.
+    Text { utf8_names: bool },
+}
+
+#[cfg(feature = "foundations-metrics-backend")]
+impl ScrapeFormat {
+    /// The format assumed when a scraper expresses no usable preference.
+    const fn fallback() -> Self {
+        Self::Text { utf8_names: false }
+    }
+
+    /// Content type describing what this format produces.
+    ///
+    /// Each string is owned by the encoder that emits it, so that what is
+    /// advertised cannot drift from what is produced.
+    fn content_type(self) -> &'static str {
+        match self {
+            Self::Protobuf => foundations_metrics::PROTOBUF_CONTENT_TYPE,
+            Self::Text { utf8_names: true } => foundations_metrics::OPENMETRICS_CONTENT_TYPE,
+            Self::Text { utf8_names: false } => LEGACY_CONTENT_TYPE,
+        }
+    }
+}
+
+/// Chooses the most preferred format that the active encoder can produce, given
+/// the value of a request's `Accept` header.
+///
+/// `None` means the header ruled out every format this server can produce. An
+/// absent header expresses no preference and yields the fallback instead.
+#[cfg(feature = "foundations-metrics-backend")]
+fn negotiate(accept: Option<&str>, protobuf_available: bool) -> Option<ScrapeFormat> {
+    let Some(accept) = accept else {
+        return Some(ScrapeFormat::fallback());
+    };
+
+    let mut best: Option<(f32, ScrapeFormat)> = None;
+
+    for range in accept.split(',') {
+        let mut parts = range.split(';').map(str::trim);
+        let Some(media_type) = parts.next().filter(|media| !media.is_empty()) else {
+            continue;
+        };
+
+        let mut quality = 1.0f32;
+        let (mut escaping, mut proto, mut encoding) = (None, None, None);
+
+        for parameter in parts {
+            let Some((name, value)) = parameter.split_once('=') else {
+                continue;
+            };
+
+            let value = value.trim().trim_matches('"');
+            let name = name.trim();
+
+            if name.eq_ignore_ascii_case("q") {
+                quality = match value.parse::<f32>() {
+                    Ok(parsed) if (0.0..=1.0).contains(&parsed) => parsed,
+                    _ => 0.0,
+                };
+            } else if name.eq_ignore_ascii_case("escaping") {
+                escaping = Some(value);
+            } else if name.eq_ignore_ascii_case("proto") {
+                proto = Some(value);
+            } else if name.eq_ignore_ascii_case("encoding") {
+                encoding = Some(value);
+            }
+        }
+
+        // `q=0` refuses a format outright rather than ranking it last.
+        if quality <= 0.0 {
+            continue;
+        }
+
+        let format = if media_type.eq_ignore_ascii_case("application/vnd.google.protobuf") {
+            // Only delimited streams of this message type are produced, and only
+            // when protobuf can carry the whole exposition.
+            if protobuf_available
+                && proto.is_some_and(|proto| proto == "io.prometheus.client.MetricFamily")
+                && encoding.is_some_and(|encoding| encoding.eq_ignore_ascii_case("delimited"))
+            {
+                ScrapeFormat::Protobuf
+            } else {
+                continue;
+            }
+        } else if media_type.eq_ignore_ascii_case("application/openmetrics-text") {
+            ScrapeFormat::Text {
+                utf8_names: escaping
+                    .is_some_and(|escaping| escaping.eq_ignore_ascii_case("allow-utf-8")),
+            }
+        } else if media_type.eq_ignore_ascii_case("text/plain") || media_type == "*/*" {
+            ScrapeFormat::Text { utf8_names: false }
+        } else {
+            continue;
+        };
+
+        // Highest quality wins; ties keep the earliest listed.
+        if best.is_none_or(|(best_quality, _)| quality > best_quality) {
+            best = Some((quality, format));
+        }
+    }
+
+    best.map(|(_, format)| format)
+}
+
+/// Reports whether protobuf can represent everything this process exposes.
+///
+/// Extra producers hand over opaque text, which cannot be transcoded into the
+/// protobuf data model, so serving protobuf while any are registered would
+/// silently drop every series they emit.
+///
+/// Evaluated per scrape because producers may be registered at any point.
+#[cfg(feature = "foundations-metrics-backend")]
+#[allow(deprecated)]
+fn protobuf_available() -> bool {
+    EXTRA_PRODUCERS
+        .get()
+        .is_none_or(|producers| producers.read().is_empty())
+}
+
+/// Collects metrics in the format a scraper asked for through its `Accept` header.
+///
+/// The content type is returned alongside the body so that the two cannot
+/// disagree; deriving one separately from the other is how a response ends up
+/// declaring a format it did not encode.
+///
+/// An `Accept` header that rules out every available format is served the
+/// fallback text format, after logging a warning.
+///
+/// The negotiated escaping is currently reported rather than enforced: the text
+/// encoder quotes a name whenever that name requires it, regardless of what the
+/// scraper asked for.
+pub fn collect_negotiated(
+    accept: Option<&str>,
+    settings: &MetricsSettings,
+) -> Result<(&'static str, Vec<u8>)> {
+    #[cfg(feature = "foundations-metrics-backend")]
+    {
+        let format = negotiate(accept, protobuf_available()).unwrap_or_else(|| {
+            let fallback = ScrapeFormat::fallback();
+
+            // Only a header that was present can rule everything out, so the
+            // default here stands in for a case `negotiate` never reports.
+            report_unsatisfiable_accept(accept.unwrap_or_default(), fallback.content_type());
+
+            fallback
+        });
+
+        // Protobuf is only reachable with no extra producers registered, so the
+        // registry holds everything and skipping them here loses nothing.
+        if format == ScrapeFormat::Protobuf {
+            let families = foundations_metrics::collect(collection_options(settings));
+
+            return Ok((
+                format.content_type(),
+                foundations_metrics::encode_to_protobuf(&families),
+            ));
+        }
+
+        Ok((format.content_type(), collect(settings)?.into_bytes()))
+    }
+
+    #[cfg(not(feature = "foundations-metrics-backend"))]
+    {
+        let _ = accept;
+
+        Ok((LEGACY_CONTENT_TYPE, collect(settings)?.into_bytes()))
+    }
+}
+
+/// Warns that a scrape's `Accept` header ruled out every available format.
+///
+/// Not routed through [`report_nonfatal_collect_error`], because collection
+/// itself succeeded and the actionable detail is the header.
+#[cfg(feature = "foundations-metrics-backend")]
+fn report_unsatisfiable_accept(accept: &str, served: &str) {
+    #[cfg(feature = "logging")]
+    crate::telemetry::log::warn!(
+        "no requested metrics format can be served, responding with the fallback instead";
+        "accept" => accept,
+        "served" => served,
+    );
+
+    #[cfg(not(feature = "logging"))]
+    eprintln!(
+        "no requested metrics format can be served, responding with the fallback instead: \
+         accept={accept:?} served={served:?}"
+    );
 }
 
 /// Removes the trailing OpenMetrics terminator, if present.
@@ -581,10 +788,14 @@ impl MetricConstructor<TimeHistogram> for HistogramBuilder {
 ///
 /// cache.register_metrics(&mut sub_registry);
 ///
+/// # #[allow(deprecated)]
 /// foundations::telemetry::metrics::add_extra_producer(move |buffer: &mut Vec<u8>| {
 ///     prometheus_client::encoding::text::encode(buffer, &registry).unwrap();
 /// });
 /// ```
+#[deprecated = "Text output bypasses validation and cannot be encoded as protobuf. Implement `EncodeMetric` and pass it to `register` instead, enabling the `foundations-metrics-backend` feature if it is disabled."]
+// TODO: remove before next major release
+#[allow(deprecated)]
 pub fn add_extra_producer<P>(p: P)
 where
     P: ExtraProducer + 'static,
@@ -600,25 +811,236 @@ where
 }
 
 /// Producers appended to the collected metrics, in registration order.
-///
-/// The metric registry only holds metrics that encode into the protobuf data
-/// model, so text-emitting producers are kept here instead.
 #[cfg(feature = "foundations-metrics-backend")]
+#[allow(deprecated)]
 static EXTRA_PRODUCERS: OnceLock<parking_lot::RwLock<Vec<Box<dyn ExtraProducer>>>> =
     OnceLock::new();
 
 /// Describes something that can expand prometheus metrics but appending
 /// them in a text format to a provided buffer.
+#[deprecated = "Text output bypasses validation and cannot be encoded as protobuf. Implement `EncodeMetric` instead, enabling the `foundations-metrics-backend` feature if it is disabled."]
+// TODO: remove before next major release
 pub trait ExtraProducer: Send + Sync {
     /// Takes a buffer and appends prometheus metrics in text format into it.
     fn produce(&self, buffer: &mut Vec<u8>);
 }
 
+#[allow(deprecated)]
 impl<F> ExtraProducer for F
 where
     F: Fn(&mut Vec<u8>) + Send + Sync,
 {
     fn produce(&self, buffer: &mut Vec<u8>) {
         self(buffer)
+    }
+}
+
+#[cfg(all(test, feature = "foundations-metrics-backend"))]
+mod negotiation_tests {
+    use super::*;
+
+    const TEXT: Option<ScrapeFormat> = Some(ScrapeFormat::Text { utf8_names: false });
+    const TEXT_UTF8: Option<ScrapeFormat> = Some(ScrapeFormat::Text { utf8_names: true });
+    const PROTOBUF: Option<ScrapeFormat> = Some(ScrapeFormat::Protobuf);
+
+    /// What Prometheus sends unless configured to prefer protobuf.
+    const PROMETHEUS_DEFAULT: &str = "application/openmetrics-text;version=1.0.0;q=0.5,\
+                                      text/plain;version=0.0.4;q=0.4,*/*;q=0.1";
+
+    const PROTOBUF_PREFERRED: &str = "application/vnd.google.protobuf;\
+                                      proto=io.prometheus.client.MetricFamily;\
+                                      encoding=delimited;q=0.5,\
+                                      application/openmetrics-text;version=1.0.0;q=0.4";
+
+    /// Delimited protobuf and nothing else: no text range, no `*/*`.
+    const PROTOBUF_ONLY: &str = "application/vnd.google.protobuf;\
+                                 proto=io.prometheus.client.MetricFamily;encoding=delimited";
+
+    #[test]
+    fn absent_header_falls_back_to_legacy_text() {
+        assert_eq!(negotiate(None, true), TEXT);
+    }
+
+    #[test]
+    fn prometheus_default_accept_selects_text() {
+        assert_eq!(negotiate(Some(PROMETHEUS_DEFAULT), true), TEXT);
+    }
+
+    #[test]
+    fn utf8_escaping_is_detected() {
+        let accept =
+            "application/openmetrics-text;version=1.0.0;escaping=allow-utf-8;q=0.5,*/*;q=0.1";
+
+        assert_eq!(negotiate(Some(accept), true), TEXT_UTF8);
+    }
+
+    #[test]
+    fn delimited_protobuf_wins_when_preferred() {
+        assert_eq!(negotiate(Some(PROTOBUF_PREFERRED), true), PROTOBUF);
+    }
+
+    #[test]
+    fn protobuf_without_delimited_encoding_is_not_offered() {
+        let accept = "application/vnd.google.protobuf;\
+                      proto=io.prometheus.client.MetricFamily;q=0.9,text/plain;q=0.1";
+
+        assert_eq!(negotiate(Some(accept), true), TEXT);
+    }
+
+    #[test]
+    fn zero_quality_refuses_a_format() {
+        let accept = "application/openmetrics-text;escaping=allow-utf-8;q=0,text/plain;q=0.4";
+
+        assert_eq!(negotiate(Some(accept), true), TEXT);
+    }
+
+    #[test]
+    fn zero_quality_on_the_only_range_matches_nothing() {
+        assert_eq!(
+            negotiate(Some("application/openmetrics-text;q=0"), true),
+            None
+        );
+    }
+
+    #[test]
+    fn malformed_quality_refuses_a_format() {
+        let accept = "application/openmetrics-text;escaping=allow-utf-8;q=garbage,text/plain;q=0.4";
+
+        assert_eq!(negotiate(Some(accept), true), TEXT);
+    }
+
+    #[test]
+    fn parameters_tolerate_whitespace_case_and_quoting() {
+        let accept =
+            "  APPLICATION/OpenMetrics-Text ; Version=1.0.0 ; Escaping=\"Allow-UTF-8\" ; Q=0.7 ";
+
+        assert_eq!(negotiate(Some(accept), true), TEXT_UTF8);
+    }
+
+    #[test]
+    fn ties_keep_the_earliest_listed() {
+        let accept = "application/openmetrics-text;escaping=allow-utf-8;q=0.5,text/plain;q=0.5";
+
+        assert_eq!(negotiate(Some(accept), true), TEXT_UTF8);
+    }
+
+    #[test]
+    fn protobuf_is_withheld_when_unavailable() {
+        assert_eq!(negotiate(Some(PROTOBUF_PREFERRED), false), TEXT);
+    }
+
+    #[test]
+    fn withholding_protobuf_leaves_text_negotiation_untouched() {
+        let utf8 = "application/openmetrics-text;escaping=allow-utf-8;q=0.9,text/plain;q=0.1";
+
+        assert_eq!(negotiate(Some(utf8), false), TEXT_UTF8);
+        assert_eq!(negotiate(Some(PROMETHEUS_DEFAULT), false), TEXT);
+        assert_eq!(negotiate(None, false), TEXT);
+    }
+
+    #[test]
+    fn protobuf_only_matches_nothing_when_unavailable() {
+        assert_eq!(negotiate(Some(PROTOBUF_ONLY), false), None);
+    }
+
+    #[test]
+    fn protobuf_only_is_served_when_available() {
+        assert_eq!(negotiate(Some(PROTOBUF_ONLY), true), PROTOBUF);
+    }
+
+    #[test]
+    fn unservable_media_types_match_nothing() {
+        assert_eq!(negotiate(Some("application/json,text/html"), true), None);
+    }
+
+    #[test]
+    fn malformed_quality_on_the_only_range_matches_nothing() {
+        let accept = "application/vnd.google.protobuf;\
+                      proto=io.prometheus.client.MetricFamily;encoding=delimited;q=";
+
+        assert_eq!(negotiate(Some(accept), true), None);
+    }
+
+    #[test]
+    fn unrankable_quality_matches_nothing() {
+        for weight in [
+            "nan", "NaN", "+nan", "inf", "infinity", "-inf", "2", "1e3", "-0.5",
+        ] {
+            let accept = format!("application/openmetrics-text;q={weight}");
+
+            assert_eq!(
+                negotiate(Some(&accept), true),
+                None,
+                "q={weight} should invalidate the range"
+            );
+        }
+    }
+
+    #[test]
+    fn unrankable_quality_does_not_mask_a_later_range() {
+        let accept = format!("application/openmetrics-text;q=nan,{PROTOBUF_PREFERRED}");
+
+        assert_eq!(negotiate(Some(&accept), true), PROTOBUF);
+    }
+
+    #[test]
+    fn out_of_range_quality_does_not_outrank_the_maximum() {
+        let accept = "application/openmetrics-text;escaping=allow-utf-8;q=5,text/plain;q=1.0";
+
+        assert_eq!(negotiate(Some(accept), true), TEXT);
+    }
+
+    #[test]
+    fn quality_bounds_are_accepted() {
+        assert_eq!(
+            negotiate(Some("application/openmetrics-text;q=1.000"), true),
+            TEXT
+        );
+        assert_eq!(
+            negotiate(Some("application/openmetrics-text;q=0.001"), true),
+            TEXT
+        );
+    }
+}
+
+/// Covers the warning emitted when an `Accept` header cannot be satisfied.
+#[cfg(all(test, feature = "foundations-metrics-backend", feature = "logging"))]
+mod fallback_logging_tests {
+    use super::*;
+    use crate::telemetry::TelemetryContext;
+
+    /// Matches nothing on offer whether or not protobuf is available, so it
+    /// reaches the fallback in a test binary that has no extra producers.
+    const UNSERVABLE: &str = "application/json,text/html";
+
+    #[test]
+    fn unsatisfiable_accept_is_served_as_text_with_a_warning() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        let (content_type, body) =
+            collect_negotiated(Some(UNSERVABLE), &MetricsSettings::default())
+                .expect("an unsatisfiable header should still produce a body");
+
+        assert_eq!(content_type, ScrapeFormat::fallback().content_type());
+        assert!(
+            body.ends_with(b"# EOF\n"),
+            "fallback body should be terminated text"
+        );
+
+        let records = ctx.log_records();
+        let warning = records
+            .iter()
+            .find(|record| record.message.contains("no requested metrics format"))
+            .unwrap_or_else(|| panic!("falling back should warn: {records:?}"));
+
+        assert_eq!(warning.level, slog::Level::Warning);
+        assert!(
+            warning
+                .fields
+                .contains(&("accept".to_owned(), UNSERVABLE.to_owned())),
+            "the warning should name the header that could not be satisfied: {:?}",
+            warning.fields
+        );
     }
 }

--- a/foundations/src/telemetry/mod.rs
+++ b/foundations/src/telemetry/mod.rs
@@ -344,7 +344,7 @@ pub fn init(config: TelemetryConfig) -> BootstrapResult<TelemetryDriver> {
     }
 
     #[cfg(feature = "metrics")]
-    self::metrics::init::init(config.service_info, &config.settings.metrics);
+    self::metrics::init::init(config.service_info, &config.settings.metrics)?;
 
     #[cfg(feature = "metrics")]
     crate::panic::install_hook();

--- a/foundations/src/telemetry/server/router.rs
+++ b/foundations/src/telemetry/server/router.rs
@@ -117,12 +117,17 @@ impl Routes {
         self.set(TelemetryServerRoute {
             path: "/metrics".into(),
             methods: vec![Method::GET],
-            handler: Box::new(|_, settings| {
+            handler: Box::new(|req, settings| {
+                let accept = req
+                    .headers()
+                    .get(header::ACCEPT)
+                    .and_then(|v| v.to_str().ok())
+                    .map(str::to_owned);
                 async move {
-                    into_response(
-                        "application/openmetrics-text; version=1.0.0; charset=utf-8",
-                        metrics::collect(&settings.metrics),
-                    )
+                    match metrics::collect_negotiated(accept.as_deref(), &settings.metrics) {
+                        Ok((content_type, body)) => into_response(content_type, Ok(body)),
+                        Err(err) => into_response("text/plain", Err::<Vec<u8>, _>(err)),
+                    }
                 }
                 .boxed()
             }),

--- a/foundations/tests/metrics_negotiation.rs
+++ b/foundations/tests/metrics_negotiation.rs
@@ -1,0 +1,99 @@
+//! The `/metrics` endpoint must serve the format a scraper asks for through its
+//! `Accept` header, and must describe what it served.
+//!
+//! Protobuf is the only format able to carry native histograms, so this covers
+//! the path that makes them reachable at all. That the protobuf bytes are
+//! well formed is covered by unit tests in `foundations-metrics`; what matters
+//! here is that the route pairs the right encoder with the right content type.
+#![cfg(feature = "foundations-metrics-backend")]
+
+use std::future::IntoFuture;
+use std::net::{Ipv4Addr, SocketAddr};
+
+use foundations::telemetry::settings::{TelemetryServerSettings, TelemetrySettings};
+use foundations::telemetry::{TelemetryConfig, TelemetryContext};
+
+const PROTOBUF_ACCEPT: &str = "application/vnd.google.protobuf;\
+                               proto=io.prometheus.client.MetricFamily;\
+                               encoding=delimited;q=0.5,\
+                               application/openmetrics-text;version=1.0.0;q=0.4,\
+                               */*;q=0.1";
+
+const TEXT_ACCEPT: &str = "application/openmetrics-text;version=1.0.0;q=0.5,\
+                           text/plain;version=0.0.4;q=0.4,*/*;q=0.1";
+
+#[tokio::test]
+async fn metrics_endpoint_serves_the_negotiated_format() {
+    let _ctx = TelemetryContext::test();
+    let server_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 1347));
+
+    let settings = TelemetrySettings {
+        server: TelemetryServerSettings {
+            enabled: true,
+            addr: server_addr.into(),
+        },
+        ..Default::default()
+    };
+
+    tokio::spawn(
+        foundations::telemetry::init(TelemetryConfig {
+            service_info: &foundations::service_info!(),
+            settings: &settings,
+            custom_server_routes: vec![],
+        })
+        .unwrap()
+        .into_future(),
+    );
+
+    let client = reqwest::Client::new();
+    let url = format!("http://{server_addr}/metrics");
+
+    let scrape = |accept: &'static str| {
+        let client = client.clone();
+        let url = url.clone();
+        async move {
+            let response = client
+                .get(url)
+                .header(reqwest::header::ACCEPT, accept)
+                .send()
+                .await
+                .unwrap();
+
+            let content_type = response
+                .headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .expect("/metrics should declare a content type")
+                .to_str()
+                .unwrap()
+                .to_owned();
+
+            (content_type, response.bytes().await.unwrap())
+        }
+    };
+
+    let (content_type, body) = scrape(PROTOBUF_ACCEPT).await;
+
+    assert_eq!(content_type, foundations_metrics::PROTOBUF_CONTENT_TYPE);
+    assert!(!body.is_empty(), "protobuf response should not be empty");
+    assert!(
+        !body.starts_with(b"# "),
+        "protobuf response looks like text: {:?}",
+        String::from_utf8_lossy(&body[..body.len().min(64)])
+    );
+    assert!(
+        !body.ends_with(b"# EOF\n"),
+        "protobuf response carries the text terminator"
+    );
+
+    let (content_type, body) = scrape(TEXT_ACCEPT).await;
+
+    assert!(
+        content_type.starts_with("application/openmetrics-text"),
+        "unexpected content type: {content_type}"
+    );
+
+    let text = String::from_utf8(body.to_vec()).expect("text response should be UTF-8");
+
+    assert!(text.contains("# TYPE"), "text response was: {text}");
+    assert!(text.ends_with("# EOF\n"), "text response was: {text}");
+}

--- a/foundations/tests/metrics_negotiation_extra_producers.rs
+++ b/foundations/tests/metrics_negotiation_extra_producers.rs
@@ -1,0 +1,128 @@
+//! Protobuf must not be served while text-only extra producers are registered,
+//! since it cannot carry what they emit and the loss would be invisible.
+//!
+//! Separate test binary on purpose: producer registration is process-global and
+//! one-way, so registering one here would make protobuf permanently unreachable
+//! for every other test in the binary.
+#![cfg(feature = "foundations-metrics-backend")]
+
+use std::future::IntoFuture;
+use std::net::{Ipv4Addr, SocketAddr};
+
+use foundations::telemetry::settings::{TelemetryServerSettings, TelemetrySettings};
+use foundations::telemetry::{TelemetryConfig, TelemetryContext};
+
+/// Delimited protobuf preferred, text still acceptable.
+const PROTOBUF_PREFERRED: &str = "application/vnd.google.protobuf;\
+                                  proto=io.prometheus.client.MetricFamily;\
+                                  encoding=delimited;q=0.9,\
+                                  application/openmetrics-text;version=1.0.0;q=0.1";
+
+/// Delimited protobuf and nothing else: no text range, no `*/*`.
+const PROTOBUF_ONLY: &str = "application/vnd.google.protobuf;\
+                             proto=io.prometheus.client.MetricFamily;encoding=delimited";
+
+const PRODUCER_SERIES: &str = "extra_producer_witness_total";
+
+#[tokio::test]
+async fn extra_producers_withhold_protobuf() {
+    let _ctx = TelemetryContext::test();
+    let server_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 1357));
+
+    // Shaped like a service's cache metrics: a self-contained document with its
+    // own terminator, which foundations strips before adding the final one.
+    #[allow(deprecated)]
+    foundations::telemetry::metrics::add_extra_producer(|buffer: &mut Vec<u8>| {
+        buffer.extend_from_slice(
+            b"# TYPE extra_producer_witness counter\n\
+              # HELP extra_producer_witness Emitted only by a text-only extra producer.\n\
+              extra_producer_witness_total 7\n\
+              # EOF\n",
+        );
+    });
+
+    let settings = TelemetrySettings {
+        server: TelemetryServerSettings {
+            enabled: true,
+            addr: server_addr.into(),
+        },
+        ..Default::default()
+    };
+
+    tokio::spawn(
+        foundations::telemetry::init(TelemetryConfig {
+            service_info: &foundations::service_info!(),
+            settings: &settings,
+            custom_server_routes: vec![],
+        })
+        .unwrap()
+        .into_future(),
+    );
+
+    let client = reqwest::Client::new();
+    let url = format!("http://{server_addr}/metrics");
+
+    let scrape = |accept: &'static str| {
+        let client = client.clone();
+        let url = url.clone();
+        async move {
+            let response = client
+                .get(url)
+                .header(reqwest::header::ACCEPT, accept)
+                .send()
+                .await
+                .unwrap();
+
+            let status = response.status();
+            let content_type = response
+                .headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .expect("/metrics should declare a content type")
+                .to_str()
+                .unwrap()
+                .to_owned();
+
+            (status, content_type, response.bytes().await.unwrap())
+        }
+    };
+
+    // Text is acceptable to this scraper, so it gets text with the producer
+    // output intact rather than protobuf without it.
+    let (status, content_type, body) = scrape(PROTOBUF_PREFERRED).await;
+
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert!(
+        content_type.starts_with("application/openmetrics-text"),
+        "protobuf was served despite registered extra producers: {content_type}"
+    );
+
+    let text = String::from_utf8(body.to_vec()).expect("response should be text");
+
+    assert!(
+        text.contains(PRODUCER_SERIES),
+        "extra producer output missing, body was: {text}"
+    );
+    assert!(
+        text.contains("# TYPE"),
+        "registered metrics missing, body was: {text}"
+    );
+    assert!(
+        text.ends_with("# EOF\n"),
+        "response was not terminated, body was: {text}"
+    );
+    assert_eq!(
+        text.matches("# EOF").count(),
+        1,
+        "expected exactly one terminator, body was: {text}"
+    );
+
+    // Nothing this scraper accepts can be served: protobuf is withheld and it
+    // offers no text range, so it receives the fallback text format.
+    let (status, content_type, ..) = scrape(PROTOBUF_ONLY).await;
+
+    assert_eq!(status, reqwest::StatusCode::OK);
+    assert!(
+        content_type.starts_with("application/openmetrics-text"),
+        "unsatisfiable Accept should fall back to text, got: {content_type}"
+    );
+}

--- a/foundations/tests/metrics_service_label_validation.rs
+++ b/foundations/tests/metrics_service_label_validation.rs
@@ -1,0 +1,49 @@
+//! An unencodable service label name must stop startup rather than surface as an
+//! empty exposition later.
+//!
+//! Separate test binary on purpose: a successful `telemetry::init` elsewhere in
+//! the binary would make these observe its once-per-process refusal instead.
+#![cfg(all(feature = "foundations-metrics-backend", feature = "settings"))]
+
+use foundations::telemetry::TelemetryConfig;
+use foundations::telemetry::settings::{ServiceNameFormat, TelemetrySettings};
+
+fn init_with(format: ServiceNameFormat) -> foundations::BootstrapResult<()> {
+    let mut settings = TelemetrySettings::default();
+    settings.metrics.service_name_format = format;
+
+    foundations::telemetry::init(TelemetryConfig {
+        service_info: &foundations::service_info!(),
+        settings: &settings,
+        custom_server_routes: vec![],
+    })
+    .map(|_| ())
+}
+
+#[test]
+fn empty_service_label_name_is_rejected_at_startup() {
+    let error = init_with(ServiceNameFormat::LabelWithName(String::new()))
+        .expect_err("an unencodable service label name should stop startup");
+
+    let message = error.to_string();
+
+    assert!(
+        message.contains("service_name_format"),
+        "the error should name the setting at fault: {message}"
+    );
+    assert!(
+        message.contains("non-empty"),
+        "the error should state what was expected: {message}"
+    );
+}
+
+#[test]
+fn service_label_name_with_nul_is_rejected_at_startup() {
+    let error = init_with(ServiceNameFormat::LabelWithName("ser\0vice".to_owned()))
+        .expect_err("a label name with a NUL byte should stop startup");
+
+    assert!(
+        error.to_string().contains("service_name_format"),
+        "the error should name the setting at fault: {error}"
+    );
+}


### PR DESCRIPTION
## Summary

- Negotiate OpenMetrics text and length-delimited protobuf responses from the metrics endpoint using `Accept` preferences.
- Fall back to text for unsupported or invalid preferences, and when legacy text-only extra producers are registered.
- Apply the configured service name during collection and reject service label names that cannot be encoded.
- Add integration coverage for negotiation, extra-producer fallback, protobuf output, and startup validation.

## Testing

- Full nextest suite passed.
- Strict clippy passed.
- Legacy no-default-features backend check passed.