### PR TITLE
Release 5.9.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "5.9.1"
+version = "5.9.2"
 repository = "https://github.com/cloudflare/foundations"
 edition = "2024"
 authors = ["Cloudflare"]
@@ -42,8 +42,8 @@ check-cfg = [
 [workspace.dependencies]
 anyhow = "1.0.102"
 backtrace = "0.3.76"
-foundations = { version = "5.9.1", path = "./foundations", default-features = false }
-foundations-macros = { version = "=5.9.1", path = "./foundations-macros", default-features = false }
+foundations = { version = "5.9.2", path = "./foundations", default-features = false }
+foundations-macros = { version = "=5.9.2", path = "./foundations-macros", default-features = false }
 foundations-metrics-registry = { version = "1.0.0", path = "./foundations-metrics-registry", default-features = false }
 foundations-metrics = { version = "0.1.0-beta.3", path = "./foundations-metrics", default-features = false }
 bindgen = { version = "0.72.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ backtrace = "0.3.76"
 foundations = { version = "5.9.1", path = "./foundations", default-features = false }
 foundations-macros = { version = "=5.9.1", path = "./foundations-macros", default-features = false }
 foundations-metrics-registry = { version = "1.0.0", path = "./foundations-metrics-registry", default-features = false }
-foundations-metrics = { version = "0.1.0-beta.2", path = "./foundations-metrics", default-features = false }
+foundations-metrics = { version = "0.1.0-beta.3", path = "./foundations-metrics", default-features = false }
 bindgen = { version = "0.72.1", default-features = false }
 cc = "1.2.61"
 cf-rustracing = "1.4.0"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,8 @@
 
+5.9.2
+- 2026-08-26 fix(metrics): terminate classic histogram buckets with +Inf
+- 2026-08-25 fix(metrics): pin prometheus's protobuf feature for process metrics
+
 5.9.1
 - 2026-08-18 feat(metrics): expose max_zero_threshold on NativeHistogramBuilder
 - 2026-08-17 feat(metrics): let native histograms recover lost resolution

--- a/foundations-metrics/Cargo.toml
+++ b/foundations-metrics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "foundations-metrics"
 description = "Metric types and encoders for the Foundations stack."
-version = "0.1.0-beta.2"
+version = "0.1.0-beta.3"
 readme = "README.md"
 repository = { workspace = true }
 edition = { workspace = true }

--- a/foundations-metrics/RELEASE_NOTES.md
+++ b/foundations-metrics/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 
-0.1.0-beta.2
+0.1.0-beta.3
+- 2026-08-26 fix(metrics): terminate classic histogram buckets with +Inf
 - 2026-08-18 feat(metrics): expose max_zero_threshold on NativeHistogramBuilder
 - 2026-08-17 feat(metrics): let native histograms recover lost resolution
 


### PR DESCRIPTION
### Fixed
- #258: With `foundations-metrics-backend` enabled, the `process` metrics implementation relied on an accessor in the `prometheus` crate that is not present when the `protobuf` feature is enabled. This change enables the `protobuf` feature in `prometheus` instead and uses a different accessor.
- #260: `NativeHistogram`, when scraped in protobuf format, now correctly exposes an upper bound of `f64::INFINITY` rather than `f64::MAX`.