### PR TITLE
fix(metrics): terminate classic histogram buckets with +Inf

### DIFF
--- a/foundations-metrics/src/encoding/text.rs
+++ b/foundations-metrics/src/encoding/text.rs
@@ -219,17 +219,6 @@ fn encode_histogram(
     let mut infinity_bucket_seen = false;
     for bucket in &histogram.bucket {
         let upper_bound = bucket.upper_bound.unwrap_or_default();
-        // `Histogram` uses `f64::MAX` as its terminal bucket bound, matching
-        // `prometheus_client`, so that the bound stays a finite value the
-        // protobuf data model round-trips unchanged. The text exposition format
-        // has no such constraint and requires the catch-all bucket to be
-        // labelled `le="+Inf"`, so the sentinel is translated on the way out
-        // rather than at its source.
-        let upper_bound = if upper_bound == f64::MAX {
-            f64::INFINITY
-        } else {
-            upper_bound
-        };
         infinity_bucket_seen |= upper_bound == f64::INFINITY;
 
         write_sample(
@@ -605,7 +594,7 @@ requests{kind=\"a\\\"b\\\\c\\nd\"} 1 1.5 # {trace_id=\"abc\"} 2.0\n\
     }
 
     #[test]
-    fn encodes_classic_histogram_and_maps_terminal_bucket_to_infinity() {
+    fn encodes_classic_histogram_with_infinite_terminal_bucket() {
         let families = [MetricFamily {
             name: Some("request_duration_seconds".to_owned()),
             help: Some("Request duration.".to_owned()),
@@ -626,7 +615,7 @@ requests{kind=\"a\\\"b\\\\c\\nd\"} 1 1.5 # {trace_id=\"abc\"} 2.0\n\
                         },
                         Bucket {
                             cumulative_count: Some(3),
-                            upper_bound: Some(f64::MAX),
+                            upper_bound: Some(f64::INFINITY),
                             ..Default::default()
                         },
                     ],

--- a/foundations-metrics/src/metrics/histogram.rs
+++ b/foundations-metrics/src/metrics/histogram.rs
@@ -52,10 +52,10 @@ impl Histogram {
     /// Creates a histogram with the provided inclusive upper bounds.
     ///
     /// Bounds may be given in any order; they are sorted ascending. A terminal
-    /// `f64::MAX` bucket is appended automatically.
+    /// `f64::INFINITY` bucket is appended automatically.
     pub fn new(bounds: impl IntoIterator<Item = f64>) -> Self {
         let mut buckets: Vec<_> = bounds.into_iter().map(|bound| (bound, 0)).collect();
-        buckets.push((f64::MAX, 0));
+        buckets.push((f64::INFINITY, 0));
         buckets.sort_by(|(a, _), (b, _)| a.total_cmp(b));
 
         Self {
@@ -358,11 +358,11 @@ impl TimeHistogram {
     /// Creates a time histogram with inclusive bucket bounds in seconds.
     ///
     /// Bounds may be given in any order; they are sorted ascending. A terminal
-    /// `f64::MAX` bucket is appended automatically.
+    /// `f64::INFINITY` bucket is appended automatically.
     pub fn new(buckets: impl IntoIterator<Item = f64>) -> Self {
         let mut buckets: Vec<_> = buckets
             .into_iter()
-            .chain(once(f64::MAX))
+            .chain(once(f64::INFINITY))
             .map(|upper_bound| (upper_bound, AtomicU64::new(0)))
             .collect();
         buckets.sort_by(|(a, _), (b, _)| a.total_cmp(b));
@@ -477,7 +477,7 @@ mod tests {
             HistogramSnapshot {
                 sum: 6.0,
                 count: 4,
-                buckets: vec![(1.0, 2), (2.0, 1), (f64::MAX, 1)],
+                buckets: vec![(1.0, 2), (2.0, 1), (f64::INFINITY, 1)],
             }
         );
     }
@@ -496,7 +496,10 @@ mod tests {
         let unsorted = Histogram::new([10.0, 1.0]);
         unsorted.observe(0.5);
         let snapshot = unsorted.snapshot();
-        assert_eq!(snapshot.buckets, vec![(1.0, 1), (10.0, 0), (f64::MAX, 0)],);
+        assert_eq!(
+            snapshot.buckets,
+            vec![(1.0, 1), (10.0, 0), (f64::INFINITY, 0)],
+        );
     }
 
     #[test]
@@ -528,7 +531,7 @@ mod tests {
             vec![
                 (Some(1.0), Some(1)),
                 (Some(2.0), Some(2)),
-                (Some(f64::MAX), Some(3)),
+                (Some(f64::INFINITY), Some(3)),
             ]
         );
     }
@@ -596,7 +599,7 @@ mod tests {
 
         assert_eq!(
             histogram.snapshot().buckets(),
-            &[(1.0, 1), (2.0, 0), (f64::MAX, 0)]
+            &[(1.0, 1), (2.0, 0), (f64::INFINITY, 0)]
         );
     }
 
@@ -626,7 +629,7 @@ mod tests {
                 (4.0, 1),
                 (8.0, 0),
                 (16.0, 1),
-                (f64::MAX, 0),
+                (f64::INFINITY, 0),
             ]
         );
     }

--- a/foundations-metrics/src/metrics/native_histogram.rs
+++ b/foundations-metrics/src/metrics/native_histogram.rs
@@ -490,7 +490,7 @@ fn convert_native_histogram(histogram: prometheus_proto::Histogram) -> proto::Hi
                 cumulative_count: Some(bucket.cumulative_count),
                 cumulative_count_float: (bucket.cumulative_count_float > 0.0)
                     .then_some(bucket.cumulative_count_float),
-                upper_bound: Some(bucket.upper_bound),
+                upper_bound: Some(classic_upper_bound(bucket.upper_bound)),
                 ..Default::default()
             })
             .collect(),
@@ -514,6 +514,23 @@ fn convert_native_histogram(histogram: prometheus_proto::Histogram) -> proto::Hi
         positive_delta: histogram.positive_delta,
         positive_count: histogram.positive_count,
         ..Default::default()
+    }
+}
+
+/// Translates `prometheus_client`'s terminal classic bucket bound to `+Inf`.
+///
+/// Upstream ends its classic bucket list with the finite `f64::MAX` rather than
+/// `f64::INFINITY`. Prometheus expects the catch-all bucket of a classic
+/// histogram to be `+Inf` and synthesises one when the encoded buckets do not
+/// end in an infinite bound, so passing the sentinel through would expose an
+/// extra `le` series duplicating `+Inf`. [`Histogram`](super::Histogram) and
+/// [`TimeHistogram`](super::TimeHistogram) own their bucket lists and already
+/// use `f64::INFINITY`; only the buckets borrowed from upstream need this.
+fn classic_upper_bound(upper_bound: f64) -> f64 {
+    if upper_bound == f64::MAX {
+        f64::INFINITY
+    } else {
+        upper_bound
     }
 }
 
@@ -662,7 +679,7 @@ mod tests {
             vec![
                 (Some(1.0), Some(0)),
                 (Some(2.0), Some(1)),
-                (Some(f64::MAX), Some(1)),
+                (Some(f64::INFINITY), Some(1)),
             ]
         );
         assert!(encoded.schema.is_some());

--- a/foundations-metrics/tests/histogram_terminal_bucket.rs
+++ b/foundations-metrics/tests/histogram_terminal_bucket.rs
@@ -1,0 +1,135 @@
+//! The catch-all bucket of a classic histogram must be exposed as `+Inf` by
+//! every encoder.
+//!
+//! Prometheus treats an infinite bound as the terminator of a classic bucket
+//! list and appends a synthetic `+Inf` bucket carrying the sample count when it
+//! does not find one. A finite terminal bound is therefore scraped as an extra
+//! `le` series duplicating `+Inf`, which inflates series counts and lets
+//! `histogram_quantile` interpolate between the last real bound and the
+//! sentinel.
+
+use foundations_metrics::{
+    EncodeMetric, Histogram, NamedMetric, NativeHistogram, TimeHistogram, encode_to_protobuf,
+    encode_to_text,
+};
+use foundations_metrics_registry::proto::MetricFamily;
+use prost::Message;
+
+const BOUNDS: [f64; 2] = [0.1, 0.5];
+
+fn decode(mut bytes: &[u8]) -> Vec<MetricFamily> {
+    let mut families = Vec::new();
+    while !bytes.is_empty() {
+        families.push(
+            MetricFamily::decode_length_delimited(&mut bytes).expect("encoded family decodes"),
+        );
+    }
+    families
+}
+
+/// Upper bounds of every classic bucket in the protobuf exposition.
+fn protobuf_upper_bounds(families: &[MetricFamily]) -> Vec<f64> {
+    decode(&encode_to_protobuf(families))
+        .iter()
+        .flat_map(|family| &family.metric)
+        .filter_map(|metric| metric.histogram.as_ref())
+        .flat_map(|histogram| &histogram.bucket)
+        .map(|bucket| bucket.upper_bound.expect("bucket has an upper bound"))
+        .collect()
+}
+
+/// `le` label values of every `_bucket` line in the text exposition.
+fn text_upper_bounds(families: &[MetricFamily]) -> Vec<String> {
+    encode_to_text(families)
+        .lines()
+        .filter(|line| line.contains("_bucket{"))
+        .map(|line| {
+            let le = line.split("le=\"").nth(1).expect("bucket line carries le");
+            le.split('"').next().expect("le is quoted").to_owned()
+        })
+        .collect()
+}
+
+#[track_caller]
+fn assert_terminates_with_infinity(families: &[MetricFamily]) {
+    let protobuf = protobuf_upper_bounds(families);
+    let text = text_upper_bounds(families);
+
+    // One bucket per bound, plus the catch-all: no duplicate terminal series.
+    assert_eq!(
+        protobuf.len(),
+        BOUNDS.len() + 1,
+        "unexpected protobuf bucket count: {protobuf:?}"
+    );
+    assert_eq!(
+        text.len(),
+        BOUNDS.len() + 1,
+        "unexpected text bucket count: {text:?}"
+    );
+
+    assert!(
+        protobuf.last().is_some_and(|bound| bound.is_infinite()),
+        "protobuf must terminate with +Inf, got {protobuf:?}"
+    );
+    assert_eq!(
+        text.last().map(String::as_str),
+        Some("+Inf"),
+        "text must terminate with +Inf, got {text:?}"
+    );
+
+    // The `prometheus_client` sentinel must never reach the wire.
+    assert!(
+        !protobuf.contains(&f64::MAX),
+        "f64::MAX leaked into the protobuf exposition: {protobuf:?}"
+    );
+
+    // Both encoders must describe the same bucket boundaries.
+    let protobuf_as_text: Vec<_> = protobuf
+        .iter()
+        .map(|bound| {
+            if bound.is_infinite() {
+                "+Inf".to_owned()
+            } else {
+                bound.to_string()
+            }
+        })
+        .collect();
+    assert_eq!(
+        protobuf_as_text, text,
+        "text and protobuf disagree on bucket bounds"
+    );
+}
+
+#[test]
+fn classic_histogram_terminates_with_infinity() {
+    let histogram = Histogram::new(BOUNDS);
+    histogram.observe(0.05);
+    histogram.observe(0.2);
+    histogram.observe(999.0); // Overflows every configured bound.
+
+    assert_terminates_with_infinity(&NamedMetric::new("demo_seconds", "Demo.", histogram).encode());
+}
+
+#[test]
+fn time_histogram_terminates_with_infinity() {
+    let histogram = TimeHistogram::new(BOUNDS);
+    histogram.observe(50_000_000);
+    histogram.observe(200_000_000);
+    histogram.observe(999_000_000_000);
+
+    assert_terminates_with_infinity(
+        &NamedMetric::new("demo_time_seconds", "Demo.", histogram).encode(),
+    );
+}
+
+#[test]
+fn native_histogram_classic_buckets_terminate_with_infinity() {
+    let histogram = NativeHistogram::new_classic_and_native(BOUNDS, 1.1);
+    histogram.observe(0.05);
+    histogram.observe(0.2);
+    histogram.observe(999.0);
+
+    assert_terminates_with_infinity(
+        &NamedMetric::new("demo_native_seconds", "Demo.", histogram).encode(),
+    );
+}


### PR DESCRIPTION
Classic histogram bucket lists terminated with a finite `f64::MAX` instead of `f64::INFINITY`. `encode_to_text` rewrote it to `+Inf`; `encode_to_protobuf` did not, so scrapes gained a phantom `le="1.7976931348623157e+308"` series and `histogram_quantile` interpolated against the sentinel (p99 returned ~`1.8e308` rather than clamping to the top bucket).

Changes:

- `metrics/histogram.rs` – `Histogram::new` and `TimeHistogram::new` append `f64::INFINITY`.
- `metrics/native_histogram.rs` – new `classic_upper_bound` translates the sentinel where `prometheus_client`'s buckets enter our protobuf model. Needed separately: upstream appends `f64::MAX` itself, so `NativeHistogram` isn't covered by the change above.
- `encoding/text.rs` – dropped the rewrite. Nothing emits the sentinel now, and its comment wrongly claimed the finite bound was required by the protobuf data model.
- `tests/histogram_terminal_bucket.rs` – asserts the terminal bound across both encoders for classic, time and native+classic histograms.

Also fixes `observe(f64::INFINITY)` matching no bucket while still incrementing the count.

Breaking for consumers reading the terminal bound: `HistogramSnapshot::buckets()` and the encoded value are now `f64::INFINITY`. `cloudchamberd-rs/src/rpc_metrics.rs` asserts the old value.
