### PR TITLE
Add docs for new type enum variants to generated settings

### DIFF
--- a/foundations-macros/src/settings.rs
+++ b/foundations-macros/src/settings.rs
@@ -4,10 +4,11 @@ use darling::util::{Flag, Override};
 use proc_macro::TokenStream;
 use quote::{ToTokens, TokenStreamExt, quote, quote_spanned};
 use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{
     Attribute, Expr, ExprLit, Field, Fields, Ident, Item, ItemEnum, ItemStruct, Lit, LitStr, Meta,
-    MetaNameValue, Path, Type, parse_macro_input, parse_quote,
+    MetaNameValue, Path, Token, Type, Variant, parse_macro_input, parse_quote,
 };
 
 const ERR_NOT_STRUCT_OR_ENUM: &str = "Settings should be either structure or enum.";
@@ -127,13 +128,12 @@ fn expand_enum(options: Options, item: &mut ItemEnum) -> Result<proc_macro2::Tok
     item.attrs
         .push(parse_quote!(#[serde(rename_all = "snake_case")]));
 
-    let ident = item.ident.clone();
-    let crate_path = options.crate_path;
+    let impl_settings = impl_settings_trait_for_enum(&options, item);
 
     Ok(quote! {
         #item
 
-        impl #crate_path::settings::Settings for #ident { }
+        #impl_settings
     })
 }
 
@@ -295,6 +295,96 @@ fn impl_settings_trait_for_field(
     impl_for_field
 }
 
+fn impl_settings_trait_for_enum(options: &Options, item: &ItemEnum) -> proc_macro2::TokenStream {
+    let ident = item.ident.clone();
+    let crate_path = &options.crate_path;
+
+    // Nothing under a variant can be documented, so keep the default no-op `add_docs`.
+    if !item.variants.iter().any(is_documented_variant) {
+        return quote! {
+            impl #crate_path::settings::Settings for #ident { }
+        };
+    }
+
+    let mut doc_comments_impl = quote! {};
+
+    for variant in &item.variants {
+        doc_comments_impl.append_all(impl_settings_trait_for_variant(options, variant));
+    }
+
+    quote! {
+        impl #crate_path::settings::Settings for #ident {
+            fn add_docs(
+                &self,
+                parent_key: &[String],
+                docs: &mut ::std::collections::HashMap<Vec<String>, &'static [&'static str]>)
+            {
+                match self {
+                    #doc_comments_impl
+                }
+            }
+        }
+    }
+}
+
+/// Returns whether a variant gets a key of its own in the serialized settings.
+///
+/// A unit variant serializes as a bare value, so there is no line to document. A skipped
+/// variant never reaches the config at all, and the type it wraps doesn't have to implement
+/// [`Settings`].
+fn is_documented_variant(variant: &Variant) -> bool {
+    matches!(variant.fields, Fields::Unnamed(_)) && !is_serde_skipped(&variant.attrs)
+}
+
+fn impl_settings_trait_for_variant(
+    options: &Options,
+    variant: &Variant,
+) -> proc_macro2::TokenStream {
+    let ident = &variant.ident;
+    let span = variant.fields.span();
+
+    let cfg_attrs = variant
+        .attrs
+        .iter()
+        .filter(|a| a.path().is_ident("cfg"))
+        .collect::<Vec<_>>();
+
+    if !is_documented_variant(variant) {
+        let pattern = match variant.fields {
+            Fields::Unnamed(_) => quote_spanned! { span=> Self::#ident(..) },
+            _ => quote_spanned! { span=> Self::#ident },
+        };
+
+        return quote! {
+            #(#cfg_attrs)*
+            #pattern => {}
+        };
+    }
+
+    let crate_path = &options.crate_path;
+    let key_str = serde_variant_name(variant);
+    let docs = extract_doc_comments(&variant.attrs);
+
+    let mut impl_for_variant = quote_spanned! { span=>
+        let mut key = parent_key.to_vec();
+        key.push(#key_str.into());
+        #crate_path::settings::Settings::add_docs(value, &key, docs);
+    };
+
+    if !docs.is_empty() {
+        impl_for_variant.append_all(quote! {
+            docs.insert(key, &[#(#docs,)*][..]);
+        });
+    }
+
+    quote_spanned! { span=>
+        #(#cfg_attrs)*
+        Self::#ident(value) => {
+            #impl_for_variant
+        }
+    }
+}
+
 fn extract_doc_comments(attrs: &[Attribute]) -> Vec<LitStr> {
     let mut comments = vec![];
 
@@ -349,6 +439,87 @@ fn is_serde_flattened(attrs: &[Attribute]) -> bool {
         SerdeArgs::parse_from_attrs(attrs),
         Ok(Some(args)) if args.flatten.is_present(),
     )
+}
+
+/// Returns the arguments of every `serde` attribute in `attrs`, including the ones written as
+/// `cfg_attr(<predicate>, serde(...))`, which reach an attribute macro unexpanded.
+fn serde_args(attrs: &[Attribute]) -> Vec<Meta> {
+    let mut args = Vec::new();
+
+    for attr in attrs {
+        let meta = if attr.path().is_ident("serde") {
+            attr.meta.clone()
+        } else if attr.path().is_ident("cfg_attr") {
+            let Ok(nested) = attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+            else {
+                continue;
+            };
+
+            // The first argument is the `cfg` predicate, the rest are the attributes it guards.
+            let Some(meta) = nested
+                .into_iter()
+                .skip(1)
+                .find(|meta| meta.path().is_ident("serde"))
+            else {
+                continue;
+            };
+
+            meta
+        } else {
+            continue;
+        };
+
+        let Meta::List(list) = meta else {
+            continue;
+        };
+
+        if let Ok(nested) = list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated) {
+            args.extend(nested);
+        }
+    }
+
+    args
+}
+
+/// Returns whether `attrs` contains `serde(skip)`.
+fn is_serde_skipped(attrs: &[Attribute]) -> bool {
+    serde_args(attrs)
+        .iter()
+        .any(|arg| arg.path().is_ident("skip"))
+}
+
+/// Returns the key an enum variant serializes under.
+fn serde_variant_name(variant: &Variant) -> String {
+    for arg in serde_args(&variant.attrs) {
+        if let Meta::NameValue(MetaNameValue {
+            path,
+            value:
+                Expr::Lit(ExprLit {
+                    lit: Lit::Str(name),
+                    ..
+                }),
+            ..
+        }) = &arg
+            && path.is_ident("rename")
+        {
+            return name.value();
+        }
+    }
+
+    // `expand_enum` puts `serde(rename_all = "snake_case")` on every settings enum, so an
+    // un-renamed variant serializes under the snake case of its identifier.
+    let ident = variant.ident.to_string();
+    let mut name = String::with_capacity(ident.len());
+
+    for (index, character) in ident.char_indices() {
+        if index > 0 && character.is_uppercase() {
+            name.push('_');
+        }
+
+        name.push(character.to_ascii_lowercase());
+    }
+
+    name
 }
 
 fn impl_serde_aware_default(item: &ItemStruct) -> Result<proc_macro2::TokenStream> {
@@ -904,7 +1075,22 @@ mod tests {
                 NewTypeVariant(String)
             }
 
-            impl ::foundations::settings::Settings for TestEnum { }
+            impl ::foundations::settings::Settings for TestEnum {
+                fn add_docs(
+                    &self,
+                    parent_key: &[String],
+                    docs: &mut ::std::collections::HashMap<Vec<String>, &'static [&'static str]>)
+                {
+                    match self {
+                        Self::UnitVariant => {}
+                        Self::NewTypeVariant(value) => {
+                            let mut key = parent_key.to_vec();
+                            key.push("new_type_variant".into());
+                            ::foundations::settings::Settings::add_docs(value, &key, docs);
+                        }
+                    }
+                }
+            }
         };
 
         assert_eq!(actual, expected);
@@ -940,7 +1126,22 @@ mod tests {
                 NewTypeVariant(String)
             }
 
-            impl ::foundations::settings::Settings for TestEnum { }
+            impl ::foundations::settings::Settings for TestEnum {
+                fn add_docs(
+                    &self,
+                    parent_key: &[String],
+                    docs: &mut ::std::collections::HashMap<Vec<String>, &'static [&'static str]>)
+                {
+                    match self {
+                        Self::UnitVariant => {}
+                        Self::NewTypeVariant(value) => {
+                            let mut key = parent_key.to_vec();
+                            key.push("new_type_variant".into());
+                            ::foundations::settings::Settings::add_docs(value, &key, docs);
+                        }
+                    }
+                }
+            }
         };
 
         assert_eq!(actual, expected);
