### PR TITLE
Release 5.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "5.9.2"
+version = "5.10.0"
 repository = "https://github.com/cloudflare/foundations"
 edition = "2024"
 authors = ["Cloudflare"]
@@ -42,8 +42,8 @@ check-cfg = [
 [workspace.dependencies]
 anyhow = "1.0.102"
 backtrace = "0.3.76"
-foundations = { version = "5.9.2", path = "./foundations", default-features = false }
-foundations-macros = { version = "=5.9.2", path = "./foundations-macros", default-features = false }
+foundations = { version = "5.10.0", path = "./foundations", default-features = false }
+foundations-macros = { version = "=5.10.0", path = "./foundations-macros", default-features = false }
 foundations-metrics-registry = { version = "1.0.0", path = "./foundations-metrics-registry", default-features = false }
 foundations-metrics = { version = "0.1.0-beta.3", path = "./foundations-metrics", default-features = false }
 bindgen = { version = "0.72.1", default-features = false }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 
+5.10.0
+- 2026-08-28 feat(examples): add span_with_probe demo workload
+- 2026-08-28 feat(telemetry): add span_with_probe! macro and span_fn's end_probe option
+
 5.9.2
+- 2026-08-26 Release 5.9.2 (#259)
 - 2026-08-26 fix(metrics): terminate classic histogram buckets with +Inf
 - 2026-08-25 fix(metrics): pin prometheus's protobuf feature for process metrics
 


### PR DESCRIPTION
### Added
- #257: The new `span_with_probe!` macro (and its `#[span_fn]` counterpart, `end_probe = true`) adds a unique USDT probe point to the created span. It is executed when the span is dropped (provided something attached to the probe point.) The probe point is named after the span, so you can choose which span ends to observe. See the [`probe!`](https://docs.rs/probe/latest/probe/) docs for details on how this works internally.