### PR TITLE
Release 5.9.0 with new metrics backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "5.8.1"
+version = "5.9.0"
 repository = "https://github.com/cloudflare/foundations"
 edition = "2024"
 authors = ["Cloudflare"]
@@ -42,8 +42,8 @@ check-cfg = [
 [workspace.dependencies]
 anyhow = "1.0.102"
 backtrace = "0.3.76"
-foundations = { version = "5.8.1", path = "./foundations", default-features = false }
-foundations-macros = { version = "=5.8.1", path = "./foundations-macros", default-features = false }
+foundations = { version = "5.9.0", path = "./foundations", default-features = false }
+foundations-macros = { version = "=5.9.0", path = "./foundations-macros", default-features = false }
 foundations-metrics-registry = { version = "1.0.0", path = "./foundations-metrics-registry", default-features = false }
 foundations-metrics = { version = "0.1.0-beta.1", path = "./foundations-metrics", default-features = false }
 bindgen = { version = "0.72.1", default-features = false }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,18 @@
 
+5.9.0
+- 2026-08-13 fix: Make ScrapeFormat non-exhaustive to allow future expansion
+- 2026-08-13 refactor(metrics): finalize public API for publishing (#253)
+- 2026-08-13 docs(metrics): prepare the new metrics crates for publishing (#249)
+- 2026-08-12 Correct the UserSpan lifetime docs
+- 2026-08-11 Collapse duplicate span write-lock matches onto with_write
+- 2026-08-11 Add an owned UserSpan handle for user tracing
+- 2026-08-11 feat(metrics): Add NativeTimeHistogram, new_classic_and_native method, and third-party linux process metrics from prometheus crate (#244)
+- 2026-08-10 feat(foundations): negotiate metrics scrape formats (#248)
+- 2026-08-09 Fix typo in tracing settings
+- 2026-08-07 feat(foundations): migrate the metrics facade to foundations-metrics (#247)
+- 2026-08-07 feat(metrics): add info and custom metrics (#245)
+- 2026-08-05 feat(metrics): Implement exemplar metrics (#239)
+
 5.8.1
 - 2026-08-03 Add pause syscall to seccomp SERVICE_BASICS allowlist (#241)
 - 2026-07-31 feat(metrics): add metric validation + UTF-8 support (#238)

--- a/foundations-metrics-registry/Cargo.toml
+++ b/foundations-metrics-registry/Cargo.toml
@@ -8,7 +8,7 @@ authors = { workspace = true }
 license = { workspace = true }
 readme = "README.md"
 categories = ["development-tools", "encoding"]
-keywords = ["foundations"]
+keywords = ["foundations", "metrics", "prometheus"]
 # Regenerating the model is a repo-development check whose result depends on the
 # exact `prost-build` in use. Don't publish it.
 exclude = ["tests/proto_codegen.rs"]

--- a/foundations-metrics-registry/RELEASE_NOTES.md
+++ b/foundations-metrics-registry/RELEASE_NOTES.md
@@ -1,0 +1,20 @@
+
+1.0.0
+- 2026-08-13 refactor(metrics): finalize public API for publishing (#253)
+- 2026-08-13 docs(metrics): prepare the new metrics crates for publishing (#249)
+- 2026-08-07 feat(foundations): migrate the metrics facade to foundations-metrics (#247)
+- 2026-08-07 feat(metrics): add info and custom metrics (#245)
+- 2026-07-30 feat(metrics): add protobuf and OpenMetrics text encoders and collection (#237)
+- 2026-07-28 feat(metrics): add support for classic, time, and native histograms. (#236)
+- 2026-07-21 feat(metrics): add support for metric families and label serialisation (#234)
+- 2026-07-13 feat(metrics): implement Gauge, RangeGauge and GaugeGuard
+- 2026-07-13 feat(metrics): add Counter implementation.
+- 2026-07-10 chore(metrics-registry): remove subsystem comment
+- 2026-07-10 refactor(metrics-registry): simplify snapshots with static metric references
+- 2026-07-10 Apply suggestions from code review
+- 2026-07-09 feat(metrics-registry): add core registration API
+- 2026-07-09 fix(cargo): fix fmt & clippy
+- 2026-07-08 feat(metrics-registry): vendor generated Prometheus protobuf model
+- 2026-07-08 feat(metrics-registry): add crate with Prometheus protobuf data model
+
+

--- a/foundations-metrics/README.md
+++ b/foundations-metrics/README.md
@@ -10,21 +10,23 @@ model.
 `foundations` re-exports this crate's items through
 `foundations::telemetry::metrics` when its opt-in `foundations-metrics-backend`
 feature is enabled. Existing counter, gauge, histogram, and family call sites
-therefore continue to compile. This compatibility is intended to ease migration
-and will be removed in the next major release. Code using exemplars must move to
-the generic `WithExemplar` wrapper, and the deprecated items below require code
-changes.
+therefore continue to compile. This compatibility is intended to ease migration,
+but exposes users to more breaking changes via foundations' larger API surface.
+Code using exemplars must move to the generic `WithExemplar` wrapper, and the
+deprecated items below require code changes.
 
 `Counter` no longer exposes an underlying
 `prometheus_client::metrics::counter::Counter`. Code that previously accessed it
 through `counter.0` should call methods on `Counter` directly, such as `inc`,
 `inc_by`, or `get`.
 
-To migrate, depend on this crate directly and update the import path:
+Users that do not want any of the other features of foundations are encouraged to
+depend directly on `foundations-metrics` in the future. To migrate, update your
+`Cargo.toml` and import paths:
 
 ```toml
 [dependencies]
-foundations-metrics = "0.1"
+foundations-metrics = "0.1.0-beta.1"
 ```
 
 ```rust

--- a/foundations-metrics/RELEASE_NOTES.md
+++ b/foundations-metrics/RELEASE_NOTES.md
@@ -1,0 +1,24 @@
+
+0.1.0-beta.1
+- 2026-08-13 refactor(metrics): finalize public API for publishing (#253)
+- 2026-08-13 docs(metrics): prepare the new metrics crates for publishing (#249)
+- 2026-08-11 feat(metrics): Add NativeTimeHistogram, new_classic_and_native method, and third-party linux process metrics from prometheus crate (#244)
+- 2026-08-10 feat(foundations): negotiate metrics scrape formats (#248)
+- 2026-08-07 feat(foundations): migrate the metrics facade to foundations-metrics (#247)
+- 2026-08-07 feat(metrics): add info and custom metrics (#245)
+- 2026-08-05 feat(metrics): Implement exemplar metrics (#239)
+- 2026-07-31 feat(metrics): add metric validation + UTF-8 support (#238)
+- 2026-07-30 feat(metrics): add protobuf and OpenMetrics text encoders and collection (#237)
+- 2026-07-28 feat(metrics): add support for classic, time, and native histograms. (#236)
+- 2026-07-21 feat(metrics): add support for metric families and label serialisation (#234)
+- 2026-07-16 Apply suggestions from code review
+- 2026-07-16 doc(metrics): apply doc suggestions from code review.
+- 2026-07-15 docs(metrics): improve comments & examples in gauge.rs
+- 2026-07-14 feat(metrics): re-export registry API
+- 2026-07-13 refactor(metrics): own scalar metric atomic storage
+- 2026-07-13 chore(metrics): cleanup comments
+- 2026-07-13 fix(metrics): add Counter inner accessor
+- 2026-07-13 feat(metrics): implement Gauge, RangeGauge and GaugeGuard
+- 2026-07-13 feat(metrics): add Counter implementation.
+
+

--- a/foundations/src/telemetry/metrics/mod.rs
+++ b/foundations/src/telemetry/metrics/mod.rs
@@ -302,8 +302,14 @@ fn report_nonfatal_collect_error(err: &dyn Display) {
 /// * [`Histogram`]
 /// * [`TimeHistogram`]
 ///
-/// To attach exemplars, wrap any of the above in [`WithExemplar<T, S>`], which
-/// derefs to the metric it wraps.
+#[cfg_attr(
+    feature = "foundations-metrics-backend",
+    doc = "To attach exemplars, wrap any of the above in [`WithExemplar<T, S>`], which derefs to the metric it wraps."
+)]
+#[cfg_attr(
+    not(feature = "foundations-metrics-backend"),
+    doc = "To attach exemplars, we provide [`CounterWithExemplar`] and [`HistogramWithExemplars`]."
+)]
 ///
 /// ```ignore
 /// let requests: WithExemplar<Counter, TraceLabels> = WithExemplar::default();

--- a/foundations/src/telemetry/metrics/negotiation.rs
+++ b/foundations/src/telemetry/metrics/negotiation.rs
@@ -20,6 +20,7 @@ const PROTOBUF_CONTENT_TYPE: &str =
     "application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited";
 
 /// Wire format a scraper asked for.
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ScrapeFormat {
     /// Length-delimited Prometheus protobuf, the only format able to carry


### PR DESCRIPTION
### Added
- `foundations-metrics-backend` feature: @ethanolchik has been hard at work creating a new protobuf-native metrics implementation for foundations. This unlocks native histogram support and will replace the current implementation, which is stuck on an outdated version of `prometheus-client`, in foundations 6. The new implementation is designed to be backwards-compatible for the majority of users. It can be enabled as a preview via the `foundations-metrics-backend` feature. A migration guide is available in the `foundations-metrics` README.md. **Please note that, as an opt-in preview, we reserve the right to make breaking changes in minor versions.**

- `UserSpan` type: `user-tracing` spans can now be created as a separate type detached from the regular thread-local tracing stack. This is similar to a `TelemetryContext`, but without pulling in the other telemetry sources as well (logging and regular tracing). See #252.