@@ -978,7 +1179,97 @@ mod tests {
                 NewTypeVariant(String)
             }
 
-            impl ::foundations::settings::Settings for TestEnum { }
+            impl ::foundations::settings::Settings for TestEnum {
+                fn add_docs(
+                    &self,
+                    parent_key: &[String],
+                    docs: &mut ::std::collections::HashMap<Vec<String>, &'static [&'static str]>)
+                {
+                    match self {
+                        Self::UnitVariant => {}
+                        Self::NewTypeVariant(value) => {
+                            let mut key = parent_key.to_vec();
+                            key.push("new_type_variant".into());
+                            ::foundations::settings::Settings::add_docs(value, &key, docs);
+                        }
+                    }
+                }
+            }
+        };
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn expand_enum_with_variant_docs() {
+        let options = parse_attr! {
+            #[settings(impl_default = false)]
+        };
+
+        let src = parse_quote! {
+            enum TestEnum {
+                /// Nested settings.
+                Nested(NestedStruct),
+                /// Renamed variant.
+                #[serde(rename = "RENAMED")]
+                Renamed(NestedStruct),
+                /// Not serialized.
+                #[serde(skip)]
+                Skipped(NotSettings),
+                /// A unit variant.
+                UnitVariant
+            }
+        };
+
+        let actual = expand_from_parsed(options, src).unwrap().to_string();
+
+        let expected = code_str! {
+            #[derive(
+                Clone,
+                ::foundations::reexports_for_macros::serde::Serialize,
+                ::foundations::reexports_for_macros::serde::Deserialize,
+            )]
+            #[derive(Debug)]
+            #[serde(crate = ":: foundations :: reexports_for_macros :: serde")]
+            #[serde(deny_unknown_fields)]
+            #[serde(rename_all="snake_case")]
+            enum TestEnum {
+                #[doc = r" Nested settings."]
+                Nested(NestedStruct),
+                #[doc = r" Renamed variant."]
+                #[serde(rename = "RENAMED")]
+                Renamed(NestedStruct),
+                #[doc = r" Not serialized."]
+                #[serde(skip)]
+                Skipped(NotSettings),
+                #[doc = r" A unit variant."]
+                UnitVariant
+            }
+
+            impl ::foundations::settings::Settings for TestEnum {
+                fn add_docs(
+                    &self,
+                    parent_key: &[String],
+                    docs: &mut ::std::collections::HashMap<Vec<String>, &'static [&'static str]>)
+                {
+                    match self {
+                        Self::Nested(value) => {
+                            let mut key = parent_key.to_vec();
+                            key.push("nested".into());
+                            ::foundations::settings::Settings::add_docs(value, &key, docs);
+                            docs.insert(key, &[r" Nested settings.",][..]);
+                        }
+                        Self::Renamed(value) => {
+                            let mut key = parent_key.to_vec();
+                            key.push("RENAMED".into());
+                            ::foundations::settings::Settings::add_docs(value, &key, docs);
+                            docs.insert(key, &[r" Renamed variant.",][..]);
+                        }
+                        Self::Skipped(..) => {}
+                        Self::UnitVariant => {}
+                    }
+                }
+            }
         };
 
         assert_eq!(actual, expected);

