### PR TITLE
refactor(metrics): finalize public API for publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ backtrace = "0.3.76"
 foundations = { version = "5.8.1", path = "./foundations", default-features = false }
 foundations-macros = { version = "=5.8.1", path = "./foundations-macros", default-features = false }
 foundations-metrics-registry = { version = "1.0.0", path = "./foundations-metrics-registry", default-features = false }
-foundations-metrics = { version = "0.1.0-beta1", path = "./foundations-metrics", default-features = false }
+foundations-metrics = { version = "0.1.0-beta.1", path = "./foundations-metrics", default-features = false }
 bindgen = { version = "0.72.1", default-features = false }
 cc = "1.2.61"
 cf-rustracing = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ anyhow = "1.0.102"
 backtrace = "0.3.76"
 foundations = { version = "5.8.1", path = "./foundations", default-features = false }
 foundations-macros = { version = "=5.8.1", path = "./foundations-macros", default-features = false }
-foundations-metrics-registry = { version = "0.1.0", path = "./foundations-metrics-registry", default-features = false }
-foundations-metrics = { version = "0.1.0", path = "./foundations-metrics", default-features = false }
+foundations-metrics-registry = { version = "1.0.0", path = "./foundations-metrics-registry", default-features = false }
+foundations-metrics = { version = "0.1.0-beta1", path = "./foundations-metrics", default-features = false }
 bindgen = { version = "0.72.1", default-features = false }
 cc = "1.2.61"
 cf-rustracing = "1.4.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,9 @@ release = false
 
 [dev-dependencies]
 anyhow = { workspace = true }
-foundations = { workspace = true, features = ["default"] }
+# The native histogram in `http_server` is only offered by the new backend, so
+# the example opts in to it explicitly.
+foundations = { workspace = true, features = ["default", "foundations-metrics-backend"] }
 futures-util = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }

--- a/foundations-metrics-registry/Cargo.toml
+++ b/foundations-metrics-registry/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "foundations-metrics-registry"
 description = "Process-global metric registry and Prometheus protobuf data model for Foundations."
-version = "0.1.0"
+version = "1.0.0"
 edition = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }

--- a/foundations-metrics/Cargo.toml
+++ b/foundations-metrics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "foundations-metrics"
 description = "Metric types and encoders for the Foundations stack."
-version = "0.1.0"
+version = "0.1.0-beta1"
 readme = "README.md"
 repository = { workspace = true }
 edition = { workspace = true }

--- a/foundations-metrics/Cargo.toml
+++ b/foundations-metrics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "foundations-metrics"
 description = "Metric types and encoders for the Foundations stack."
-version = "0.1.0-beta1"
+version = "0.1.0-beta.1"
 readme = "README.md"
 repository = { workspace = true }
 edition = { workspace = true }

--- a/foundations-metrics/README.md
+++ b/foundations-metrics/README.md
@@ -8,7 +8,7 @@ model.
 ## Migrating from `foundations::telemetry::metrics`
 
 `foundations` re-exports this crate's items through
-`foundations::telemetry::metrics` when its default `foundations-metrics-backend`
+`foundations::telemetry::metrics` when its opt-in `foundations-metrics-backend`
 feature is enabled. Existing counter, gauge, histogram, and family call sites
 therefore continue to compile. This compatibility is intended to ease migration
 and will be removed in the next major release. Code using exemplars must move to

--- a/foundations-metrics/src/lib.rs
+++ b/foundations-metrics/src/lib.rs
@@ -35,8 +35,7 @@ pub use labels::{LabelError, to_label_pairs};
 pub use metrics::{
     Counter, CounterAtomic, Family, FamilyMetricGuard, Gauge, GaugeAtomic, GaugeGuard, Histogram,
     HistogramBuilder, HistogramSnapshot, HistogramTimer, MetricConstructor, NativeHistogram,
-    NativeHistogramBuilder, NativeTimeHistogram, ObserveNanos, RangeGauge, TimeHistogram,
-    WithExemplar,
+    NativeHistogramBuilder, NativeTimeHistogram, RangeGauge, TimeHistogram, WithExemplar,
 };
 pub use registered::NamedMetric;
 pub use validation::{NAME_REQUIREMENT, is_valid_name};

