### PR TITLE
Release 5.10.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "5.10.0"
+version = "5.10.1"
 repository = "https://github.com/cloudflare/foundations"
 edition = "2024"
 authors = ["Cloudflare"]
@@ -42,8 +42,8 @@ check-cfg = [
 [workspace.dependencies]
 anyhow = "1.0.102"
 backtrace = "0.3.76"
-foundations = { version = "5.10.0", path = "./foundations", default-features = false }
-foundations-macros = { version = "=5.10.0", path = "./foundations-macros", default-features = false }
+foundations = { version = "5.10.1", path = "./foundations", default-features = false }
+foundations-macros = { version = "=5.10.1", path = "./foundations-macros", default-features = false }
 foundations-metrics-registry = { version = "1.0.0", path = "./foundations-metrics-registry", default-features = false }
 foundations-metrics = { version = "0.1.0-beta.3", path = "./foundations-metrics", default-features = false }
 bindgen = { version = "0.72.1", default-features = false }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,9 @@
 
+5.10.1
+- 2026-09-03 feat(telemetry): attach user spans to contexts
+- 2026-09-03 refactor(telemetry): distinguish deferred user spans
+- 2026-09-03 feat(telemetry): add deferred user span activation
+
 5.10.0
 - 2026-08-28 feat(examples): add span_with_probe demo workload
 - 2026-08-28 feat(telemetry): add span_with_probe! macro and span_fn's end_probe option


### PR DESCRIPTION
### Added
- #262: `UserSpan`s can now be created in a "detached" mode. This allows them to be included in a `TelemetryContext` similar to an inactive (unsampled) span, but then be activated later on. Once activated, all ambient helpers will act on the newly-created span as normal. *Caveat:* children created before the detached span is activated are _inactive spans_ and will stay that way even after the detached span has been activated.
- #265: `TelemetryContext::with_user_span` is a shorthand for `my_user_span.enter().into_context()`