--- a/foundations-macros/src/settings.rs
+++ b/foundations-macros/src/settings.rs
@@ -299,8 +299,12 @@ fn impl_settings_trait_for_enum(options: &Options, item: &ItemEnum) -> proc_macr
     let ident = item.ident.clone();
     let crate_path = &options.crate_path;
 
-    // Nothing under a variant can be documented, so keep the default no-op `add_docs`.
-    if !item.variants.iter().any(is_documented_variant) {
+    // Documenting a new type variant makes the type it wraps reachable through `add_docs`, so
+    // that type has to implement `Settings`. That is a new requirement on existing code, so it
+    // stays behind `--cfg foundations_unstable` until the next breaking release.
+    //
+    // Nothing under a variant can be documented otherwise, so keep the default no-op `add_docs`.
+    if !cfg!(foundations_unstable) || !item.variants.iter().any(is_documented_variant) {
         return quote! {
             impl #crate_path::settings::Settings for #ident { }
         };
@@ -564,6 +568,37 @@ mod tests {
     use super::*;
     use crate::common::test_utils::{code_str, parse_attr};
     use syn::parse_quote;
+
+    /// The `Settings` impl expected for an enum with a new type variant.
+    ///
+    /// Documenting a new type variant is behind `--cfg foundations_unstable`, see
+    /// `impl_settings_trait_for_enum`. Without it the enum keeps the default no-op `add_docs`.
+    fn test_enum_settings_impl() -> String {
+        if cfg!(foundations_unstable) {
+            code_str! {
+                impl ::foundations::settings::Settings for TestEnum {
+                    fn add_docs(
+                        &self,
+                        parent_key: &[String],
+                        docs: &mut ::std::collections::HashMap<Vec<String>, &'static [&'static str]>)
+                    {
+                        match self {
+                            Self::UnitVariant => {}
+                            Self::NewTypeVariant(value) => {
+                                let mut key = parent_key.to_vec();
+                                key.push("new_type_variant".into());
+                                ::foundations::settings::Settings::add_docs(value, &key, docs);
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            code_str! {
+                impl ::foundations::settings::Settings for TestEnum { }
+            }
+        }
+    }
 
     #[test]
     fn expand_structure() {
@@ -1058,7 +1093,7 @@ mod tests {
 
         let actual = expand_from_parsed(options, src).unwrap().to_string();
 
-        let expected = code_str! {
+        let mut expected = code_str! {
             #[derive(Default)]
             #[derive(
                 Clone,
@@ -1074,24 +1109,9 @@ mod tests {
                 UnitVariant,
                 NewTypeVariant(String)
             }
-
-            impl ::foundations::settings::Settings for TestEnum {
-                fn add_docs(
-                    &self,
-                    parent_key: &[String],
-                    docs: &mut ::std::collections::HashMap<Vec<String>, &'static [&'static str]>)
-                {
-                    match self {
-                        Self::UnitVariant => {}
-                        Self::NewTypeVariant(value) => {
-                            let mut key = parent_key.to_vec();
-                            key.push("new_type_variant".into());
-                            ::foundations::settings::Settings::add_docs(value, &key, docs);
-                        }
-                    }
-                }
-            }
         };
+        expected.push(' ');
+        expected.push_str(&test_enum_settings_impl());
 
         assert_eq!(actual, expected);
     }
@@ -1111,7 +1131,7 @@ mod tests {
 
         let actual = expand_from_parsed(options, src).unwrap().to_string();
 
-        let expected = code_str! {
+        let mut expected = code_str! {
             #[derive(
                 Clone,
                 ::foundations::reexports_for_macros::serde::Serialize,
@@ -1125,24 +1145,9 @@ mod tests {
                 UnitVariant,
                 NewTypeVariant(String)
             }
-
-            impl ::foundations::settings::Settings for TestEnum {
-                fn add_docs(
-                    &self,
-                    parent_key: &[String],
-                    docs: &mut ::std::collections::HashMap<Vec<String>, &'static [&'static str]>)
-                {
-                    match self {
-                        Self::UnitVariant => {}
-                        Self::NewTypeVariant(value) => {
-                            let mut key = parent_key.to_vec();
-                            key.push("new_type_variant".into());
-                            ::foundations::settings::Settings::add_docs(value, &key, docs);
-                        }
-                    }
-                }
-            }
         };
+        expected.push(' ');
+        expected.push_str(&test_enum_settings_impl());
 
         assert_eq!(actual, expected);
     }
@@ -1163,7 +1168,7 @@ mod tests {
 
         let actual = expand_from_parsed(options, src).unwrap().to_string();
 
-        let expected = code_str! {
+        let mut expected = code_str! {
             #[derive(Default)]
             #[derive(
                 Clone,
@@ -1178,28 +1183,14 @@ mod tests {
                 UnitVariant,
                 NewTypeVariant(String)
             }
-
-            impl ::foundations::settings::Settings for TestEnum {
-                fn add_docs(
-                    &self,
-                    parent_key: &[String],
-                    docs: &mut ::std::collections::HashMap<Vec<String>, &'static [&'static str]>)
-                {
-                    match self {
-                        Self::UnitVariant => {}
-                        Self::NewTypeVariant(value) => {
-                            let mut key = parent_key.to_vec();
-                            key.push("new_type_variant".into());
-                            ::foundations::settings::Settings::add_docs(value, &key, docs);
-                        }
-                    }
-                }
-            }
         };
+        expected.push(' ');
+        expected.push_str(&test_enum_settings_impl());
 
         assert_eq!(actual, expected);
     }
 
+    #[cfg(foundations_unstable)]
     #[test]
     fn expand_enum_with_variant_docs() {
         let options = parse_attr! {

--- a/foundations/src/lib.rs
+++ b/foundations/src/lib.rs
@@ -51,7 +51,6 @@
 //! Foundations has unstable features which are gated behind `--cfg foundations_unstable`:
 //!
 //! - **tokio-runtime-metrics**: Enables runtime metrics for Tokio runtimes. Implicitly enables the **metrics** feature. [Also requires tokio_unstable](https://docs.rs/tokio/latest/tokio/#unstable-features).
-//! - **settings-new-type-variant-docs**: Documents the fields of a new type enum variant in generated settings. Requires the type the variant wraps to implement [`Settings`](crate::settings::Settings).
 //!
 //! To enable these, you must add `--cfg foundations_unstable` to your RUSTFLAGS environment variable.
 //!

--- a/foundations/src/lib.rs
+++ b/foundations/src/lib.rs
@@ -51,6 +51,7 @@
 //! Foundations has unstable features which are gated behind `--cfg foundations_unstable`:
 //!
 //! - **tokio-runtime-metrics**: Enables runtime metrics for Tokio runtimes. Implicitly enables the **metrics** feature. [Also requires tokio_unstable](https://docs.rs/tokio/latest/tokio/#unstable-features).
+//! - **settings-new-type-variant-docs**: Documents the fields of a new type enum variant in generated settings. Requires the type the variant wraps to implement [`Settings`](crate::settings::Settings).
 //!
 //! To enable these, you must add `--cfg foundations_unstable` to your RUSTFLAGS environment variable.
 //!

--- a/foundations/src/settings/mod.rs
+++ b/foundations/src/settings/mod.rs
@@ -334,6 +334,15 @@ use std::path::Path;
 /// }
 /// ```
 ///
+/// # New type variant documentation (unstable)
+///
+/// **This feature is unstable and becomes a noop without `cfg(foundations_unstable)`.**
+///
+/// A new type enum variant is serialized under a key of its own. With the flag, that key gets
+/// the doc comment of the variant, and the value under it gets the documentation of the type
+/// the variant wraps. This requires that type to implement [`Settings`], so variants annotated
+/// with `#[serde(skip)]` are left out.
+///
 /// [`Settings`]: crate::settings::Settings
 pub use foundations_macros::settings;
 

--- a/foundations/tests/data/serde-saphyr/settings_enum_new_type_variant_fields.yaml
+++ b/foundations/tests/data/serde-saphyr/settings_enum_new_type_variant_fields.yaml
@@ -1,0 +1,8 @@
+# Where the output is written
+output:
+  # Writes the output to a file.
+  file:
+    # Path of the output file.
+    path: ""
+    # Whether an existing file is truncated.
+    truncate: false

--- a/foundations/tests/data/serde-yaml/settings_enum_new_type_variant_fields.yaml
+++ b/foundations/tests/data/serde-yaml/settings_enum_new_type_variant_fields.yaml
@@ -1,0 +1,9 @@
+---
+# Where the output is written
+output:
+  # Writes the output to a file.
+  file:
+    # Path of the output file.
+    path: ""
+    # Whether an existing file is truncated.
+    truncate: false

--- a/foundations/tests/settings.rs
+++ b/foundations/tests/settings.rs
@@ -61,6 +61,9 @@ struct StructWithEnumField {
     field: SomeEnum,
 }
 
+// Documenting a new type variant is behind `--cfg foundations_unstable`, since it requires the
+// type the variant wraps to implement `Settings`.
+#[cfg(foundations_unstable)]
 #[settings(impl_default = false)]
 enum SomeOutput {
     /// Writes the output to a file.
@@ -69,12 +72,14 @@ enum SomeOutput {
     Terminal,
 }
 
+#[cfg(foundations_unstable)]
 impl Default for SomeOutput {
     fn default() -> Self {
         Self::File(Default::default())
     }
 }
 
+#[cfg(foundations_unstable)]
 #[settings]
 struct FileOutputSettings {
     /// Path of the output file.
@@ -83,6 +88,7 @@ struct FileOutputSettings {
     truncate: bool,
 }
 
+#[cfg(foundations_unstable)]
 #[settings]
 struct StructWithNewTypeEnumField {
     /// Where the output is written
@@ -248,6 +254,7 @@ fn enum_fields() {
     assert_ser_eq!(StructWithEnumField::default(), "settings_enum_fields.yaml");
 }
 
+#[cfg(foundations_unstable)]
 #[test]
 fn enum_new_type_variant_fields() {
     assert_ser_eq!(

--- a/foundations/tests/settings.rs
+++ b/foundations/tests/settings.rs
@@ -61,6 +61,34 @@ struct StructWithEnumField {
     field: SomeEnum,
 }
 
+#[settings(impl_default = false)]
+enum SomeOutput {
+    /// Writes the output to a file.
+    File(FileOutputSettings),
+    /// Writes the output to the terminal.
+    Terminal,
+}
+
+impl Default for SomeOutput {
+    fn default() -> Self {
+        Self::File(Default::default())
+    }
+}
+
+#[settings]
+struct FileOutputSettings {
+    /// Path of the output file.
+    path: String,
+    /// Whether an existing file is truncated.
+    truncate: bool,
+}
+
+#[settings]
+struct StructWithNewTypeEnumField {
+    /// Where the output is written
+    output: SomeOutput,
+}
+
 #[settings]
 struct ProxySettings {
     /// Proxy address.
@@ -218,6 +246,14 @@ fn simple_config_with_docs() {
 #[test]
 fn enum_fields() {
     assert_ser_eq!(StructWithEnumField::default(), "settings_enum_fields.yaml");
+}
+
+#[test]
+fn enum_new_type_variant_fields() {
+    assert_ser_eq!(
+        StructWithNewTypeEnumField::default(),
+        "settings_enum_new_type_variant_fields.yaml"
+    );
 }
 
 #[test]


### PR DESCRIPTION
`#[settings]` on an enum throws away the documentation of everything the enum wraps. `expand_enum` emits a bare `impl Settings for #ident { }` (foundations-macros/src/settings.rs:136), so `add_docs` falls back to the no-op default at foundations/src/settings/mod.rs:418. A new type variant is the one variant kind that gets a key of its own in the YAML, and every field under that key comes out with no comments.

This hits foundations' own settings. `TracingSettings::output` defaults to `TracesOutput::JaegerThriftUdp` (foundations/src/telemetry/settings/tracing.rs:84), which wraps `JaegerThriftUdpOutputSettings`, whose four fields all have doc comments. Here is what `to_yaml_string(&TracingSettings::default())` prints today, which is what a service writes out with `Cli`'s `--generate`:

```yaml
output:
  jaeger_thrift_udp:
    server_addr: "127.0.0.1:6831"
    reporter_bind_addr: ~
    num_tasks: 1
    max_batch_size: 100
```

`UserTracesOutput::OtlpUds` (user_tracing.rs:56) and `SamplingStrategy::Active` (tracing.rs:222) lose their documentation the same way, and both are the default variant of their enum.

With this change the same call prints:

```yaml
output:
  # Sends traces to the collector in the [Jaeger Thrift (UDP)] format.
  #
  # [Jaeger Thrift (UDP)]: https://www.jaegertracing.io/docs/1.55/apis/#thrift-over-udp-stable
  jaeger_thrift_udp:
    # The address of the Jaeger Thrift (UDP) agent.
    #
    # The default value is the default Jaeger UDP server address.
    # See: <https://www.jaegertracing.io/docs/1.31/getting-started/#all-in-one>
    server_addr: "127.0.0.1:6831"
    # Overrides the bind address for the reporter API.
    #
    # By default, the reporter API is only exposed on the loopback
    # interface. This won't work in environments where the
    # Jaeger agent is on another host (for example, Docker).
    # Must have the same address family as `jaeger_tracing_server_addr`.
    reporter_bind_addr: ~
    # Number of concurrent tasks to spawn for output.
    #
    # A higher number means more spans can be collected in parallel in a
    # multi-threaded runtime. All tasks share a UDP socket for sending datagrams.
    # The default is 1 task.
    num_tasks: 1
    # Maximum number of spans to batch together for output.
    #
    # Currently, each span is still sent as a separate UDP datagram due to
    # datagram size limits. This setting only affects how many spans are
    # taken from the queue as a batch.
    #
    # Defaults to `100`.
    max_batch_size: 100
```

`expand_enum` now generates an `add_docs` that matches on the variants. For each new type variant that serde serializes it pushes the variant's key, forwards to the wrapped value, then records the variant's own doc comment, which is what the macro already does for a struct field. Unit variants serialize as a bare value, so there is no line to attach a comment to and their arm is empty. `serde(skip)` variants are left out as well, so the type behind one still does not need to implement `Settings`: `LogOutput::Custom` wraps an `Arc<dyn Drain>` and would otherwise stop compiling. The key honours `serde(rename = "...")` and otherwise follows the `rename_all = "snake_case"` the macro puts on every settings enum. Generated code is a match rather than one `if let` per variant because `if let` trips `irrefutable_let_patterns` on a single variant enum, which is what `TracesOutput` is without `telemetry-otlp-grpc`.

Verified on macOS with cargo 1.95.0.

`cargo test -p foundations --no-default-features --features settings --test settings`, and the same with `--features settings,serde-saphyr`: 13 passed, 0 failed on both. The new `enum_new_type_variant_fields` test fails on main with the four comment lines missing from the output and passes here, and there is a golden file for each YAML backend. No existing golden file changed.

`cargo test -p foundations-macros`: 69 passed, 0 failed. Three existing `expand_enum*` expansion tests needed their expected output updated, and `expand_enum_with_variant_docs` is new and covers a plain new type variant, a renamed one, a skipped one wrapping a type that is not `Settings`, and a unit variant.

`RUSTFLAGS=-Dwarnings cargo check -p foundations --no-default-features --features settings,client-telemetry,user-tracing,telemetry-otlp-grpc`: clean. That is the set that covers `LogOutput`, `TracesOutput`, `UserTracesOutput`, `SamplingStrategy` and `ServiceNameFormat`.

`cargo clippy` with the flags from AGENTS.md on `-p foundations-macros --all-targets` and on `-p foundations --no-default-features --features settings --lib --test settings`: clean. `rustfmt --check --edition 2024` on both changed Rust files: clean.

I left RELEASE_NOTES.md alone since git-cliff generates it from commit subjects at release time.
