### PR TITLE
fix(metrics): pin prometheus's protobuf feature for process metrics

### DIFF
--- a/foundations/Cargo.toml
+++ b/foundations/Cargo.toml
@@ -253,7 +253,7 @@ once_cell = { workspace = true, optional = true }
 opentelemetry-proto = { workspace = true, optional = true, features = ["gen-tonic-messages", "trace"] }
 parking_lot = { workspace = true, optional = true }
 percent-encoding = { workspace = true, optional = true }
-prometheus = { workspace = true, optional = true, features = ["process"] }
+prometheus = { workspace = true, optional = true, features = ["process", "protobuf"] }
 prometheus-client = { workspace = true, optional = true }
 prometools = { workspace = true, optional = true, features = ["serde"] }
 prost = { workspace = true, optional = true }

--- a/foundations/src/telemetry/metrics/process.rs
+++ b/foundations/src/telemetry/metrics/process.rs
@@ -59,7 +59,7 @@ fn convert_family(family: PrometheusMetricFamily) -> Option<MetricFamily> {
                 MetricType::Counter => Metric {
                     label,
                     counter: Some(Counter {
-                        value: Some(metric.get_counter().get_value()),
+                        value: Some(metric.get_counter().value()),
                         ..Default::default()
                     }),
                     ..Default::default()
@@ -67,7 +67,7 @@ fn convert_family(family: PrometheusMetricFamily) -> Option<MetricFamily> {
                 MetricType::Gauge => Metric {
                     label,
                     gauge: Some(Gauge {
-                        value: Some(metric.get_gauge().get_value()),
+                        value: Some(metric.get_gauge().value()),
                     }),
                     ..Default::default()
                 },


### PR DESCRIPTION
`process.rs` calls prometheus's `get_value()`, which only exists when prometheus's `protobuf` feature is off — but the feature was never pinned, so any other crate in the graph enabling it (it is a prometheus *default*) swaps in the protobuf model and breaks the build.

Pin `protobuf` on and use the `value()` accessor, which is public in that model (`get_value()` lives on the private `proto_ext::MessageFieldExt` trait).