### PR TITLE
Release 5.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "5.9.0"
+version = "5.9.1"
 repository = "https://github.com/cloudflare/foundations"
 edition = "2024"
 authors = ["Cloudflare"]
@@ -42,8 +42,8 @@ check-cfg = [
 [workspace.dependencies]
 anyhow = "1.0.102"
 backtrace = "0.3.76"
-foundations = { version = "5.9.0", path = "./foundations", default-features = false }
-foundations-macros = { version = "=5.9.0", path = "./foundations-macros", default-features = false }
+foundations = { version = "5.9.1", path = "./foundations", default-features = false }
+foundations-macros = { version = "=5.9.1", path = "./foundations-macros", default-features = false }
 foundations-metrics-registry = { version = "1.0.0", path = "./foundations-metrics-registry", default-features = false }
 foundations-metrics = { version = "0.1.0-beta.2", path = "./foundations-metrics", default-features = false }
 bindgen = { version = "0.72.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ backtrace = "0.3.76"
 foundations = { version = "5.9.0", path = "./foundations", default-features = false }
 foundations-macros = { version = "=5.9.0", path = "./foundations-macros", default-features = false }
 foundations-metrics-registry = { version = "1.0.0", path = "./foundations-metrics-registry", default-features = false }
-foundations-metrics = { version = "0.1.0-beta.1", path = "./foundations-metrics", default-features = false }
+foundations-metrics = { version = "0.1.0-beta.2", path = "./foundations-metrics", default-features = false }
 bindgen = { version = "0.72.1", default-features = false }
 cc = "1.2.61"
 cf-rustracing = "1.4.0"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,8 @@
 
+5.9.1
+- 2026-08-18 feat(metrics): expose max_zero_threshold on NativeHistogramBuilder
+- 2026-08-17 feat(metrics): let native histograms recover lost resolution
+
 5.9.0
 - 2026-08-13 fix: Make ScrapeFormat non-exhaustive to allow future expansion
 - 2026-08-13 refactor(metrics): finalize public API for publishing (#253)

--- a/foundations-metrics/Cargo.toml
+++ b/foundations-metrics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "foundations-metrics"
 description = "Metric types and encoders for the Foundations stack."
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 readme = "README.md"
 repository = { workspace = true }
 edition = { workspace = true }

--- a/foundations-metrics/RELEASE_NOTES.md
+++ b/foundations-metrics/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 
-0.1.0-beta.1
+0.1.0-beta.2
+- 2026-08-18 feat(metrics): expose max_zero_threshold on NativeHistogramBuilder
+- 2026-08-17 feat(metrics): let native histograms recover lost resolution
+
+foundations-metrics-v0.1.0-beta.1
 - 2026-08-13 refactor(metrics): finalize public API for publishing (#253)
 - 2026-08-13 docs(metrics): prepare the new metrics crates for publishing (#249)
 - 2026-08-11 feat(metrics): Add NativeTimeHistogram, new_classic_and_native method, and third-party linux process metrics from prometheus crate (#244)


### PR DESCRIPTION
### Fixed
- #255: New config knobs `min_reset_duration` and `max_zero_threshold` in `NativeHistogramBuilder` give users control over downsampling behavior in native histograms. (Only available with the preview `foundations-metrics-backend` feature.)