--- a/foundations-metrics/src/metrics/histogram.rs
+++ b/foundations-metrics/src/metrics/histogram.rs
@@ -244,9 +244,6 @@ mod private {
 /// This is what lets a [`HistogramTimer`] drive either a fixed-bucket
 /// [`TimeHistogram`] or an exponential-bucket
 /// [`NativeTimeHistogram`](super::NativeTimeHistogram).
-///
-/// This trait is an implementation detail: it is neither exported nor
-/// implementable outside this crate.
 pub trait ObserveNanos: private::Sealed {
     /// Records an observed duration in nanoseconds.
     fn observe_nanos(&self, nanos: u64);

--- a/foundations-metrics/src/metrics/histogram.rs
+++ b/foundations-metrics/src/metrics/histogram.rs
@@ -245,8 +245,9 @@ mod private {
 /// [`TimeHistogram`] or an exponential-bucket
 /// [`NativeTimeHistogram`](super::NativeTimeHistogram).
 ///
-/// This trait is sealed and cannot be implemented outside this crate.
-pub trait ObserveNanos: private::Sealed + Clone {
+/// This trait is an implementation detail: it is neither exported nor
+/// implementable outside this crate.
+pub trait ObserveNanos: private::Sealed {
     /// Records an observed duration in nanoseconds.
     fn observe_nanos(&self, nanos: u64);
 }

--- a/foundations-metrics/src/metrics/mod.rs
+++ b/foundations-metrics/src/metrics/mod.rs
@@ -46,7 +46,7 @@ pub use exemplar::WithExemplar;
 pub use family::{Family, FamilyMetricGuard, MetricConstructor};
 pub use gauge::{Gauge, GaugeAtomic, GaugeGuard, RangeGauge};
 pub use histogram::{
-    Histogram, HistogramBuilder, HistogramSnapshot, HistogramTimer, ObserveNanos, TimeHistogram,
+    Histogram, HistogramBuilder, HistogramSnapshot, HistogramTimer, TimeHistogram,
 };
 pub use native_histogram::{NativeHistogram, NativeHistogramBuilder, NativeTimeHistogram};
 

--- a/foundations-sentry/tests/sentry_hook.rs
+++ b/foundations-sentry/tests/sentry_hook.rs
@@ -36,12 +36,10 @@ fn sentry_hook_increments_metric_on_event() {
 
     const SERIES: &str = "sentry_events_total{level=\"error\"} ";
 
-    let body = foundations::telemetry::metrics::collect_format(
-        foundations::telemetry::metrics::ScrapeFormat::fallback(),
-        &Default::default(),
-    )
-    .unwrap();
-    let metrics = String::from_utf8(body).unwrap();
+    // `collect` rather than `collect_format`, which needs the new metrics
+    // backend; the `allow` covers the deprecation it carries there.
+    #[allow(deprecated)]
+    let metrics = foundations::telemetry::metrics::collect(&Default::default()).unwrap();
     let has_metric = metrics.lines().any(|line| {
         line.strip_prefix(SERIES)
             .and_then(|value| value.parse::<f64>().ok())

--- a/foundations-sentry/tests/sentry_hook.rs
+++ b/foundations-sentry/tests/sentry_hook.rs
@@ -36,7 +36,12 @@ fn sentry_hook_increments_metric_on_event() {
 
     const SERIES: &str = "sentry_events_total{level=\"error\"} ";
 
-    let metrics = foundations::telemetry::metrics::collect(&Default::default()).unwrap();
+    let body = foundations::telemetry::metrics::collect_format(
+        foundations::telemetry::metrics::ScrapeFormat::fallback(),
+        &Default::default(),
+    )
+    .unwrap();
+    let metrics = String::from_utf8(body).unwrap();
     let has_metric = metrics.lines().any(|line| {
         line.strip_prefix(SERIES)
             .and_then(|value| value.parse::<f64>().ok())

--- a/foundations-sentry/tests/sentry_hook.rs
+++ b/foundations-sentry/tests/sentry_hook.rs
@@ -36,8 +36,6 @@ fn sentry_hook_increments_metric_on_event() {
 
     const SERIES: &str = "sentry_events_total{level=\"error\"} ";
 
-    // `collect` rather than `collect_format`, which needs the new metrics
-    // backend; the `allow` covers the deprecation it carries there.
     #[allow(deprecated)]
     let metrics = foundations::telemetry::metrics::collect(&Default::default()).unwrap();
     let has_metric = metrics.lines().any(|line| {

--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -33,7 +33,7 @@ pre-release-hook = [
 
 [features]
 # Default set of features.
-default = ["platform-common-default", "security", "foundations-metrics-backend"]
+default = ["platform-common-default", "security"]
 
 # All non platform-specific features
 platform-common-default = [
@@ -216,8 +216,6 @@ telemetry-server-pattern-routing = []
 tracing-rs-compat = ["dep:tracing-slog"]
 
 # Selects the `foundations-metrics` implementation behind `telemetry::metrics`.
-# The `metrics` macro expands identically either way: it emits paths that this
-# crate resolves, so the macro needs no feature of its own.
 foundations-metrics-backend = ["dep:foundations-metrics", "dep:foundations-metrics-registry"]
 
 [package.metadata.docs.rs]

--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -4,7 +4,14 @@
 //! - Use [`metrics`] macro to define regular metrics.
 //! - Use [`report_info`] function to register service information metrics (metrics, whose value is
 //!   persistent during the service lifetime, e.g. software version).
-//! - Use [`collect_format`] method to obtain metrics report programmatically.
+#![cfg_attr(
+    feature = "foundations-metrics-backend",
+    doc = "- Use [`collect_format`] method to obtain metrics report programmatically."
+)]
+#![cfg_attr(
+    not(feature = "foundations-metrics-backend"),
+    doc = "- Use [`collect`] method to obtain metrics report programmatically."
+)]
 //! - Use [telemetry server] to expose a metrics endpoint.
 //!
 //! [Prometheus]: https://prometheus.io/
@@ -115,7 +122,10 @@ fn collect_registered_metrics(
 /// Collects all metrics in [Prometheus text format].
 ///
 /// [Prometheus text format]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
-#[deprecated = "Only ever produces text. Use `collect_format` instead, serving the body it returns with the matching `ScrapeFormat::content_type`."]
+#[cfg_attr(
+    feature = "foundations-metrics-backend",
+    deprecated = "Only ever produces text. Use `collect_format` instead, serving the body it returns with the matching `ScrapeFormat::content_type`."
+)]
 pub fn collect(settings: &MetricsSettings) -> Result<String> {
     collect_text(settings)
 }
@@ -130,13 +140,33 @@ pub fn collect(settings: &MetricsSettings) -> Result<String> {
 /// # Errors
 ///
 /// Fails when `format` cannot represent everything this process exposes.
-/// [`ScrapeFormat::Protobuf`] requires the `foundations-metrics-backend`
-/// feature, and cannot carry the output of a registered extra producer, which is
-/// opaque text; [`allow_protobuf`] reports whether it may be asked for.
-/// [`ScrapeFormat::fallback`] never fails for this reason.
+/// [`ScrapeFormat::Protobuf`] cannot carry the output of a registered extra
+/// producer, which is opaque text; [`allow_protobuf`] reports whether it may be
+/// asked for. [`ScrapeFormat::fallback`] never fails for this reason.
+#[cfg(feature = "foundations-metrics-backend")]
 pub fn collect_format(format: ScrapeFormat, settings: &MetricsSettings) -> Result<Vec<u8>> {
+    collect_encoded(format, settings)
+}
+
+/// Encodes a scrape as `format`, backing both `collect_format` and the
+/// telemetry server's `/metrics` route.
+///
+/// The server negotiates formats whichever backend is active, so encoding stays
+/// available internally even where `collect_format` is not exposed.
+#[cfg(any(feature = "foundations-metrics-backend", feature = "telemetry-server"))]
+pub(crate) fn collect_encoded(format: ScrapeFormat, settings: &MetricsSettings) -> Result<Vec<u8>> {
     match format {
+        #[cfg(feature = "foundations-metrics-backend")]
         ScrapeFormat::Protobuf => collect_protobuf(settings),
+
+        // Unreachable through negotiation, which is never told protobuf is
+        // available here, but reported rather than mis-encoded regardless.
+        #[cfg(not(feature = "foundations-metrics-backend"))]
+        ScrapeFormat::Protobuf => Err(
+            "metrics can only be encoded as protobuf with the `foundations-metrics-backend` feature enabled"
+                .into(),
+        ),
+
         ScrapeFormat::Text { .. } => Ok(collect_text(settings)?.into_bytes()),
     }
 }
@@ -144,7 +174,7 @@ pub fn collect_format(format: ScrapeFormat, settings: &MetricsSettings) -> Resul
 /// Collects all metrics as protobuf, which only the new backend can encode.
 #[cfg(feature = "foundations-metrics-backend")]
 fn collect_protobuf(settings: &MetricsSettings) -> Result<Vec<u8>> {
-    if !allow_protobuf() {
+    if !protobuf_available() {
         return Err(
             "metrics cannot be encoded as protobuf while an extra producer is registered".into(),
         );
@@ -153,11 +183,6 @@ fn collect_protobuf(settings: &MetricsSettings) -> Result<Vec<u8>> {
     let families = collect_registered_metrics(settings);
 
     Ok(foundations_metrics::encode_to_protobuf(&families))
-}
-
-#[cfg(not(feature = "foundations-metrics-backend"))]
-fn collect_protobuf(_settings: &MetricsSettings) -> Result<Vec<u8>> {
-    Err("metrics can only be encoded as protobuf with the `foundations-metrics-backend` feature enabled".into())
 }
 
 /// Collects all metrics as OpenMetrics text, which every backend can encode.
@@ -200,27 +225,40 @@ fn collect_text(settings: &MetricsSettings) -> Result<String> {
 
 /// Reports whether protobuf can represent everything this process exposes.
 ///
-/// Pass the result to [`negotiate`] as `allow_protobuf`. It is `false` without
-/// the `foundations-metrics-backend` feature, which has no protobuf encoder, and
-/// `false` while any extra producer is registered: those hand over opaque text,
-/// which cannot be transcoded into the protobuf data model, so serving protobuf
-/// would silently drop every series they emit.
+/// Pass the result to [`negotiate`] as `allow_protobuf`. It is `false` while any
+/// extra producer is registered: those hand over opaque text, which cannot be
+/// transcoded into the protobuf data model, so serving protobuf would silently
+/// drop every series they emit.
 ///
 /// Evaluate it per scrape, because producers may be registered at any point.
 #[cfg(feature = "foundations-metrics-backend")]
-#[allow(deprecated)]
+#[deprecated = "Only reports whether an extra producer is registered, so it becomes redundant once `ExtraProducer` is removed. Until then, pass it to `negotiate`."]
+// TODO: remove alongside `ExtraProducer`
 pub fn allow_protobuf() -> bool {
+    protobuf_available()
+}
+
+/// Whether protobuf can carry everything this process exposes.
+///
+/// Backs `allow_protobuf` and the telemetry server's negotiation, so the server
+/// keeps withholding protobuf without depending on a deprecated function.
+#[cfg(feature = "foundations-metrics-backend")]
+#[allow(deprecated)]
+pub(crate) fn protobuf_available() -> bool {
     EXTRA_PRODUCERS
         .get()
         .is_none_or(|producers| producers.read().is_empty())
 }
 
-/// Reports whether protobuf can represent everything this process exposes.
+/// Whether protobuf can carry everything this process exposes.
 ///
 /// Always `false` here: encoding protobuf needs the
 /// `foundations-metrics-backend` feature.
-#[cfg(not(feature = "foundations-metrics-backend"))]
-pub fn allow_protobuf() -> bool {
+#[cfg(all(
+    not(feature = "foundations-metrics-backend"),
+    feature = "telemetry-server"
+))]
+pub(crate) fn protobuf_available() -> bool {
     false
 }
 
@@ -273,7 +311,7 @@ fn report_nonfatal_collect_error(err: &dyn Display) {
 /// ```
 ///
 /// The metrics associated with the functions are automatically registered in a global
-/// registry, and they can be collected with the [`collect_format`] function.
+/// registry, from which this module's collection functions report them.
 ///
 /// # Metric attributes
 ///
@@ -287,8 +325,8 @@ fn report_nonfatal_collect_error(err: &dyn Display) {
 /// ## `#[optional]`
 ///
 /// Metrics marked with `#[optional]` are collected in a separate registry and reported only if
-/// [`MetricsSettings::report_optional`] is set to `true`, whether they are collected through
-/// [`collect_format`] or the [telemetry server].
+/// [`MetricsSettings::report_optional`] is set to `true`, whether they are collected
+/// programmatically or through the [telemetry server].
 ///
 /// Can be used for heavy-weight metrics (e.g. with high cardinality) that don't need to be reported
 /// on a regular basis.
@@ -674,7 +712,12 @@ impl MetricConstructor<TimeHistogram> for HistogramBuilder {
 ///     prometheus_client::encoding::text::encode(buffer, &registry).unwrap();
 /// });
 /// ```
-#[deprecated = "Text output bypasses validation and cannot be encoded as protobuf. Implement `EncodeMetric` and pass it to `register` instead, enabling the `foundations-metrics-backend` feature if it is disabled."]
+// Only deprecated where `register` exists to replace it, so that services on the
+// old backend are not warned about an alternative they cannot reach.
+#[cfg_attr(
+    feature = "foundations-metrics-backend",
+    deprecated = "Text output bypasses validation and cannot be encoded as protobuf. Implement `EncodeMetric` and pass it to `register` instead."
+)]
 // TODO: remove before next major release
 #[allow(deprecated)]
 pub fn add_extra_producer<P>(p: P)
@@ -699,7 +742,10 @@ static EXTRA_PRODUCERS: OnceLock<parking_lot::RwLock<Vec<Box<dyn ExtraProducer>>
 
 /// Describes something that can expand prometheus metrics but appending
 /// them in a text format to a provided buffer.
-#[deprecated = "Text output bypasses validation and cannot be encoded as protobuf. Implement `EncodeMetric` instead, enabling the `foundations-metrics-backend` feature if it is disabled."]
+#[cfg_attr(
+    feature = "foundations-metrics-backend",
+    deprecated = "Text output bypasses validation and cannot be encoded as protobuf. Implement `EncodeMetric` instead."
+)]
 // TODO: remove before next major release
 pub trait ExtraProducer: Send + Sync {
     /// Takes a buffer and appends prometheus metrics in text format into it.

--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -4,7 +4,7 @@
 //! - Use [`metrics`] macro to define regular metrics.
 //! - Use [`report_info`] function to register service information metrics (metrics, whose value is
 //!   persistent during the service lifetime, e.g. software version).
-//! - Use [`collect`] method to obtain metrics report programmatically.
+//! - Use [`collect_format`] method to obtain metrics report programmatically.
 //! - Use [telemetry server] to expose a metrics endpoint.
 //!
 //! [Prometheus]: https://prometheus.io/
@@ -28,6 +28,7 @@ use std::sync::OnceLock;
 
 #[cfg(not(feature = "foundations-metrics-backend"))]
 mod gauge;
+mod negotiation;
 #[cfg(all(feature = "foundations-metrics-backend", target_os = "linux"))]
 mod process;
 #[cfg(not(feature = "foundations-metrics-backend"))]
@@ -50,9 +51,9 @@ use internal::{ErasedInfoMetric, Registries};
 #[cfg(feature = "foundations-metrics-backend")]
 mod backend {
     pub use foundations_metrics::{
-        Counter, Family, Gauge, GaugeGuard, Histogram, HistogramTimer, InfoMetric,
-        MetricConstructor, NativeHistogram, NativeHistogramBuilder, NativeTimeHistogram,
-        RangeGauge, TimeHistogram, WithExemplar,
+        Counter, Family, Gauge, GaugeGuard, Histogram, HistogramBuilder, HistogramTimer,
+        InfoMetric, MetricConstructor, NativeHistogram, NativeHistogramBuilder,
+        NativeTimeHistogram, RangeGauge, TimeHistogram, WithExemplar,
     };
 
     // Everything needed to define, register, and label a custom metric. The
@@ -76,6 +77,8 @@ mod backend {
 }
 
 pub use backend::*;
+
+pub use negotiation::{ScrapeFormat, negotiate, negotiate_or_fallback};
 
 /// Translates telemetry settings into collection options.
 ///
@@ -112,7 +115,53 @@ fn collect_registered_metrics(
 /// Collects all metrics in [Prometheus text format].
 ///
 /// [Prometheus text format]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
+#[deprecated = "Only ever produces text. Use `collect_format` instead, serving the body it returns with the matching `ScrapeFormat::content_type`."]
 pub fn collect(settings: &MetricsSettings) -> Result<String> {
+    collect_text(settings)
+}
+
+/// Collects all metrics encoded as `format`.
+///
+/// Content negotiation is a separate concern: pass the format chosen by
+/// [`negotiate`], and serve the returned body with that format's
+/// [`ScrapeFormat::content_type`] so a response cannot advertise something it
+/// did not encode.
+///
+/// # Errors
+///
+/// Fails when `format` cannot represent everything this process exposes.
+/// [`ScrapeFormat::Protobuf`] requires the `foundations-metrics-backend`
+/// feature, and cannot carry the output of a registered extra producer, which is
+/// opaque text; [`allow_protobuf`] reports whether it may be asked for.
+/// [`ScrapeFormat::fallback`] never fails for this reason.
+pub fn collect_format(format: ScrapeFormat, settings: &MetricsSettings) -> Result<Vec<u8>> {
+    match format {
+        ScrapeFormat::Protobuf => collect_protobuf(settings),
+        ScrapeFormat::Text { .. } => Ok(collect_text(settings)?.into_bytes()),
+    }
+}
+
+/// Collects all metrics as protobuf, which only the new backend can encode.
+#[cfg(feature = "foundations-metrics-backend")]
+fn collect_protobuf(settings: &MetricsSettings) -> Result<Vec<u8>> {
+    if !allow_protobuf() {
+        return Err(
+            "metrics cannot be encoded as protobuf while an extra producer is registered".into(),
+        );
+    }
+
+    let families = collect_registered_metrics(settings);
+
+    Ok(foundations_metrics::encode_to_protobuf(&families))
+}
+
+#[cfg(not(feature = "foundations-metrics-backend"))]
+fn collect_protobuf(_settings: &MetricsSettings) -> Result<Vec<u8>> {
+    Err("metrics can only be encoded as protobuf with the `foundations-metrics-backend` feature enabled".into())
+}
+
+/// Collects all metrics as OpenMetrics text, which every backend can encode.
+fn collect_text(settings: &MetricsSettings) -> Result<String> {
     let mut buffer: Vec<u8> = Vec::with_capacity(128);
 
     #[cfg(not(feature = "foundations-metrics-backend"))]
@@ -149,203 +198,30 @@ pub fn collect(settings: &MetricsSettings) -> Result<String> {
     Ok(metrics_str)
 }
 
-const LEGACY_CONTENT_TYPE: &str = "application/openmetrics-text; version=1.0.0; charset=utf-8";
-
-/// Wire format a scraper asked for.
-#[cfg(feature = "foundations-metrics-backend")]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum ScrapeFormat {
-    /// Length-delimited Prometheus protobuf, the only format able to carry
-    /// native histograms.
-    Protobuf,
-
-    /// OpenMetrics text, optionally permitted to quote UTF-8 names.
-    Text { utf8_names: bool },
-}
-
-#[cfg(feature = "foundations-metrics-backend")]
-impl ScrapeFormat {
-    /// The format assumed when a scraper expresses no usable preference.
-    const fn fallback() -> Self {
-        Self::Text { utf8_names: false }
-    }
-
-    /// Content type describing what this format produces.
-    ///
-    /// Each string is owned by the encoder that emits it, so that what is
-    /// advertised cannot drift from what is produced.
-    fn content_type(self) -> &'static str {
-        match self {
-            Self::Protobuf => foundations_metrics::PROTOBUF_CONTENT_TYPE,
-            Self::Text { utf8_names: true } => foundations_metrics::OPENMETRICS_CONTENT_TYPE,
-            Self::Text { utf8_names: false } => LEGACY_CONTENT_TYPE,
-        }
-    }
-}
-
-/// Chooses the most preferred format that the active encoder can produce, given
-/// the value of a request's `Accept` header.
-///
-/// `None` means the header ruled out every format this server can produce. An
-/// absent header expresses no preference and yields the fallback instead.
-#[cfg(feature = "foundations-metrics-backend")]
-fn negotiate(accept: Option<&str>, protobuf_available: bool) -> Option<ScrapeFormat> {
-    let Some(accept) = accept else {
-        return Some(ScrapeFormat::fallback());
-    };
-
-    let mut best: Option<(f32, ScrapeFormat)> = None;
-
-    for range in accept.split(',') {
-        let mut parts = range.split(';').map(str::trim);
-        let Some(media_type) = parts.next().filter(|media| !media.is_empty()) else {
-            continue;
-        };
-
-        let mut quality = 1.0f32;
-        let (mut escaping, mut proto, mut encoding) = (None, None, None);
-
-        for parameter in parts {
-            let Some((name, value)) = parameter.split_once('=') else {
-                continue;
-            };
-
-            let value = value.trim().trim_matches('"');
-            let name = name.trim();
-
-            if name.eq_ignore_ascii_case("q") {
-                quality = match value.parse::<f32>() {
-                    Ok(parsed) if (0.0..=1.0).contains(&parsed) => parsed,
-                    _ => 0.0,
-                };
-            } else if name.eq_ignore_ascii_case("escaping") {
-                escaping = Some(value);
-            } else if name.eq_ignore_ascii_case("proto") {
-                proto = Some(value);
-            } else if name.eq_ignore_ascii_case("encoding") {
-                encoding = Some(value);
-            }
-        }
-
-        // `q=0` refuses a format outright rather than ranking it last.
-        if quality <= 0.0 {
-            continue;
-        }
-
-        let format = if media_type.eq_ignore_ascii_case("application/vnd.google.protobuf") {
-            // Only delimited streams of this message type are produced, and only
-            // when protobuf can carry the whole exposition.
-            if protobuf_available
-                && proto.is_some_and(|proto| proto == "io.prometheus.client.MetricFamily")
-                && encoding.is_some_and(|encoding| encoding.eq_ignore_ascii_case("delimited"))
-            {
-                ScrapeFormat::Protobuf
-            } else {
-                continue;
-            }
-        } else if media_type.eq_ignore_ascii_case("application/openmetrics-text") {
-            ScrapeFormat::Text {
-                utf8_names: escaping
-                    .is_some_and(|escaping| escaping.eq_ignore_ascii_case("allow-utf-8")),
-            }
-        } else if media_type.eq_ignore_ascii_case("text/plain") || media_type == "*/*" {
-            ScrapeFormat::Text { utf8_names: false }
-        } else {
-            continue;
-        };
-
-        // Highest quality wins; ties keep the earliest listed.
-        if best.is_none_or(|(best_quality, _)| quality > best_quality) {
-            best = Some((quality, format));
-        }
-    }
-
-    best.map(|(_, format)| format)
-}
-
 /// Reports whether protobuf can represent everything this process exposes.
 ///
-/// Extra producers hand over opaque text, which cannot be transcoded into the
-/// protobuf data model, so serving protobuf while any are registered would
-/// silently drop every series they emit.
+/// Pass the result to [`negotiate`] as `allow_protobuf`. It is `false` without
+/// the `foundations-metrics-backend` feature, which has no protobuf encoder, and
+/// `false` while any extra producer is registered: those hand over opaque text,
+/// which cannot be transcoded into the protobuf data model, so serving protobuf
+/// would silently drop every series they emit.
 ///
-/// Evaluated per scrape because producers may be registered at any point.
+/// Evaluate it per scrape, because producers may be registered at any point.
 #[cfg(feature = "foundations-metrics-backend")]
 #[allow(deprecated)]
-fn protobuf_available() -> bool {
+pub fn allow_protobuf() -> bool {
     EXTRA_PRODUCERS
         .get()
         .is_none_or(|producers| producers.read().is_empty())
 }
 
-/// Collects metrics in the format a scraper asked for through its `Accept` header.
+/// Reports whether protobuf can represent everything this process exposes.
 ///
-/// The content type is returned alongside the body so that the two cannot
-/// disagree; deriving one separately from the other is how a response ends up
-/// declaring a format it did not encode.
-///
-/// An `Accept` header that rules out every available format is served the
-/// fallback text format, after logging a warning.
-///
-/// The negotiated escaping is currently reported rather than enforced: the text
-/// encoder quotes a name whenever that name requires it, regardless of what the
-/// scraper asked for.
-pub fn collect_negotiated(
-    accept: Option<&str>,
-    settings: &MetricsSettings,
-) -> Result<(&'static str, Vec<u8>)> {
-    #[cfg(feature = "foundations-metrics-backend")]
-    {
-        let format = negotiate(accept, protobuf_available()).unwrap_or_else(|| {
-            let fallback = ScrapeFormat::fallback();
-
-            // Only a header that was present can rule everything out, so the
-            // default here stands in for a case `negotiate` never reports.
-            report_unsatisfiable_accept(accept.unwrap_or_default(), fallback.content_type());
-
-            fallback
-        });
-
-        // Protobuf is only reachable with no extra producers registered, so the
-        // registry holds everything and skipping them here loses nothing.
-        if format == ScrapeFormat::Protobuf {
-            let families = collect_registered_metrics(settings);
-
-            return Ok((
-                format.content_type(),
-                foundations_metrics::encode_to_protobuf(&families),
-            ));
-        }
-
-        Ok((format.content_type(), collect(settings)?.into_bytes()))
-    }
-
-    #[cfg(not(feature = "foundations-metrics-backend"))]
-    {
-        let _ = accept;
-
-        Ok((LEGACY_CONTENT_TYPE, collect(settings)?.into_bytes()))
-    }
-}
-
-/// Warns that a scrape's `Accept` header ruled out every available format.
-///
-/// Not routed through [`report_nonfatal_collect_error`], because collection
-/// itself succeeded and the actionable detail is the header.
-#[cfg(feature = "foundations-metrics-backend")]
-fn report_unsatisfiable_accept(accept: &str, served: &str) {
-    #[cfg(feature = "logging")]
-    crate::telemetry::log::warn!(
-        "no requested metrics format can be served, responding with the fallback instead";
-        "accept" => accept,
-        "served" => served,
-    );
-
-    #[cfg(not(feature = "logging"))]
-    eprintln!(
-        "no requested metrics format can be served, responding with the fallback instead: \
-         accept={accept:?} served={served:?}"
-    );
+/// Always `false` here: encoding protobuf needs the
+/// `foundations-metrics-backend` feature.
+#[cfg(not(feature = "foundations-metrics-backend"))]
+pub fn allow_protobuf() -> bool {
+    false
 }
 
 /// Removes the trailing OpenMetrics terminator, if present.
@@ -397,7 +273,7 @@ fn report_nonfatal_collect_error(err: &dyn Display) {
 /// ```
 ///
 /// The metrics associated with the functions are automatically registered in a global
-/// registry, and they can be collected with the [`collect`] function.
+/// registry, and they can be collected with the [`collect_format`] function.
 ///
 /// # Metric attributes
 ///
@@ -411,8 +287,8 @@ fn report_nonfatal_collect_error(err: &dyn Display) {
 /// ## `#[optional]`
 ///
 /// Metrics marked with `#[optional]` are collected in a separate registry and reported only if
-/// `collect_optional` argument of [`collect`] is set to `true`, or, in case the [telemetry server]
-/// is used, if [`MetricsSettings::report_optional`] is set to `true`.
+/// [`MetricsSettings::report_optional`] is set to `true`, whether they are collected through
+/// [`collect_format`] or the [telemetry server].
 ///
 /// Can be used for heavy-weight metrics (e.g. with high cardinality) that don't need to be reported
 /// on a regular basis.
@@ -719,12 +595,14 @@ where
 /// }
 /// # }
 /// ```
+#[cfg(not(feature = "foundations-metrics-backend"))]
 #[derive(Clone)]
 pub struct HistogramBuilder {
     /// The buckets of the histogram to be built.
     pub buckets: &'static [f64],
 }
 
+#[cfg(not(feature = "foundations-metrics-backend"))]
 impl MetricConstructor<Histogram> for HistogramBuilder {
     fn new_metric(&self) -> Histogram {
         Histogram::new(self.buckets.iter().cloned())
@@ -738,16 +616,7 @@ impl<S> MetricConstructor<HistogramWithExemplars<S>> for HistogramBuilder {
     }
 }
 
-// The `foundations-metrics` backend replaces the per-type exemplar wrappers
-// with a single generic `WithExemplar<T, S>`, so the builder constructs that
-// instead.
-#[cfg(feature = "foundations-metrics-backend")]
-impl<S> MetricConstructor<WithExemplar<Histogram, S>> for HistogramBuilder {
-    fn new_metric(&self) -> WithExemplar<Histogram, S> {
-        WithExemplar::new(MetricConstructor::<Histogram>::new_metric(self))
-    }
-}
-
+#[cfg(not(feature = "foundations-metrics-backend"))]
 impl MetricConstructor<TimeHistogram> for HistogramBuilder {
     fn new_metric(&self) -> TimeHistogram {
         TimeHistogram::new(self.buckets.iter().cloned())
@@ -844,215 +713,5 @@ where
 {
     fn produce(&self, buffer: &mut Vec<u8>) {
         self(buffer)
-    }
-}
-
-#[cfg(all(test, feature = "foundations-metrics-backend"))]
-mod negotiation_tests {
-    use super::*;
-
-    const TEXT: Option<ScrapeFormat> = Some(ScrapeFormat::Text { utf8_names: false });
-    const TEXT_UTF8: Option<ScrapeFormat> = Some(ScrapeFormat::Text { utf8_names: true });
-    const PROTOBUF: Option<ScrapeFormat> = Some(ScrapeFormat::Protobuf);
-
-    /// What Prometheus sends unless configured to prefer protobuf.
-    const PROMETHEUS_DEFAULT: &str = "application/openmetrics-text;version=1.0.0;q=0.5,\
-                                      text/plain;version=0.0.4;q=0.4,*/*;q=0.1";
-
-    const PROTOBUF_PREFERRED: &str = "application/vnd.google.protobuf;\
-                                      proto=io.prometheus.client.MetricFamily;\
-                                      encoding=delimited;q=0.5,\
-                                      application/openmetrics-text;version=1.0.0;q=0.4";
-
-    /// Delimited protobuf and nothing else: no text range, no `*/*`.
-    const PROTOBUF_ONLY: &str = "application/vnd.google.protobuf;\
-                                 proto=io.prometheus.client.MetricFamily;encoding=delimited";
-
-    #[test]
-    fn absent_header_falls_back_to_legacy_text() {
-        assert_eq!(negotiate(None, true), TEXT);
-    }
-
-    #[test]
-    fn prometheus_default_accept_selects_text() {
-        assert_eq!(negotiate(Some(PROMETHEUS_DEFAULT), true), TEXT);
-    }
-
-    #[test]
-    fn utf8_escaping_is_detected() {
-        let accept =
-            "application/openmetrics-text;version=1.0.0;escaping=allow-utf-8;q=0.5,*/*;q=0.1";
-
-        assert_eq!(negotiate(Some(accept), true), TEXT_UTF8);
-    }
-
-    #[test]
-    fn delimited_protobuf_wins_when_preferred() {
-        assert_eq!(negotiate(Some(PROTOBUF_PREFERRED), true), PROTOBUF);
-    }
-
-    #[test]
-    fn protobuf_without_delimited_encoding_is_not_offered() {
-        let accept = "application/vnd.google.protobuf;\
-                      proto=io.prometheus.client.MetricFamily;q=0.9,text/plain;q=0.1";
-
-        assert_eq!(negotiate(Some(accept), true), TEXT);
-    }
-
-    #[test]
-    fn zero_quality_refuses_a_format() {
-        let accept = "application/openmetrics-text;escaping=allow-utf-8;q=0,text/plain;q=0.4";
-
-        assert_eq!(negotiate(Some(accept), true), TEXT);
-    }
-
-    #[test]
-    fn zero_quality_on_the_only_range_matches_nothing() {
-        assert_eq!(
-            negotiate(Some("application/openmetrics-text;q=0"), true),
-            None
-        );
-    }
-
-    #[test]
-    fn malformed_quality_refuses_a_format() {
-        let accept = "application/openmetrics-text;escaping=allow-utf-8;q=garbage,text/plain;q=0.4";
-
-        assert_eq!(negotiate(Some(accept), true), TEXT);
-    }
-
-    #[test]
-    fn parameters_tolerate_whitespace_case_and_quoting() {
-        let accept =
-            "  APPLICATION/OpenMetrics-Text ; Version=1.0.0 ; Escaping=\"Allow-UTF-8\" ; Q=0.7 ";
-
-        assert_eq!(negotiate(Some(accept), true), TEXT_UTF8);
-    }
-
-    #[test]
-    fn ties_keep_the_earliest_listed() {
-        let accept = "application/openmetrics-text;escaping=allow-utf-8;q=0.5,text/plain;q=0.5";
-
-        assert_eq!(negotiate(Some(accept), true), TEXT_UTF8);
-    }
-
-    #[test]
-    fn protobuf_is_withheld_when_unavailable() {
-        assert_eq!(negotiate(Some(PROTOBUF_PREFERRED), false), TEXT);
-    }
-
-    #[test]
-    fn withholding_protobuf_leaves_text_negotiation_untouched() {
-        let utf8 = "application/openmetrics-text;escaping=allow-utf-8;q=0.9,text/plain;q=0.1";
-
-        assert_eq!(negotiate(Some(utf8), false), TEXT_UTF8);
-        assert_eq!(negotiate(Some(PROMETHEUS_DEFAULT), false), TEXT);
-        assert_eq!(negotiate(None, false), TEXT);
-    }
-
-    #[test]
-    fn protobuf_only_matches_nothing_when_unavailable() {
-        assert_eq!(negotiate(Some(PROTOBUF_ONLY), false), None);
-    }
-
-    #[test]
-    fn protobuf_only_is_served_when_available() {
-        assert_eq!(negotiate(Some(PROTOBUF_ONLY), true), PROTOBUF);
-    }
-
-    #[test]
-    fn unservable_media_types_match_nothing() {
-        assert_eq!(negotiate(Some("application/json,text/html"), true), None);
-    }
-
-    #[test]
-    fn malformed_quality_on_the_only_range_matches_nothing() {
-        let accept = "application/vnd.google.protobuf;\
-                      proto=io.prometheus.client.MetricFamily;encoding=delimited;q=";
-
-        assert_eq!(negotiate(Some(accept), true), None);
-    }
-
-    #[test]
-    fn unrankable_quality_matches_nothing() {
-        for weight in [
-            "nan", "NaN", "+nan", "inf", "infinity", "-inf", "2", "1e3", "-0.5",
-        ] {
-            let accept = format!("application/openmetrics-text;q={weight}");
-
-            assert_eq!(
-                negotiate(Some(&accept), true),
-                None,
-                "q={weight} should invalidate the range"
-            );
-        }
-    }
-
-    #[test]
-    fn unrankable_quality_does_not_mask_a_later_range() {
-        let accept = format!("application/openmetrics-text;q=nan,{PROTOBUF_PREFERRED}");
-
-        assert_eq!(negotiate(Some(&accept), true), PROTOBUF);
-    }
-
-    #[test]
-    fn out_of_range_quality_does_not_outrank_the_maximum() {
-        let accept = "application/openmetrics-text;escaping=allow-utf-8;q=5,text/plain;q=1.0";
-
-        assert_eq!(negotiate(Some(accept), true), TEXT);
-    }
-
-    #[test]
-    fn quality_bounds_are_accepted() {
-        assert_eq!(
-            negotiate(Some("application/openmetrics-text;q=1.000"), true),
-            TEXT
-        );
-        assert_eq!(
-            negotiate(Some("application/openmetrics-text;q=0.001"), true),
-            TEXT
-        );
-    }
-}
-
-/// Covers the warning emitted when an `Accept` header cannot be satisfied.
-#[cfg(all(test, feature = "foundations-metrics-backend", feature = "logging"))]
-mod fallback_logging_tests {
-    use super::*;
-    use crate::telemetry::TelemetryContext;
-
-    /// Matches nothing on offer whether or not protobuf is available, so it
-    /// reaches the fallback in a test binary that has no extra producers.
-    const UNSERVABLE: &str = "application/json,text/html";
-
-    #[test]
-    fn unsatisfiable_accept_is_served_as_text_with_a_warning() {
-        let ctx = TelemetryContext::test();
-        let _scope = ctx.scope();
-
-        let (content_type, body) =
-            collect_negotiated(Some(UNSERVABLE), &MetricsSettings::default())
-                .expect("an unsatisfiable header should still produce a body");
-
-        assert_eq!(content_type, ScrapeFormat::fallback().content_type());
-        assert!(
-            body.ends_with(b"# EOF\n"),
-            "fallback body should be terminated text"
-        );
-
-        let records = ctx.log_records();
-        let warning = records
-            .iter()
-            .find(|record| record.message.contains("no requested metrics format"))
-            .unwrap_or_else(|| panic!("falling back should warn: {records:?}"));
-
-        assert_eq!(warning.level, slog::Level::Warning);
-        assert!(
-            warning
-                .fields
-                .contains(&("accept".to_owned(), UNSERVABLE.to_owned())),
-            "the warning should name the header that could not be satisfied: {:?}",
-            warning.fields
-        );
     }
 }

--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -52,7 +52,7 @@ mod backend {
     pub use foundations_metrics::{
         Counter, Family, Gauge, GaugeGuard, Histogram, HistogramTimer, InfoMetric,
         MetricConstructor, NativeHistogram, NativeHistogramBuilder, NativeTimeHistogram,
-        ObserveNanos, RangeGauge, TimeHistogram, WithExemplar,
+        RangeGauge, TimeHistogram, WithExemplar,
     };
 
     // Everything needed to define, register, and label a custom metric. The

--- a/foundations/src/telemetry/metrics/negotiation.rs
+++ b/foundations/src/telemetry/metrics/negotiation.rs
@@ -1,0 +1,391 @@
+//! Choosing which wire format to serve a metrics scrape.
+//!
+//! Negotiation is deliberately separate from collection: [`negotiate`] only
+//! reads an `Accept` header and [`collect_format`](super::collect_format) only
+//! encodes, so a service exposing its own endpoint can reuse either half on its
+//! own. Nothing here depends on the active metrics backend.
+
+/// Content type of the text exposition with legacy name escaping.
+const LEGACY_CONTENT_TYPE: &str = "application/openmetrics-text; version=1.0.0; charset=utf-8";
+
+#[cfg(feature = "foundations-metrics-backend")]
+use foundations_metrics::{OPENMETRICS_CONTENT_TYPE, PROTOBUF_CONTENT_TYPE};
+
+#[cfg(not(feature = "foundations-metrics-backend"))]
+const OPENMETRICS_CONTENT_TYPE: &str =
+    "application/openmetrics-text; version=1.0.0; charset=utf-8; escaping=allow-utf-8";
+
+#[cfg(not(feature = "foundations-metrics-backend"))]
+const PROTOBUF_CONTENT_TYPE: &str =
+    "application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited";
+
+/// Wire format a scraper asked for.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ScrapeFormat {
+    /// Length-delimited Prometheus protobuf, the only format able to carry
+    /// native histograms.
+    Protobuf,
+
+    /// OpenMetrics text, optionally permitted to quote UTF-8 names.
+    Text {
+        /// Whether the scraper accepts names quoted rather than escaped.
+        utf8_names: bool,
+    },
+}
+
+impl ScrapeFormat {
+    /// The format assumed when a scraper expresses no usable preference.
+    ///
+    /// Every backend can produce it, so it is always safe to serve.
+    pub const fn fallback() -> Self {
+        Self::Text { utf8_names: false }
+    }
+
+    /// Content type describing what this format produces.
+    pub fn content_type(self) -> &'static str {
+        match self {
+            Self::Protobuf => PROTOBUF_CONTENT_TYPE,
+            Self::Text { utf8_names: true } => OPENMETRICS_CONTENT_TYPE,
+            Self::Text { utf8_names: false } => LEGACY_CONTENT_TYPE,
+        }
+    }
+}
+
+/// Chooses the most preferred format that the caller can produce, given the
+/// value of a request's `Accept` header.
+///
+/// `None` means the header ruled out every format on offer. An absent header
+/// expresses no preference and yields [`ScrapeFormat::fallback`] instead.
+///
+/// The negotiated escaping is currently reported rather than enforced: the text
+/// encoder quotes a name whenever that name requires it, regardless of what the
+/// scraper asked for.
+pub fn negotiate(accept: Option<&str>, allow_protobuf: bool) -> Option<ScrapeFormat> {
+    let Some(accept) = accept else {
+        return Some(ScrapeFormat::fallback());
+    };
+
+    let mut best: Option<(f32, ScrapeFormat)> = None;
+
+    for range in accept.split(',') {
+        let mut parts = range.split(';').map(str::trim);
+        let Some(media_type) = parts.next().filter(|media| !media.is_empty()) else {
+            continue;
+        };
+
+        let mut quality = 1.0f32;
+        let (mut escaping, mut proto, mut encoding) = (None, None, None);
+
+        for parameter in parts {
+            let Some((name, value)) = parameter.split_once('=') else {
+                continue;
+            };
+
+            let value = value.trim().trim_matches('"');
+            let name = name.trim();
+
+            if name.eq_ignore_ascii_case("q") {
+                quality = match value.parse::<f32>() {
+                    Ok(parsed) if (0.0..=1.0).contains(&parsed) => parsed,
+                    _ => 0.0,
+                };
+            } else if name.eq_ignore_ascii_case("escaping") {
+                escaping = Some(value);
+            } else if name.eq_ignore_ascii_case("proto") {
+                proto = Some(value);
+            } else if name.eq_ignore_ascii_case("encoding") {
+                encoding = Some(value);
+            }
+        }
+
+        // `q=0` refuses a format outright rather than ranking it last.
+        if quality <= 0.0 {
+            continue;
+        }
+
+        let format = if media_type.eq_ignore_ascii_case("application/vnd.google.protobuf") {
+            // Only delimited streams of this message type are produced, and only
+            // when protobuf can carry the whole exposition.
+            if allow_protobuf
+                && proto.is_some_and(|proto| proto == "io.prometheus.client.MetricFamily")
+                && encoding.is_some_and(|encoding| encoding.eq_ignore_ascii_case("delimited"))
+            {
+                ScrapeFormat::Protobuf
+            } else {
+                continue;
+            }
+        } else if media_type.eq_ignore_ascii_case("application/openmetrics-text") {
+            ScrapeFormat::Text {
+                utf8_names: escaping
+                    .is_some_and(|escaping| escaping.eq_ignore_ascii_case("allow-utf-8")),
+            }
+        } else if media_type.eq_ignore_ascii_case("text/plain") || media_type == "*/*" {
+            ScrapeFormat::Text { utf8_names: false }
+        } else {
+            continue;
+        };
+
+        // Highest quality wins; ties keep the earliest listed.
+        if best.is_none_or(|(best_quality, _)| quality > best_quality) {
+            best = Some((quality, format));
+        }
+    }
+
+    best.map(|(_, format)| format)
+}
+
+/// Negotiates a format, serving [`ScrapeFormat::fallback`] with a warning when
+/// the `Accept` header rules out everything on offer.
+///
+/// This is what the telemetry server's `/metrics` route does; callers wanting to
+/// reject an unsatisfiable header with `406 Not Acceptable` instead should match
+/// on [`negotiate`] directly.
+pub fn negotiate_or_fallback(accept: Option<&str>, allow_protobuf: bool) -> ScrapeFormat {
+    negotiate(accept, allow_protobuf).unwrap_or_else(|| {
+        let fallback = ScrapeFormat::fallback();
+
+        // Only a header that was present can rule everything out, so the
+        // default here stands in for a case `negotiate` never reports.
+        report_unsatisfiable_accept(accept.unwrap_or_default(), fallback.content_type());
+
+        fallback
+    })
+}
+
+/// Warns that a scrape's `Accept` header ruled out every available format.
+///
+/// Not routed through
+/// [`report_nonfatal_collect_error`](super::report_nonfatal_collect_error),
+/// because collection itself succeeded and the actionable detail is the header.
+fn report_unsatisfiable_accept(accept: &str, served: &str) {
+    #[cfg(feature = "logging")]
+    crate::telemetry::log::warn!(
+        "no requested metrics format can be served, responding with the fallback instead";
+        "accept" => accept,
+        "served" => served,
+    );
+
+    #[cfg(not(feature = "logging"))]
+    eprintln!(
+        "no requested metrics format can be served, responding with the fallback instead: \
+         accept={accept:?} served={served:?}"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEXT: Option<ScrapeFormat> = Some(ScrapeFormat::Text { utf8_names: false });
+    const TEXT_UTF8: Option<ScrapeFormat> = Some(ScrapeFormat::Text { utf8_names: true });
+    const PROTOBUF: Option<ScrapeFormat> = Some(ScrapeFormat::Protobuf);
+
+    /// What Prometheus sends unless configured to prefer protobuf.
+    const PROMETHEUS_DEFAULT: &str = "application/openmetrics-text;version=1.0.0;q=0.5,\
+                                      text/plain;version=0.0.4;q=0.4,*/*;q=0.1";
+
+    const PROTOBUF_PREFERRED: &str = "application/vnd.google.protobuf;\
+                                      proto=io.prometheus.client.MetricFamily;\
+                                      encoding=delimited;q=0.5,\
+                                      application/openmetrics-text;version=1.0.0;q=0.4";
+
+    /// Delimited protobuf and nothing else: no text range, no `*/*`.
+    const PROTOBUF_ONLY: &str = "application/vnd.google.protobuf;\
+                                 proto=io.prometheus.client.MetricFamily;encoding=delimited";
+
+    #[test]
+    fn absent_header_falls_back_to_legacy_text() {
+        assert_eq!(negotiate(None, true), TEXT);
+    }
+
+    #[test]
+    fn prometheus_default_accept_selects_text() {
+        assert_eq!(negotiate(Some(PROMETHEUS_DEFAULT), true), TEXT);
+    }
+
+    #[test]
+    fn utf8_escaping_is_detected() {
+        let accept =
+            "application/openmetrics-text;version=1.0.0;escaping=allow-utf-8;q=0.5,*/*;q=0.1";
+
+        assert_eq!(negotiate(Some(accept), true), TEXT_UTF8);
+    }
+
+    #[test]
+    fn delimited_protobuf_wins_when_preferred() {
+        assert_eq!(negotiate(Some(PROTOBUF_PREFERRED), true), PROTOBUF);
+    }
+
+    #[test]
+    fn protobuf_without_delimited_encoding_is_not_offered() {
+        let accept = "application/vnd.google.protobuf;\
+                      proto=io.prometheus.client.MetricFamily;q=0.9,text/plain;q=0.1";
+
+        assert_eq!(negotiate(Some(accept), true), TEXT);
+    }
+
+    #[test]
+    fn zero_quality_refuses_a_format() {
+        let accept = "application/openmetrics-text;escaping=allow-utf-8;q=0,text/plain;q=0.4";
+
+        assert_eq!(negotiate(Some(accept), true), TEXT);
+    }
+
+    #[test]
+    fn zero_quality_on_the_only_range_matches_nothing() {
+        assert_eq!(
+            negotiate(Some("application/openmetrics-text;q=0"), true),
+            None
+        );
+    }
+
+    #[test]
+    fn malformed_quality_refuses_a_format() {
+        let accept = "application/openmetrics-text;escaping=allow-utf-8;q=garbage,text/plain;q=0.4";
+
+        assert_eq!(negotiate(Some(accept), true), TEXT);
+    }
+
+    #[test]
+    fn parameters_tolerate_whitespace_case_and_quoting() {
+        let accept =
+            "  APPLICATION/OpenMetrics-Text ; Version=1.0.0 ; Escaping=\"Allow-UTF-8\" ; Q=0.7 ";
+
+        assert_eq!(negotiate(Some(accept), true), TEXT_UTF8);
+    }
+
+    #[test]
+    fn ties_keep_the_earliest_listed() {
+        let accept = "application/openmetrics-text;escaping=allow-utf-8;q=0.5,text/plain;q=0.5";
+
+        assert_eq!(negotiate(Some(accept), true), TEXT_UTF8);
+    }
+
+    #[test]
+    fn protobuf_is_withheld_when_unavailable() {
+        assert_eq!(negotiate(Some(PROTOBUF_PREFERRED), false), TEXT);
+    }
+
+    #[test]
+    fn withholding_protobuf_leaves_text_negotiation_untouched() {
+        let utf8 = "application/openmetrics-text;escaping=allow-utf-8;q=0.9,text/plain;q=0.1";
+
+        assert_eq!(negotiate(Some(utf8), false), TEXT_UTF8);
+        assert_eq!(negotiate(Some(PROMETHEUS_DEFAULT), false), TEXT);
+        assert_eq!(negotiate(None, false), TEXT);
+    }
+
+    #[test]
+    fn protobuf_only_matches_nothing_when_unavailable() {
+        assert_eq!(negotiate(Some(PROTOBUF_ONLY), false), None);
+    }
+
+    #[test]
+    fn protobuf_only_is_served_when_available() {
+        assert_eq!(negotiate(Some(PROTOBUF_ONLY), true), PROTOBUF);
+    }
+
+    #[test]
+    fn unservable_media_types_match_nothing() {
+        assert_eq!(negotiate(Some("application/json,text/html"), true), None);
+    }
+
+    #[test]
+    fn malformed_quality_on_the_only_range_matches_nothing() {
+        let accept = "application/vnd.google.protobuf;\
+                      proto=io.prometheus.client.MetricFamily;encoding=delimited;q=";
+
+        assert_eq!(negotiate(Some(accept), true), None);
+    }
+
+    #[test]
+    fn unrankable_quality_matches_nothing() {
+        for weight in [
+            "nan", "NaN", "+nan", "inf", "infinity", "-inf", "2", "1e3", "-0.5",
+        ] {
+            let accept = format!("application/openmetrics-text;q={weight}");
+
+            assert_eq!(
+                negotiate(Some(&accept), true),
+                None,
+                "q={weight} should invalidate the range"
+            );
+        }
+    }
+
+    #[test]
+    fn unrankable_quality_does_not_mask_a_later_range() {
+        let accept = format!("application/openmetrics-text;q=nan,{PROTOBUF_PREFERRED}");
+
+        assert_eq!(negotiate(Some(&accept), true), PROTOBUF);
+    }
+
+    #[test]
+    fn out_of_range_quality_does_not_outrank_the_maximum() {
+        let accept = "application/openmetrics-text;escaping=allow-utf-8;q=5,text/plain;q=1.0";
+
+        assert_eq!(negotiate(Some(accept), true), TEXT);
+    }
+
+    #[test]
+    fn quality_bounds_are_accepted() {
+        assert_eq!(
+            negotiate(Some("application/openmetrics-text;q=1.000"), true),
+            TEXT
+        );
+        assert_eq!(
+            negotiate(Some("application/openmetrics-text;q=0.001"), true),
+            TEXT
+        );
+    }
+
+    /// Each content type must match the encoder that produces that format.
+    #[cfg(feature = "foundations-metrics-backend")]
+    #[test]
+    fn content_types_come_from_the_encoders() {
+        assert_eq!(
+            ScrapeFormat::Protobuf.content_type(),
+            foundations_metrics::PROTOBUF_CONTENT_TYPE
+        );
+        assert_eq!(
+            ScrapeFormat::Text { utf8_names: true }.content_type(),
+            foundations_metrics::OPENMETRICS_CONTENT_TYPE
+        );
+    }
+}
+
+/// Covers the warning emitted when an `Accept` header cannot be satisfied.
+#[cfg(all(test, feature = "logging"))]
+mod fallback_logging_tests {
+    use super::*;
+    use crate::telemetry::TelemetryContext;
+
+    /// Matches nothing on offer whether or not protobuf is available.
+    const UNSERVABLE: &str = "application/json,text/html";
+
+    #[test]
+    fn unsatisfiable_accept_is_served_as_text_with_a_warning() {
+        let ctx = TelemetryContext::test();
+        let _scope = ctx.scope();
+
+        assert_eq!(
+            negotiate_or_fallback(Some(UNSERVABLE), true),
+            ScrapeFormat::fallback()
+        );
+
+        let records = ctx.log_records();
+        let warning = records
+            .iter()
+            .find(|record| record.message.contains("no requested metrics format"))
+            .unwrap_or_else(|| panic!("falling back should warn: {records:?}"));
+
+        assert_eq!(warning.level, slog::Level::Warning);
+        assert!(
+            warning
+                .fields
+                .contains(&("accept".to_owned(), UNSERVABLE.to_owned())),
+            "the warning should name the header that could not be satisfied: {:?}",
+            warning.fields
+        );
+    }
+}

--- a/foundations/src/telemetry/metrics/negotiation.rs
+++ b/foundations/src/telemetry/metrics/negotiation.rs
@@ -1,9 +1,9 @@
 //! Choosing which wire format to serve a metrics scrape.
 //!
 //! Negotiation is deliberately separate from collection: [`negotiate`] only
-//! reads an `Accept` header and [`collect_format`](super::collect_format) only
-//! encodes, so a service exposing its own endpoint can reuse either half on its
-//! own. Nothing here depends on the active metrics backend.
+//! reads an `Accept` header and collection only encodes, so a service exposing
+//! its own endpoint can reuse either half on its own. Nothing here depends on
+//! the active metrics backend.
 
 /// Content type of the text exposition with legacy name escaping.
 const LEGACY_CONTENT_TYPE: &str = "application/openmetrics-text; version=1.0.0; charset=utf-8";

--- a/foundations/src/telemetry/server/router.rs
+++ b/foundations/src/telemetry/server/router.rs
@@ -128,10 +128,10 @@ impl Routes {
                     // content type served always describes the body served.
                     let format = metrics::negotiate_or_fallback(
                         accept.as_deref(),
-                        metrics::allow_protobuf(),
+                        metrics::protobuf_available(),
                     );
 
-                    match metrics::collect_format(format, &settings.metrics) {
+                    match metrics::collect_encoded(format, &settings.metrics) {
                         Ok(body) => into_response(format.content_type(), Ok(body)),
                         Err(err) => into_response("text/plain", Err::<Vec<u8>, _>(err)),
                     }

--- a/foundations/src/telemetry/server/router.rs
+++ b/foundations/src/telemetry/server/router.rs
@@ -124,8 +124,15 @@ impl Routes {
                     .and_then(|v| v.to_str().ok())
                     .map(str::to_owned);
                 async move {
-                    match metrics::collect_negotiated(accept.as_deref(), &settings.metrics) {
-                        Ok((content_type, body)) => into_response(content_type, Ok(body)),
+                    // The format is settled before anything is encoded, so the
+                    // content type served always describes the body served.
+                    let format = metrics::negotiate_or_fallback(
+                        accept.as_deref(),
+                        metrics::allow_protobuf(),
+                    );
+
+                    match metrics::collect_format(format, &settings.metrics) {
+                        Ok(body) => into_response(format.content_type(), Ok(body)),
                         Err(err) => into_response("text/plain", Err::<Vec<u8>, _>(err)),
                     }
                 }

--- a/foundations/tests/common/mod.rs
+++ b/foundations/tests/common/mod.rs
@@ -1,0 +1,16 @@
+//! Helpers shared by the integration tests.
+
+use foundations::telemetry::metrics::{self, ScrapeFormat};
+use foundations::telemetry::settings::MetricsSettings;
+
+/// Collects every metric as text.
+///
+/// `collect_format` deals in bytes because protobuf is not text, so each caller
+/// wanting a string converts one back.
+#[allow(dead_code)]
+pub(crate) fn collect_text(settings: &MetricsSettings) -> String {
+    let body = metrics::collect_format(ScrapeFormat::fallback(), settings)
+        .expect("metrics should be collectable");
+
+    String::from_utf8(body).expect("text metrics should be valid UTF-8")
+}

--- a/foundations/tests/common/mod.rs
+++ b/foundations/tests/common/mod.rs
@@ -1,16 +1,13 @@
 //! Helpers shared by the integration tests.
 
-use foundations::telemetry::metrics::{self, ScrapeFormat};
+use foundations::telemetry::metrics;
 use foundations::telemetry::settings::MetricsSettings;
 
 /// Collects every metric as text.
 ///
-/// `collect_format` deals in bytes because protobuf is not text, so each caller
-/// wanting a string converts one back.
-#[allow(dead_code)]
+/// Goes through `collect` rather than `collect_format` so the helper works on
+/// either backend; the `allow` covers the deprecation on the new one.
+#[allow(dead_code, deprecated)]
 pub(crate) fn collect_text(settings: &MetricsSettings) -> String {
-    let body = metrics::collect_format(ScrapeFormat::fallback(), settings)
-        .expect("metrics should be collectable");
-
-    String::from_utf8(body).expect("text metrics should be valid UTF-8")
+    metrics::collect(settings).expect("metrics should be collectable")
 }

--- a/foundations/tests/custom_metric_via_facade.rs
+++ b/foundations/tests/custom_metric_via_facade.rs
@@ -6,11 +6,14 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use foundations::telemetry::metrics::proto::{Gauge, Metric, MetricType};
 use foundations::telemetry::metrics::{
-    self, EncodeMetric, EncodeMetricValue, Family, MetricFamily, NamedMetric, RegistrationMetadata,
+    EncodeMetric, EncodeMetricValue, Family, MetricFamily, NamedMetric, RegistrationMetadata,
     register,
 };
 use foundations::telemetry::settings::{MetricsSettings, ServiceNameFormat};
 use serde::Serialize;
+
+mod common;
+use common::collect_text;
 
 #[derive(Clone, Eq, Hash, PartialEq, Serialize)]
 struct Labels {
@@ -58,7 +61,7 @@ fn a_custom_metric_is_exposed_through_the_facade() {
         service_name_format: ServiceNameFormat::MetricPrefix,
         report_optional: false,
     };
-    let text = metrics::collect(&settings).expect("metrics should be collectable");
+    let text = collect_text(&settings);
 
     // Telemetry is never initialised here, so the service name prefix is the
     // `UNINITIALISED_SERVICE_NAME` sentinel from `telemetry::metrics::init`

--- a/foundations/tests/info_metrics.rs
+++ b/foundations/tests/info_metrics.rs
@@ -4,7 +4,10 @@
 
 use foundations::ServiceInfo;
 use foundations::telemetry::settings::{MetricsSettings, ServiceNameFormat, TelemetrySettings};
-use foundations::telemetry::{TelemetryConfig, TelemetryContext, metrics};
+use foundations::telemetry::{TelemetryConfig, TelemetryContext};
+
+mod common;
+use common::collect_text;
 
 /// Returns the value of the sample line for `series`, if it was collected.
 fn sample_value(metrics: &str, series: &str) -> Option<f64> {
@@ -40,7 +43,7 @@ async fn init_reports_build_and_runtime_info_unprefixed() {
         service_name_format: ServiceNameFormat::MetricPrefix,
         report_optional: false,
     };
-    let text = metrics::collect(&settings).expect("metrics should be collectable");
+    let text = collect_text(&settings);
 
     assert_eq!(
         sample_value(&text, "build_info{version=\"4.5.6\"}"),

--- a/foundations/tests/metrics.rs
+++ b/foundations/tests/metrics.rs
@@ -1,7 +1,10 @@
 use foundations::ServiceInfo;
-use foundations::telemetry::metrics::{self, Counter, Family, metrics};
+use foundations::telemetry::metrics::{Counter, Family, metrics};
 use foundations::telemetry::settings::{MetricsSettings, ServiceNameFormat, TelemetrySettings};
 use foundations::telemetry::{TelemetryConfig, TelemetryContext};
+
+mod common;
+use common::collect_text;
 
 const ONE: &str = "1";
 
@@ -51,7 +54,7 @@ fn metrics_unprefixed() {
         service_name_format: ServiceNameFormat::MetricPrefix,
         report_optional: false,
     };
-    let metrics = metrics::collect(&settings).expect("metrics should be collectable");
+    let metrics = collect_text(&settings);
 
     // Global prefix defaults to "undefined" if not initialized
     assert!(metrics.contains(&format!("\nundefined_regular_requests {ONE}\n")));
@@ -90,7 +93,7 @@ undefined_encode_error_valid 1
         service_name_format: ServiceNameFormat::MetricPrefix,
         report_optional: false,
     };
-    let metrics = metrics::collect(&settings).expect("metrics should be collectable");
+    let metrics = collect_text(&settings);
     dbg!(&metrics);
 
     // On some OSs, process metrics may be automatically registered.
@@ -129,7 +132,7 @@ async fn test_context_cooperates_with_init() {
     regular::requests().inc();
     library::calls().inc();
 
-    let metrics = metrics::collect(&settings.metrics).expect("metrics should be collectable");
+    let metrics = collect_text(&settings.metrics);
 
     // Metrics registry should be initialized with explicit ServiceInfo from `foundations::telemetry::init`
     assert!(metrics.contains(&format!("\nmy_bin_regular_requests {ONE}\n")));

--- a/foundations/tests/metrics_negotiation.rs
+++ b/foundations/tests/metrics_negotiation.rs
@@ -15,6 +15,10 @@ use foundations::telemetry::settings::{MetricsSettings, ServiceNameFormat};
 use foundations::telemetry::settings::{TelemetryServerSettings, TelemetrySettings};
 use foundations::telemetry::{TelemetryConfig, TelemetryContext};
 
+mod common;
+#[cfg(target_os = "linux")]
+use common::collect_text;
+
 const PROTOBUF_ACCEPT: &str = "application/vnd.google.protobuf;\
                                proto=io.prometheus.client.MetricFamily;\
                                encoding=delimited;q=0.5,\
@@ -120,7 +124,7 @@ async fn metrics_endpoint_serves_the_negotiated_format() {
             service_name_format: ServiceNameFormat::LabelWithName("service".to_owned()),
             report_optional: false,
         };
-        let labelled = foundations::telemetry::metrics::collect(&label_settings).unwrap();
+        let labelled = collect_text(&label_settings);
 
         assert!(
             labelled

--- a/foundations/tests/metrics_negotiation_extra_producers.rs
+++ b/foundations/tests/metrics_negotiation_extra_producers.rs
@@ -125,4 +125,16 @@ async fn extra_producers_withhold_protobuf() {
         content_type.starts_with("application/openmetrics-text"),
         "unsatisfiable Accept should fall back to text, got: {content_type}"
     );
+
+    // Collecting directly bypasses negotiation, so the encoder refuses instead
+    // of silently dropping the producer's series.
+    assert!(!foundations::telemetry::metrics::allow_protobuf());
+    assert!(
+        foundations::telemetry::metrics::collect_format(
+            foundations::telemetry::metrics::ScrapeFormat::Protobuf,
+            &settings.metrics,
+        )
+        .is_err(),
+        "protobuf collection should fail while an extra producer is registered"
+    );
 }

--- a/foundations/tests/metrics_negotiation_extra_producers.rs
+++ b/foundations/tests/metrics_negotiation_extra_producers.rs
@@ -128,7 +128,10 @@ async fn extra_producers_withhold_protobuf() {
 
     // Collecting directly bypasses negotiation, so the encoder refuses instead
     // of silently dropping the producer's series.
-    assert!(!foundations::telemetry::metrics::allow_protobuf());
+    #[allow(deprecated)]
+    let allow_protobuf = foundations::telemetry::metrics::allow_protobuf();
+
+    assert!(!allow_protobuf);
     assert!(
         foundations::telemetry::metrics::collect_format(
             foundations::telemetry::metrics::ScrapeFormat::Protobuf,

--- a/foundations/tests/panic_hook.rs
+++ b/foundations/tests/panic_hook.rs
@@ -18,6 +18,9 @@ use foundations::{
 use foundations_macros::with_test_telemetry;
 use slog::Level;
 
+mod common;
+use common::collect_text;
+
 fn simulate_panic() {
     let _ = std::panic::catch_unwind(|| panic!("oh no! 😱"));
 }
@@ -41,7 +44,7 @@ fn panic_hook_metrics_are_well_formed() {
 
     let expected = "panics_total 1";
 
-    let metrics = foundations::telemetry::metrics::collect(&Default::default()).unwrap();
+    let metrics = collect_text(&Default::default());
     let has_metric = metrics.lines().any(|line| line == expected);
     assert!(has_metric);
 }


### PR DESCRIPTION
## Overview
- Keeps the `foundations-metrics-backend` feature flag off by default
- Separates negotiation from collection, deprecates the legacy `collect`
- Remove `ObserveNanos` from public API
- Re-exports backend builders and sets the correct crate versions.